### PR TITLE
(#78) Implemented tests for Query Building

### DIFF
--- a/src/utilities/__tests__/utilities.formatTrialSearchQuery.js
+++ b/src/utilities/__tests__/utilities.formatTrialSearchQuery.js
@@ -1,0 +1,567 @@
+import {defaultState} from '../../store/reducers/form';
+import { formatTrialSearchQuery } from '../utilities';
+
+/**
+ * This file contains tests for the formatTrialSearchQuery
+ * method in utilities.js.
+ */
+
+const ACTIVE_TRIAL_STATUSES = [
+  // These CTRP statuses appear in results:
+  "Active",
+  "Approved",
+  "Enrolling by Invitation",
+  "In Review",
+  "Temporarily Closed to Accrual",
+  "Temporarily Closed to Accrual and Intervention" 
+  // These CTRP statuses DO NOT appear in results:
+  /// "Administratively Complete",
+  /// "Closed to Accrual",
+  /// "Closed to Accrual and Intervention",
+  /// "Complete",
+  /// "Withdrawn"
+];
+
+const ACTIVE_RECRUITMENT_STATUSES = [
+  // These statuses appear in results:
+  "active",
+  "approved",
+  "enrolling_by_invitation",
+  "in_review",
+  "temporarily_closed_to_accrual"
+  // These statuses DO NOT appear in results:
+  /// "closed_to_accrual",
+  /// "completed",
+  /// "administratively_complete",
+  /// "closed_to_accrual_and_intervention",
+  /// "withdrawn"
+];
+
+/**
+ * The base query params added to any search.
+ */
+const BASE_EXPECTED_QUERY = { 
+  "current_trial_status":  ACTIVE_TRIAL_STATUSES,
+  "include": [
+    'nci_id',
+    'brief_title',
+    'sites.org_name',
+    'sites.org_postal_code',
+    'eligibility.structured',
+    'current_trial_status',
+    'sites.org_va',
+    'sites.org_country',
+    'sites.org_state_or_province',
+    'sites.org_city',
+    'sites.org_coordinates',
+    'sites.recruitment_status',
+    'diseases',
+  ]
+};
+
+
+
+// For these tests the parameters are:
+// - The test name
+// - Any overrides to the default state, e.g. { keywordPhrases: "chicken" }
+// - The expected API query params over the default ones, e.g {"_fulltext": "chicken"}
+// The test will then merge the defaultState with the params to make the input
+// and merge the additional query params with the base query to make the
+// expected object.
+const mappingTestCases = [
+  [ "empty query", {}, {} ],
+  [ "age parameter",
+    { age: 35 },
+    {
+      "eligibility.structured.max_age_in_years_gte": 35,
+      "eligibility.structured.min_age_in_years_lte": 35,
+    },
+  ],
+  /* TODO: GENDER MAPPING TEST */
+  [ "phrase parameter",
+    { keywordPhrases: "chicken" },
+    { "_fulltext": "chicken" },
+  ],
+  [ "single trial type",
+    {
+      trialTypes: [
+        { label: 'Treatment', value: 'treatment', checked: true },
+        { label: 'Prevention', value: 'prevention', checked: false },
+        { label: 'Supportive Care', value: 'supportive_care', checked: false },
+        {
+          label: 'Health Services Research',
+          value: 'health_services_research',
+          checked: false,
+        },
+        { label: 'Diagnostic', value: 'diagnostic', checked: false },
+        { label: 'Screening', value: 'screening', checked: false },
+        { label: 'Basic Science', value: 'basic_science', checked: false },
+        { label: 'Other', value: 'other', checked: false },
+      ]
+    },
+    {
+      'primary_purpose.primary_purpose_code' : [ 'treatment' ]
+    }
+  ],
+  [ "multiple trial type",
+    {
+      trialTypes: [
+        { label: 'Treatment', value: 'treatment', checked: true },
+        { label: 'Prevention', value: 'prevention', checked: false },
+        { label: 'Supportive Care', value: 'supportive_care', checked: true },
+        {
+          label: 'Health Services Research',
+          value: 'health_services_research',
+          checked: false,
+        },
+        { label: 'Diagnostic', value: 'diagnostic', checked: false },
+        { label: 'Screening', value: 'screening', checked: false },
+        { label: 'Basic Science', value: 'basic_science', checked: false },
+        { label: 'Other', value: 'other', checked: false },
+      ]
+    },
+    {
+      'primary_purpose.primary_purpose_code' : [ 'treatment', 'supportive_care' ]
+    }
+  ],
+  [ "principal investigator",
+    {
+      investigator: { term: 'Sophia Smith', termKey: 'Sophia Smith' }
+    },
+    {
+      "principal_investigator_fulltext": "Sophia Smith"
+    }
+  ],
+  [ "lead organization",
+    {
+      leadOrg: { term: 'Mayo Clinic', termKey: 'Mayo Clinic' }
+    },
+    {
+      "lead_org_fulltext": "Mayo Clinic"
+    }
+  ],
+  [ "single trial id",
+    {
+      trialId: "NCI-2015-00054"
+    },
+    {
+      "_trialids": ["NCI-2015-00054"]
+    }
+  ],
+  [ "multiple trial id",
+    {
+      trialId: "SWOG, CCOG"
+    },
+    {
+      "_trialids": ["SWOG", "CCOG"]
+    }
+  ],
+  [
+    "healthy volunteers",
+    {
+      healthyVolunteers: true
+    },
+    {
+      "accepts_healthy_volunteers_indicator": "YES"
+    }
+    // NOTE: New code does not support a way to indicate
+    // accepts_healthy_volunteers_indicator: "NO"
+  ],
+  /************************
+   * Phase Tests
+   ************************/
+  [ "phase i",
+    {
+      trialPhases: getPhaseObject(['i']),
+    },
+    {
+      "phase.phase": ["i", "i_ii"]
+    }
+  ],
+  [ "phase ii",
+    {
+      trialPhases: getPhaseObject(['ii']),
+    },
+    {
+      "phase.phase": ["ii", "i_ii", "ii_iii"]
+    }
+  ],
+  [ "phase iii",
+    {
+      trialPhases: getPhaseObject(['iii']),
+    },
+    {
+      "phase.phase": ["iii", "ii_iii"]
+    }
+  ],
+  [ "phase iv",
+    {
+      trialPhases: getPhaseObject(['iv']),
+    },
+    {
+      "phase.phase": ["iv"]
+    }
+  ],
+  [ "all phases selected",
+    {
+      trialPhases: getPhaseObject(['i', 'ii', 'iii', 'iv']),
+    },
+    {
+      "phase.phase": [ "i", "ii", "iii", "iv", "i_ii", "ii_iii", ]
+    }
+  ],
+
+  /***********************
+   * Location test cases
+   ***********************/
+  [ "is VA only (true)",
+    {
+      vaOnly: true
+    },
+    {
+      "sites.org_va": true,
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "NIH campus",
+    {
+      nihOnly: true,
+      location: "search-location-nih"
+    },
+    {
+      "sites.org_postal_code": "20892",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "hospital",
+    {
+      hospital: { term: 'M D Anderson Cancer Center', termKey: 'M D Anderson Cancer Center' },
+      location: "search-location-hospital"
+    },
+    {
+      "sites.org_name_fulltext": "M D Anderson Cancer Center",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "country",
+    {
+      country: "United States",
+      location: "search-location-country"
+    },
+    {
+      "sites.org_country": "United States",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "state",
+    {
+      // For the purposes of this function we want to make
+      // sure that it is not adding in anything we did not
+      // ask for.
+      country: "United States",
+      states: [{abbr: 'MD', name: 'Maryland'}],
+      location: "search-location-country"
+    },
+    {
+      "sites.org_country": "United States",
+      "sites.org_state_or_province": ["MD"],
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "city",
+    {
+      // For the purposes of this function we want to make
+      // sure that it is not adding in anything we did not
+      // ask for.
+      country: undefined,
+      city: "Baltimore",
+      location: "search-location-country"
+    },
+    {
+      "sites.org_city": "Baltimore",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "city and state",
+    {
+      // For the purposes of this function we want to make
+      // sure that it is not adding in anything we did not
+      // ask for.
+      country: "United States",
+      states: [{abbr: 'MD', name: 'Maryland'}],
+      city: "Baltimore",
+      location: "search-location-country"
+    },
+    {
+      "sites.org_country": "United States",
+      "sites.org_city": "Baltimore",
+      "sites.org_state_or_province": ["MD"],
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [
+    "country, city and state",
+    {
+      // For the purposes of this function we want to make
+      // sure that it is not adding in anything we did not
+      // ask for.
+      country: "United States",
+      states: [{abbr: 'MD', name: 'Maryland'}],
+      city: "Baltimore",
+      location: "search-location-country"
+    },
+    {
+      "sites.org_country": "United States",
+      "sites.org_city": "Baltimore",
+      "sites.org_state_or_province": ["MD"],
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [
+    "Canadian city",
+    {
+      // For the purposes of this function we want to make
+      // sure that it is not adding in anything we did not
+      // ask for.
+      country: "Canada",
+      city: "Toronto",
+      location: "search-location-country"
+    },
+    {
+      "sites.org_country": "Canada",
+      "sites.org_city": "Toronto",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  [ "Zip Code",
+    {
+      location: "search-location-zip",
+      zip: "20850",
+      zipRadius: "500",
+      zipCoords: {lat: 39.0897, long: -77.1798},  
+    },
+    {
+      "sites.org_coordinates_lat": 39.0897,
+      "sites.org_coordinates_lon": -77.1798,
+      "sites.org_coordinates_dist": "500mi",
+      "sites.recruitment_status": ACTIVE_RECRUITMENT_STATUSES
+    }
+  ],
+  /***********************
+   * Disease Params
+   ***********************/
+  [ "main type with one code",
+    {
+      cancerType: { name: 'Breast Cancer', codes: ['C4872'] }
+    },
+    {
+      "_maintypes": [ "C4872" ]
+    }
+  ],
+  [ "main type with multiple codes",
+    {
+      cancerType: { name: 'TEST Cancer', codes: ["C4872", "C6789"] }
+    },
+    {
+      "_maintypes": [ "C4872", "C6789" ]
+    }
+  ],
+  [ "one sub-type/one code",
+    {
+      subtypes: [{ name: 'Inflammatory Breast Cancer', codes: ["C4001"] }]
+    },
+    {
+      "_subtypes": [ "C4001" ]
+    }
+  ],
+  [ "one sub-type/two codes",
+    {
+      subtypes: [{ name: 'Test Subtype Cancer', codes: ["C5678", "C1234"] }]
+    },
+    {
+      "_subtypes": [ "C5678", "C1234" ]
+    }
+  ],
+  [ "two sub-types mixed",
+    {
+      subtypes: [
+        { name: 'Inflammatory Breast Cancer', codes: ["C4001"] },
+        { name: 'Test Subtype Cancer', codes: ["C5678", "C1234"] }
+      ]
+    },
+    {
+      "_subtypes": [ "C4001", "C5678", "C1234" ]
+    }
+  ],  
+  [ "one stage/one code",
+    {
+      stages: [{ name: 'Stage IIIB Inflammatory Breast Cancer', codes: ["C9246"] }]
+    },
+    {
+      "_stages": [ "C9246" ]
+    }
+  ],
+  [ "one stage/two codes",
+    {
+      stages: [{ name: 'Test Cancer Stage', codes: ["C12345", "C678910"] }]
+    },
+    {
+      "_stages": [ "C12345", "C678910" ]
+    }
+  ],
+  [ "two stages mixed",
+    {
+      stages: [
+        { name: 'Stage IIIB Inflammatory Breast Cancer', codes: ["C9246"] },
+        { name: 'Test Cancer Stage', codes: ["C12345", "C678910"] }
+      ]
+    },
+    {
+      "_stages": [ "C9246", "C12345", "C678910" ]
+    }
+  ],
+  [ "one finding/one code",
+    {
+      findings: [{ name: 'Test Finding', codes: ["C1234"] }]
+    },
+    {
+      "_findings": [ "C1234" ]
+    }
+  ],
+  [ "one finding/two codes",
+    {
+      findings: [{ name: 'Test Finding 2', codes: ["C2345", "C3456"] }]
+    },
+    {
+      "_findings": [ "C2345", "C3456" ]
+    }
+  ],
+  [ "two findings mixed",
+    {
+      findings: [
+        { name: 'Test Finding', codes: ["C1234"] },
+        { name: 'Test Finding 2', codes: ["C2345", "C3456"] }
+      ]
+    },
+    {
+      "_findings": [ "C1234", "C2345", "C3456" ]
+    }
+  ],
+  //TODO: Handle combo
+  //TODO: Test case for Subtype same as Stage, e.g. DCIS
+  /**************
+   * Drug / Interventions tests
+   **************/
+  [ "drug / one id",
+    {
+      drugs: [{name: "Trastuzumab", codes:["C1674"]}]
+    },
+    {
+      "arms.interventions.intervention_code": ["C1674"]
+    }
+  ],
+  [ "drug / two ids",
+    {
+      drugs: [{name: "Immunotherapy", codes: ["C308", "C15262"]}]
+    },
+    {
+      "arms.interventions.intervention_code": ["C308", "C15262"]
+    }
+  ],
+  [ "two drugs mixed",
+    {
+      drugs: [
+        {name: "Trastuzumab", codes:["C1674"]},
+        {name: "Immunotherapy", codes: ["C308", "C15262"]}
+      ]
+    },
+    {
+      "arms.interventions.intervention_code": ["C1674", "C308", "C15262"]
+    }
+  ],
+  [ "other intervention / one id",
+    {
+      treatments: [{name: "Surgery", codes:["C17173"]}]
+    },
+    {
+      "arms.interventions.intervention_code": ["C17173"]
+    }
+  ],
+  [ "other intervention / two ids",
+    {
+      treatments: [{name: "Can't Find Example Other With Two Codes", codes: ["C308", "C15262"]}]
+    },
+    {
+      "arms.interventions.intervention_code": ["C308", "C15262"]
+    }
+  ],
+  [ "two other interventions mixed",
+    {
+      treatments: [
+        {name: "Surgery", codes:["C17173"]},
+        {name: "Can't Find Example Other With Two Codes", codes: ["C308", "C15262"]}
+      ]
+    },
+    {
+      "arms.interventions.intervention_code": ["C17173", "C308", "C15262"]
+    }
+  ],
+  [ "one drug / one other",
+    {
+      drugs: [{name: "Immunotherapy", codes: ["C308", "C15262"]}],
+      treatments: [{name: "Surgery", codes:["C17173"]}],
+    },
+    {
+      "arms.interventions.intervention_code": ["C308", "C15262", "C17173"]
+    }
+  ],  
+];
+
+describe('formatTrialSearchQuery maps form to query', () => {
+
+  // Test iterates over multiple cases defined by mappingTestCases
+  test.each(mappingTestCases)(
+    "%# - correctly maps %s",
+    (testName, formStateChanges, additionalExpectedQuery) => {
+      const testForm = {
+        ...defaultState,
+        ...formStateChanges
+      };
+
+      const expected = {
+        ...additionalExpectedQuery,
+        ...BASE_EXPECTED_QUERY
+      }
+
+      const actual = formatTrialSearchQuery(testForm);
+      expect(actual).toEqual(expected);
+    }
+  );
+
+});
+
+/**
+ * Helper function to set enabled phases.
+ *
+ * @param array phases 
+ *   List of phases to enable
+ */
+function getPhaseObject(phases) {
+  const defaultList = [
+    { label: 'Phase I', value: 'i', checked: false },
+    { label: 'Phase II', value: 'ii', checked: false },
+    { label: 'Phase III', value: 'iii', checked: false },
+    { label: 'Phase IV', value: 'iv', checked: false },
+  ];
+
+  return defaultList.map(phase => {
+    if (phases.includes(phase.value)) {
+      return {
+        ...phase,
+        checked: true
+      };
+    } else {
+      return phase;
+    }
+  });
+}

--- a/src/utilities/utilities.js
+++ b/src/utilities/utilities.js
@@ -318,37 +318,60 @@ export const buildQueryString = formStore => {
   }
 };
 
+
+/**
+ * Collapses a list of thesaurus concepts (diseases, drugs and other interventions
+ * into a collection of ids.
+ * @param array typesList the list of diseases
+ */
+const collapseConcepts = typesList => {
+  const ids = typesList.reduce(
+    (ac, type) => {
+      return [
+        ...ac,
+        ...type.codes
+      ]
+    },
+    []
+  );
+  return [...new Set(ids)];
+};
+
 export const formatTrialSearchQuery = form => {
   let filterCriteria = {};
 
   //diseases
   if (form.cancerType.codes.length > 0) {
-    filterCriteria._maintypes = form.cancerType.codes[0];
+    filterCriteria._maintypes = form.cancerType.codes
   }
 
-  if (form.subtypes.codes && form.subtypes.codes.length > 0) {
-    filterCriteria._subtypes = form.subtypes.codes;
+  // Reduce the subtypes into a list of ids.
+  if (form.subtypes.length > 0) {
+    filterCriteria._subtypes = collapseConcepts(form.subtypes);
   }
 
-  if (form.stages.codes && form.stages.codes.length > 0) {
-    filterCriteria._stages = form.stages.codes;
+  if (form.stages.length > 0) {
+    filterCriteria._stages = collapseConcepts(form.stages);
   }
 
-  if (form.findings.codes && form.findings.codes.length > 0) {
-    filterCriteria._findings = form.findings;
+  if (form.findings.length > 0) {
+    filterCriteria._findings = collapseConcepts(form.findings);
   }
 
   //Drugs and Treatments
   if (form.drugs.length > 0 || form.treatments.length > 0) {
-    let drugAndTrialIds = [];
-    if (form.drugs.length > 0) {
-      drugAndTrialIds = [...form.drugs];
-    }
-    if (form.treatments.length > 0) {
-      drugAndTrialIds = [...drugAndTrialIds, ...form.treatments];
-    }
+
+    const drugIds = form.drugs.length > 0 ? 
+      collapseConcepts(form.drugs) :
+      [];
+    const otherIds = form.treatments.length > 0 ?
+      collapseConcepts(form.treatments) :
+      [];
     filterCriteria['arms.interventions.intervention_code'] = [
-      ...new Set(drugAndTrialIds.map(item => item.codes[0])),
+      ...new Set([
+        ...drugIds,
+        ...otherIds,
+      ])
     ];
   }
 
@@ -417,7 +440,10 @@ export const formatTrialSearchQuery = form => {
 
   //trial ids
   if (form.trialId !== '') {
-    filterCriteria._trialids = form.trialId;
+    // Split up the ids on a comma, trimming the items.
+    filterCriteria._trialids = form.trialId
+      .split(',')
+      .map(s => s.trim());
   }
 
   // VA only
@@ -435,7 +461,7 @@ export const formatTrialSearchQuery = form => {
       filterCriteria['sites.org_name_fulltext'] = form.hospital.term;
       break;
     case 'search-location-country':
-      filterCriteria['sites.org_country._raw'] = form.country;
+      filterCriteria['sites.org_country'] = form.country;
       if (form.city !== '') {
         filterCriteria['sites.org_city'] = form.city;
       }
@@ -460,19 +486,23 @@ export const formatTrialSearchQuery = form => {
   }
 
   // Adds criteria to only match locations that are actively recruiting sites. (CTSConstants.ActiveRecruitmentStatuses)
-  // filterCriteria['sites.recruitment_status'] = [
-  //   'active',
-  //   'approved',
-  //   'enrolling_by_invitation',
-  //   'in_review',
-  //   'temporarily_closed_to_accrual',
-  //   // These statuses DO NOT appear in results:
-  //   /// "closed_to_accrual",
-  //   /// "completed",
-  //   /// "administratively_complete",
-  //   /// "closed_to_accrual_and_intervention",
-  //   /// "withdrawn"
-  // ];
+  // But only do it if we are doing a location search.
+  if (form.location !== "search-location-all" || form.vaOnly) {
+
+    filterCriteria['sites.recruitment_status'] = [
+      'active',
+      'approved',
+      'enrolling_by_invitation',
+      'in_review',
+      'temporarily_closed_to_accrual',
+      // These statuses DO NOT appear in results:
+      /// "closed_to_accrual",
+      /// "completed",
+      /// "administratively_complete",
+      /// "closed_to_accrual_and_intervention",
+      /// "withdrawn"
+    ];
+  }
 
   // This is searching only for open trials (CTSConstants.ActiveTrialStatuses)
   filterCriteria.current_trial_status = [


### PR DESCRIPTION
- Fixed issue with comma separated trial ids
- Fixed issue with location searches not excluding non-recruiting study
   sites
- Fixed issue where interventions with multiple ids were only using the
   first code.
- Fixed issues with Subtype, Stage and Findings where they did not
   work at all.
- Fixed issues with maintypes not supporting diseases with multiple ids.
   Although, there is no real live example that can be found.