### PR TITLE
Hotfix/0.10.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "National Cancer Institute",
   "license": "ISC",
   "main": "build/static/js/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "author": "National Cancer Institute",
   "license": "ISC",
   "main": "build/static/js/main.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nciocpl/clinical-trials-search-app",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": "National Cancer Institute",
   "license": "ISC",
   "main": "build/static/js/main.js",

--- a/src/hooks/useModal.js
+++ b/src/hooks/useModal.js
@@ -7,7 +7,7 @@ export const useModal = () => {
     setIsShowing(!isShowing);
 
     if (!isShowing) {
-      document.getElementById('main-content').classList.add('modal-open');
+      document.body.classList.add('modal-open');
     } else {
       document.body.classList.remove('modal-open');
     }

--- a/src/views/ErrorPage/ErrorPage.jsx
+++ b/src/views/ErrorPage/ErrorPage.jsx
@@ -3,7 +3,6 @@ import { useDispatch, useSelector } from 'react-redux';
 import { clearForm } from '../../store/actions';
 import { Helmet } from 'react-helmet';
 import { Delighter } from '../../components/atomic';
-import { Link } from 'react-router-dom';
 
 import './ErrorPage.scss';
 
@@ -116,8 +115,8 @@ const ErrorPage = ({ initErrorsList }) => {
                   or call 1-800-4-CANCER (1-800-422-6237).
                 </p>
                 <p>
-                  <Link
-                    to={`${
+                  <a
+                    href={`${
                       formSnapshot.formType === 'basic'
                         ? '/about-cancer/treatment/clinical-trials/search'
                         : '/about-cancer/treatment/clinical-trials/search/advanced'
@@ -125,7 +124,7 @@ const ErrorPage = ({ initErrorsList }) => {
                     onClick={handleStartOver}
                   >
                     Try a new search
-                  </Link>
+                  </a>
                 </p>
               </div>
               <aside className="error-page__aside --side">


### PR DESCRIPTION
- After we have selected 90 trials and we are on Page 10, if we select "Select all on Page" the page becomes blank. After selecting 90 trials if we select trials one by one on Page 10 , as soon as we reach 100th trial, the page becomes blank. No modals appear. 
- Clicking "try new search" on the error page does not reload the app, it keeps me on the error page.