### PR TITLE
caching trials selected for print

### DIFF
--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import {Helmet} from 'react-helmet';
-import { updateFormField, clearForm, updateGlobal } from '../../store/actions';
+import { updateFormField, clearForm, receiveData } from '../../store/actions';
 import { Delighter, Checkbox, Modal, Pager } from '../../components/atomic';
 import { buildQueryString } from '../../utilities';
 import {
@@ -20,7 +20,7 @@ const ResultsPage = ({ location }) => {
   const dispatch = useDispatch();
   const [selectAll, setSelectAll] = useState(false);
   const [pagerPage, setPagerPage] = useState(0);
-  const [selectedResults, setSelectedResults] = useState([]);
+  
   const [pageIsLoading, setPageIsLoading] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [trialResults, setTrialResults] = useState([]);
@@ -34,9 +34,8 @@ const ResultsPage = ({ location }) => {
   );
   const [storeRehydrated, setStoreRehydrated] = useState(false);
   const [currCacheKey, setCurrCacheKey] = useState('');
-
   const [{ fetchTrials }] = useStoreToFindTrials();
-
+  const [selectedResults, setSelectedResults] = useState(cache['selectedTrialsForPrint'] || []);
   const handleUpdate = (field, value) => {
     dispatch(
       updateFormField({
@@ -80,7 +79,14 @@ const ResultsPage = ({ location }) => {
 
   //track usage of selected results for print
   useEffect(() => {
-    if (selectedResults.length >= 100) {
+    // update cacheStore with new selectedResults Value
+    dispatch(
+      receiveData(
+        'selectedTrialsForPrint',
+        [...selectedResults]
+      )
+    );
+    if (selectedResults.length > 100) {
       toggleModal();
     }
   }, [selectedResults]);

--- a/src/views/SearchPage/SearchPage.jsx
+++ b/src/views/SearchPage/SearchPage.jsx
@@ -17,7 +17,7 @@ import {
   ZipCode,
 } from '../../components/search-modules';
 import { history } from '../../services/history.service';
-import { updateFormField, clearForm } from '../../store/actions';
+import { updateFormField, clearForm, receiveData } from '../../store/actions';
 
 //Module groups in arrays will be placed side-by-side in the form
 const basicFormModules = [CancerTypeKeyword, [Age, ZipCode]];
@@ -60,6 +60,10 @@ const SearchPage = ({ formInit = 'basic' }) => {
 
   const handleSubmit = e => {
     e.preventDefault();
+    dispatch(receiveData(
+      'selectedTrialsForPrint',
+      []
+    ));
     history.push('/about-cancer/treatment/clinical-trials/search/r');
   };
 


### PR DESCRIPTION
Caching of selected trials for print.  When navigating between results page and trial description page, selections for print should be retained. New trial searches would reset the list to none.