### PR TITLE
Fix/various location display issues

### DIFF
--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -32,6 +32,7 @@ export const ACTIVE_RECRUITMENT_STATUSES = [
 // Specify which fields will be returned in the TrialsResults Object from clinicaltrialsapi
 export const SEARCH_RETURNS_FIELDS = [
   'nci_id',
+  'nct_id',
   'brief_title',
   'sites.org_name',
   'sites.org_postal_code',

--- a/src/middleware/CTSMiddleware.js
+++ b/src/middleware/CTSMiddleware.js
@@ -74,6 +74,18 @@ const createCTSMiddleware = services => ({
             }
 
             body = response;
+          } else if (response.nciID) {
+            // This is a trial, and this is REALLY dirty.
+            // I no like this middleware how everything calls the service from
+            // the same function and then adds a big conditional to manipulate
+            // the data. It is too late to redo this, but it needs to be fixed later.
+            response.sites = response.sites.filter(site => 
+              ACTIVE_RECRUITMENT_STATUSES.includes(
+                // Site comes all upper case from the API
+                site.recruitmentStatus.toLowerCase()
+              )
+            );
+            body = response;
           }
           else {
             body = response;

--- a/src/middleware/CTSMiddleware.js
+++ b/src/middleware/CTSMiddleware.js
@@ -1,4 +1,5 @@
 import { receiveData } from '../store/actions';
+import { ACTIVE_RECRUITMENT_STATUSES } from '../constants';
 
 /**
  * This middleware serves two purposes (and could perhaps be broken into two pieces).
@@ -55,9 +56,29 @@ const createCTSMiddleware = services => ({
           // if search results, add total and starting index
           if (response.terms) {
             body = response.terms;
-          } else {
+          } else if (response.trials) {
+            // This is going to be very dirty, we need to filter out
+            // inactive trial sites, but the service returns a class
+            // for each trial so we can't make this immutable. We
+            // instead need to modify the sites property of each
+            // trial.
+            for (const trial of response.trials) {
+              // change the trial sites list to only those that are
+              // actively recruiting.
+              trial.sites = trial.sites.filter(site => 
+                ACTIVE_RECRUITMENT_STATUSES.includes(
+                  // Site comes all upper case from the API
+                  site.recruitmentStatus.toLowerCase()
+                )
+              );
+            }
+
             body = response;
           }
+          else {
+            body = response;
+          }
+
           let formattedBody = body;
 
           if (fetchHandlers) {

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -291,10 +291,10 @@ export function getCountries({ size = 100 } = {}) {
         {
           method: 'getTerms',
           requestParams: {
-            category: 'sites.org_country',
+            termType: 'sites.org_country',
             additionalParams: {
               sort: 'term',
-              current_trial_status: ACTIVE_TRIAL_STATUSES,
+              current_trial_statuses: ACTIVE_TRIAL_STATUSES,
             },
             size,
           },

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -146,26 +146,35 @@ const ResultsListItem = ({ id, item, isChecked, onCheckChange, queryParams }) =>
           : site.country;
       return displayText;
     }
+    // NOTE: Displays for count should be ONLY US sites
+    // unless it is a country search and the country
+    // is not US.
+    const sitesList = (
+      (location === 'search-location-country') &&
+      (country !== 'United States')
+    ) ? item.sites :
+      item.sites.filter(site => site.country === 'United States');
+
     // zip code present
     if (zip !== '') {
       //has a zip
       if (zipCoords.lat !== '' && zipCoords.long !== '') {
-        return `${item.sites.length} location${
-          item.sites.length === 1 ? '' : 's'
-        }, including ${countNearbySitesByZip(item.sites)} near you`;
+        return `${sitesList.length} location${
+          sitesList.length === 1 ? '' : 's'
+        }, including ${countNearbySitesByZip(sitesList)} near you`;
       }
     }
     if (location === 'search-location-country') {
-      return `${item.sites.length} location${
-        item.sites.length === 1 ? '' : 's'
-      }, including ${countNearbySitesByCountryParams(item.sites)} near you`;
+      return `${sitesList.length} location${
+        sitesList.length === 1 ? '' : 's'
+      }, including ${countNearbySitesByCountryParams(sitesList)} near you`;
     }
     if (location === 'search-location-nih') {
-      return `${item.sites.length} location${
-        item.sites.length === 1 ? '' : 's'
-      }, including ${countNearbySitesByNIHParams(item.sites)} near you`;
+      return `${sitesList.length} location${
+        sitesList.length === 1 ? '' : 's'
+      }, including ${countNearbySitesByNIHParams(sitesList)} near you`;
     }
-    return `${item.sites.length} location${item.sites.length === 1 ? '' : 's'}`;
+    return `${sitesList.length} location${sitesList.length === 1 ? '' : 's'}`;
   };
 
   const setCachedTitle = () => {

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -19,6 +19,7 @@ const ResultsListItem = ({ id, item, isChecked, onCheckChange, queryParams }) =>
     country,
     states,
     city,
+    vaOnly,
   } = useSelector(store => store.form);
 
 
@@ -149,32 +150,44 @@ const ResultsListItem = ({ id, item, isChecked, onCheckChange, queryParams }) =>
     // NOTE: Displays for count should be ONLY US sites
     // unless it is a country search and the country
     // is not US.
-    const sitesList = (
+    const sitesListAll = (
       (location === 'search-location-country') &&
       (country !== 'United States')
     ) ? item.sites :
       item.sites.filter(site => site.country === 'United States');
 
-    // zip code present
-    if (zip !== '') {
+    // We filter on VA here to cut down on conditionals
+    // in all the cout by.
+    const sitesListForNearCount = vaOnly ?
+      sitesListAll.filter(site => site.isVA):
+      sitesListAll;
+
+    // Assume that search-location-zip means that
+    // you have a properly filled in zip code. 
+    if (location === 'search-location-zip') {
       //has a zip
       if (zipCoords.lat !== '' && zipCoords.long !== '') {
-        return `${sitesList.length} location${
-          sitesList.length === 1 ? '' : 's'
-        }, including ${countNearbySitesByZip(sitesList)} near you`;
+        return `${sitesListAll.length} location${
+          sitesListAll.length === 1 ? '' : 's'
+        }, including ${countNearbySitesByZip(sitesListForNearCount)} near you`;
       }
+    } else if (location === 'search-location-country') {
+      return `${sitesListAll.length} location${
+        sitesListAll.length === 1 ? '' : 's'
+      }, including ${countNearbySitesByCountryParams(sitesListForNearCount)} near you`;
+    } else if (location === 'search-location-nih') {
+      return `${sitesListAll.length} location${
+        sitesListAll.length === 1 ? '' : 's'
+      }, including ${countNearbySitesByNIHParams(sitesListForNearCount)} near you`;
+    } else if (vaOnly) {
+      // This accounts for search-location-all and vaOnly. The old code made sure
+      // hospital + va would not display, but the new logic should not have this
+      // issue.
+      return `${sitesListAll.length} location${
+        sitesListAll.length === 1 ? '' : 's'
+      }, including ${sitesListForNearCount.length} near you`;
     }
-    if (location === 'search-location-country') {
-      return `${sitesList.length} location${
-        sitesList.length === 1 ? '' : 's'
-      }, including ${countNearbySitesByCountryParams(sitesList)} near you`;
-    }
-    if (location === 'search-location-nih') {
-      return `${sitesList.length} location${
-        sitesList.length === 1 ? '' : 's'
-      }, including ${countNearbySitesByNIHParams(sitesList)} near you`;
-    }
-    return `${sitesList.length} location${sitesList.length === 1 ? '' : 's'}`;
+    return `${sitesListAll.length} location${sitesListAll.length === 1 ? '' : 's'}`;
   };
 
   const setCachedTitle = () => {

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -138,15 +138,7 @@ const ResultsListItem = ({ id, item, isChecked, onCheckChange, queryParams }) =>
   };
 
   const getLocationDisplay = () => {
-    if (item.sites.length === 1) {
-      const site = item.sites[0];
-      let displayText = `${site.name}, ${site.city}, `;
-      displayText +=
-        site.country === 'United States'
-          ? site.stateOrProvinceAbbreviation
-          : site.country;
-      return displayText;
-    }
+
     // NOTE: Displays for count should be ONLY US sites
     // unless it is a country search and the country
     // is not US.
@@ -155,6 +147,41 @@ const ResultsListItem = ({ id, item, isChecked, onCheckChange, queryParams }) =>
       (country !== 'United States')
     ) ? item.sites :
       item.sites.filter(site => site.country === 'United States');
+
+    // If there are no sites we need to display special information
+    if (sitesListAll.length === 0) {
+      // The old code also referenced a "not yet active" status, which does not exist, so
+      // we are going to ignore that.
+      if (item.currentTrialStatus === "Approved" || item.currentTrialStatus === "In Review") {
+        return "Location information is not yet available"
+      } else {
+        return (
+          <>
+            See{' '}
+            <a
+              href={`https://www.clinicaltrials.gov/show/${item.nctID}`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ClinicalTrials.gov
+            </a>
+          </>
+        );
+      }
+    }
+
+    // A single study site shows the name of the organiztion.
+    // Don't ask me (bp) what the ID is of a trial that has no
+    // US sites and only a single forign site.
+    if (sitesListAll.length === 1) {
+      const site = sitesListAll[0];
+      let displayText = `${site.name}, ${site.city}, `;
+      displayText +=
+        site.country === 'United States'
+          ? site.stateOrProvinceAbbreviation
+          : site.country;
+      return displayText;
+    }
 
     // We filter on VA here to cut down on conditionals
     // in all the cout by.

--- a/src/views/TrialDescriptionPage/SitesList.jsx
+++ b/src/views/TrialDescriptionPage/SitesList.jsx
@@ -36,12 +36,31 @@ const SitesList = sites => {
 
   const buildUSStatesList = sitesArr => {
     if (sitesArr.length > 0) {
-      let stateside = sitesArr.filter(item => item.country === 'United States');
-      let statesList = [
+      // Get all the US sites
+      const stateside = sitesArr.filter(item => item.country === 'United States');
+
+      // Get a UNIQUE list of all the US state abbreviations in use.
+      const statesAbbrs = [
         ...new Set(stateside.map(item => item.stateOrProvinceAbbreviation)),
       ];
-      statesList.sort((a, b) => (a > b ? 1 : -1));
-      setStatesList(statesList);
+
+      // Get the abbr/name combo for the states.
+      // NOTE: getStateNameFromAbbr is called later in order to draw the states
+      // dropdown. It may be beneficial to refactor this to always have the
+      // abbr/name pair sorted in statesList.
+      const stateNameAbbrObjs = statesAbbrs.map(s => ({
+        abbr: s,
+        name: getStateNameFromAbbr(s)
+      }));
+
+      // Get the sorted list of state abbreviations. NOTE: you
+      // need the names in order to sort.
+      const sortedStatesList = stateNameAbbrObjs
+        .sort((a,b) => (a.name > b.name ? 1 : -1))
+        .map(s => s.abbr);
+      
+      // Update the statesList state.
+      setStatesList(sortedStatesList);
     }
   };
 

--- a/src/views/TrialDescriptionPage/SitesList.jsx
+++ b/src/views/TrialDescriptionPage/SitesList.jsx
@@ -215,13 +215,9 @@ const SitesList = sites => {
     }
   };
 
-  const renderLocationBlock = (locationObj, index) => {
+  const renderContactInfoBlock = (locationObj) => {
     return (
-      <div key={'loc-' + locationObj.name} className="location">
-        <strong className="location-name">{locationObj.name}</strong>
-        <div>
-          Status: {getTrialStatusForDisplay(locationObj.recruitmentStatus)}
-        </div>
+      <>
         <div>Contact: {locationObj.contactName}</div>
         {locationObj.contactPhone && (
           <div>Phone: {locationObj.contactPhone}</div>
@@ -234,6 +230,22 @@ const SitesList = sites => {
             </a>
           </div>
         )}
+      </>
+    );
+  }
+
+  const renderLocationBlock = (locationObj, index) => {
+    return (
+      <div key={'loc-' + locationObj.name} className="location">
+        <strong className="location-name">{locationObj.name}</strong>
+        <div>
+          Status: {getTrialStatusForDisplay(locationObj.recruitmentStatus)}
+        </div>
+        {/* Contact only displays if there is a name */}
+        {locationObj.contactName ?
+          renderContactInfoBlock(locationObj) : 
+          (<>Name Not Available</>) 
+        }   
       </div>
     );
   };

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -348,14 +348,14 @@ const TrialDescriptionPage = ({ location }) => {
                     {trial.sites && trial.sites.length > 0 ? (
                       <SitesList sites={trial.sites} />
                     ) : noLocInfo.includes(
-                        trial.currentTrialStatus.toLower()
+                        trial.currentTrialStatus.toLowerCase()
                       ) ? (
                       <p>Location information is not yet available.</p>
                     ) : (
                       <p>
                         See trial information on{' '}
                         <a
-                          href={`https://www.clinicaltrials.gov/show/${trial.NCTID}`}
+                          href={`https://www.clinicaltrials.gov/show/${trial.nctID}`}
                           target="_blank"
                           rel="noopener noreferrer"
                         >


### PR DESCRIPTION
* Non-active recruiting sites were being shown on the trial details page
* The count of locations were incorrectly counting sites from non-US countries. ALL the sites should be counted ONLY when it is a search with a non-US country location parameter.
* Fixed issue where empty contact name was not show correctly, (Should display 'Name Not Available') example URL:
   *https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2019-04145&loc=0&pn=221&rl=2&tp=i
* Added Is VA Only as a factor in location counting on the search results
* Fixed issue where 0 trial country options where appearing in locations dropdown on the advanced search page
* Fixed state ordering on trial description page. This also included the state dropdown filter on the description page.
* When no locations are available for a trial the results page should display alternative text instead of "0 locations"