### PR TITLE
Various autocomplete related items

### DIFF
--- a/src/components/search-modules/CancerTypeCondition/CancerTypeCondition.jsx
+++ b/src/components/search-modules/CancerTypeCondition/CancerTypeCondition.jsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Fieldset, Autocomplete, InputLabel } from '../../atomic';
 import { getMainType, getCancerTypeDescendents } from '../../../store/actions';
 import { useCachedValues } from '../../../hooks';
+import {sortItemsByName} from '../../../utilities';
 import './CancerTypeCondition.scss';
 require('../../../polyfills/closest');
 
@@ -271,6 +272,7 @@ const CancerTypeCondition = ({ handleUpdate }) => {
             items={filterSelectedItems(subtypeOptions, subtypes)}
             getItemValue={item => item.name}
             shouldItemRender={matchItemToTerm}
+            sortItems={sortItemsByName}
             onChange={(event, value) => {
               setSubtype({ value });
               handleUpdate('subtypeModified', false);
@@ -321,6 +323,7 @@ const CancerTypeCondition = ({ handleUpdate }) => {
             items={filterSelectedItems(stageOptions, stages)}
             getItemValue={item => item.name}
             shouldItemRender={matchItemToTerm}
+            sortItems={sortItemsByName}
             onChange={(event, value) => {
               setStage({ value });
               handleUpdate('stagesModified', false);
@@ -370,6 +373,7 @@ const CancerTypeCondition = ({ handleUpdate }) => {
             items={filterSelectedItems(findingsOptions, findings)}
             getItemValue={item => item.name}
             shouldItemRender={matchItemToTerm}
+            sortItems={sortItemsByName}
             onChange={(event, value) => setSideEffects({ value })}
             onSelect={value => {
               handleUpdate('findings', [

--- a/src/components/search-modules/CancerTypeKeyword/CancerTypeKeyword.jsx
+++ b/src/components/search-modules/CancerTypeKeyword/CancerTypeKeyword.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Fieldset, Autocomplete } from '../../atomic';
 import { getDiseasesForSimpleTypeAhead } from '../../../store/actions';
+import { sortItemsByName } from '../../../utilities'
 
 const CancerTypeKeyword = ({ handleUpdate }) => {
   const dispatch = useDispatch();
@@ -35,6 +36,7 @@ const CancerTypeKeyword = ({ handleUpdate }) => {
         inputHelpText="Leave blank to search all cancer types or keywords."
         getItemValue={item => item.name}
         shouldItemRender={matchItemToTerm}
+        sortItems={sortItemsByName}
         onChange={(event, value) => {
           setCTK({ value });
           handleUpdate('cancerType', {name: '', codes: []})

--- a/src/components/search-modules/DrugTreatment/DrugTreatment.jsx
+++ b/src/components/search-modules/DrugTreatment/DrugTreatment.jsx
@@ -34,24 +34,26 @@ const DrugTreatment = ({ handleUpdate, useValue }) => {
     }
   }, [treatmentVal, dispatch]);
 
-  //not displaying everything!!
   const filterSelectedItems = (items = [], selections = []) => {
     if (!items.length || !selections.length) {
       return items;
     }
     const filteredItems = items.filter(
-      item => !selections.find(selection => selection.label === item.name)
+      item => !selections.find(selection => selection.name === item.name)
     );
     return filteredItems;
   };
 
-  const applyOptionsFilterAndFormatting = ( searchVal, item, isHighlighted ) => {
-    const searchStr = new RegExp('(^' + searchVal.value + '|\\s+' + searchVal.value + ')', 'i');
-    const filteredSynonyms = Array.isArray(item.synonyms) 
-      ? item.synonyms.filter( synonym => synonym.match(searchStr)) 
+  const applyOptionsFilterAndFormatting = (searchVal, item, isHighlighted) => {
+    const searchStr = new RegExp(
+      '(^' + searchVal.value + '|\\s+' + searchVal.value + ')',
+      'i'
+    );
+    const filteredSynonyms = Array.isArray(item.synonyms)
+      ? item.synonyms.filter(synonym => synonym.match(searchStr))
       : [];
     const filteredSynonymsCount = filteredSynonyms.length;
-    
+
     return (
       <div
         className={`cts-autocomplete__menu-item ${
@@ -64,18 +66,21 @@ const DrugTreatment = ({ handleUpdate, useValue }) => {
           {item.category.indexOf('category') !== -1 ? ' (DRUG FAMILY)' : ''}
         </div>
         {filteredSynonymsCount > 0 && (
-          
           <span className="synonyms">
-            Other Names: {' '}
+            Other Names:{' '}
             <ol>
-              { filteredSynonyms.map( (synonym, i) => {
+              {filteredSynonyms.map((synonym, i) => {
                 return (
-                  <li key={i}
-                      dangerouslySetInnerHTML={
-                          {__html: synonym.match(searchStr) ? synonym.replace(searchStr, `<strong>$&</strong>`) : synonym}
-                  }></li>
-                )
-              }) }
+                  <li
+                    key={i}
+                    dangerouslySetInnerHTML={{
+                      __html: synonym.match(searchStr)
+                        ? synonym.replace(searchStr, `<strong>$&</strong>`)
+                        : synonym,
+                    }}
+                  ></li>
+                );
+              })}
             </ol>
           </span>
         )}
@@ -96,10 +101,12 @@ const DrugTreatment = ({ handleUpdate, useValue }) => {
         label="Drug/Drug Family"
         inputHelpText="You can use the drug's generic or brand name. More than one selection may be made."
         value={drugVal.value}
-        inputProps={{ placeholder: 'Start typing to select drugs and/or drug families' }}
+        inputProps={{
+          placeholder: 'Start typing to select drugs and/or drug families',
+        }}
         items={filterSelectedItems(drugOptions, drugs)}
         getItemValue={item => item.name}
-        shouldItemRender={ () => true }
+        shouldItemRender={() => true}
         onChange={(event, value) => setDrugVal({ value })}
         onSelect={value => {
           handleUpdate('drugs', [
@@ -133,7 +140,9 @@ const DrugTreatment = ({ handleUpdate, useValue }) => {
             </div>
           );
         }}
-        renderItem={ (item, isHighlighted) => applyOptionsFilterAndFormatting(drugVal, item, isHighlighted) }
+        renderItem={(item, isHighlighted) =>
+          applyOptionsFilterAndFormatting(drugVal, item, isHighlighted)
+        }
       />
 
       <Autocomplete
@@ -178,7 +187,9 @@ const DrugTreatment = ({ handleUpdate, useValue }) => {
             </div>
           );
         }}
-        renderItem={(item, isHighlighted) => applyOptionsFilterAndFormatting(treatmentVal, item, isHighlighted)}
+        renderItem={(item, isHighlighted) =>
+          applyOptionsFilterAndFormatting(treatmentVal, item, isHighlighted)
+        }
       />
     </Fieldset>
   );

--- a/src/components/search-modules/Location/Location.jsx
+++ b/src/components/search-modules/Location/Location.jsx
@@ -9,14 +9,14 @@ import {
   Autocomplete,
 } from '../../atomic';
 import { getCountries, searchHospital } from '../../../store/actions';
-import { matchItemToTerm, sortItems } from '../../../utilities';
-import { useZipConversion } from '../../../hooks';
-import './Location.scss';
-
 import {
+  matchItemToTerm,
+  sortItems,
   getStates,
   matchStateToTerm,
-} from '../../../mocks/mock-autocomplete-util';
+} from '../../../utilities';
+import { useZipConversion } from '../../../hooks';
+import './Location.scss';
 
 const Location = ({ handleUpdate }) => {
   //Hooks must always be rendered in same order.
@@ -74,8 +74,11 @@ const Location = ({ handleUpdate }) => {
     let newVal = !limitToVA;
     setLimitToVA(newVal);
     handleUpdate('vaOnly', newVal);
-    // make sure that the newly hidden selections are not selected 
-    if(activeRadio === 'search-location-nih' || activeRadio === 'search-location-hospital'){
+    // make sure that the newly hidden selections are not selected
+    if (
+      activeRadio === 'search-location-nih' ||
+      activeRadio === 'search-location-hospital'
+    ) {
       setActiveRadio('search-location-all');
       handleUpdate('hospital', { term: '', termKey: '' });
     }

--- a/src/components/search-modules/Location/Location.jsx
+++ b/src/components/search-modules/Location/Location.jsx
@@ -14,6 +14,7 @@ import {
   sortItems,
   getStates,
   matchStateToTerm,
+  sortStates,
 } from '../../../utilities';
 import { useZipConversion } from '../../../hooks';
 import './Location.scss';
@@ -230,6 +231,7 @@ const Location = ({ handleUpdate }) => {
                   items={filterSelectedItems(stateOptions, states)}
                   getItemValue={item => item.name}
                   shouldItemRender={matchStateToTerm}
+                  sortItems={sortStates}
                   onChange={(event, value) => setStateVal({ value })}
                   onSelect={value => {
                     handleUpdate('states', [

--- a/src/components/search-modules/Location/Location.jsx
+++ b/src/components/search-modules/Location/Location.jsx
@@ -249,7 +249,7 @@ const Location = ({ handleUpdate }) => {
                   renderMenu={children => {
                     return (
                       <div className="cts-autocomplete__menu --drugs">
-                        {stateVal.value.length ? (
+                        {
                           filterSelectedItems(stateOptions, states).length ? (
                             children
                           ) : (
@@ -257,11 +257,7 @@ const Location = ({ handleUpdate }) => {
                               No results found
                             </div>
                           )
-                        ) : (
-                          <div className="cts-autocomplete__menu-item">
-                            Enter state name
-                          </div>
-                        )}
+                        }
                       </div>
                     );
                   }}

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -18,7 +18,7 @@ export {
 } from './stateUtils';
 export { keyHandler } from './keyHandler';
 export { uniqueIdForComponent } from './uniqueIdForComponent';
-export { sortItems } from './sortItems';
+export { sortItems, sortItemsByName } from './sortItems';
 export { ctsapiDiseaseFetcher } from './ctsapiDiseaseFetcher';
 export { ctsapiInterventionFetcher } from './ctsapiInterventionFetcher';
 export { zipcodeFetcher } from './zipcodeFetcher';

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -10,10 +10,16 @@ export {
   loadStateFromSessionStorage,
   saveStatetoSessionStorage,
 } from './sessionUtils';
+export {
+  matchStateToTerm,
+  matchStateToTermWithHeaders,
+  sortStates,
+  getStates,
+} from './stateUtils';
 export { keyHandler } from './keyHandler';
 export { uniqueIdForComponent } from './uniqueIdForComponent';
-export {sortItems} from './sortItems';
-export {ctsapiDiseaseFetcher} from './ctsapiDiseaseFetcher';
-export {ctsapiInterventionFetcher} from './ctsapiInterventionFetcher';
-export {zipcodeFetcher} from './zipcodeFetcher';
-export {queryStringToFormObject} from './queryStringToFormObject';
+export { sortItems } from './sortItems';
+export { ctsapiDiseaseFetcher } from './ctsapiDiseaseFetcher';
+export { ctsapiInterventionFetcher } from './ctsapiInterventionFetcher';
+export { zipcodeFetcher } from './zipcodeFetcher';
+export { queryStringToFormObject } from './queryStringToFormObject';

--- a/src/utilities/sortItems.js
+++ b/src/utilities/sortItems.js
@@ -9,3 +9,15 @@ export function sortItems(a, b, value) {
   }
   return aLower < bLower ? -1 : 1;
 }
+
+export function sortItemsByName(a, b, value) {
+  const aLower = a.name.toLowerCase();
+  const bLower = b.name.toLowerCase();
+  const valueLower = value.toLowerCase();
+  const queryPosA = aLower.indexOf(valueLower);
+  const queryPosB = bLower.indexOf(valueLower);
+  if (queryPosA !== queryPosB) {
+    return queryPosA - queryPosB;
+  }
+  return aLower < bLower ? -1 : 1;
+}

--- a/src/utilities/stateUtils.js
+++ b/src/utilities/stateUtils.js
@@ -1,0 +1,90 @@
+export function matchStateToTerm(state, value) {
+  return (
+    state.name.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
+    state.abbr.toLowerCase().indexOf(value.toLowerCase()) !== -1
+  );
+}
+
+export function matchStateToTermWithHeaders(state, value) {
+  return (
+    state.header ||
+    state.name.toLowerCase().indexOf(value.toLowerCase()) !== -1 ||
+    state.abbr.toLowerCase().indexOf(value.toLowerCase()) !== -1
+  );
+}
+
+/**
+ * An example of how to implement a relevancy-based sorting method. States are
+ * sorted based on the location of the match - For example, a search for "or"
+ * will return "Oregon" before "North Carolina" even though "North Carolina"
+ * would normally sort above Oregon. Strings where the match is in the same
+ * location (or there is no match) will be sorted alphabetically - For example,
+ * a search for "or" would return "North Carolina" above "North Dakota".
+ */
+export function sortStates(a, b, value) {
+  const aLower = a.name.toLowerCase();
+  const bLower = b.name.toLowerCase();
+  const valueLower = value.toLowerCase();
+  const queryPosA = aLower.indexOf(valueLower);
+  const queryPosB = bLower.indexOf(valueLower);
+  if (queryPosA !== queryPosB) {
+    return queryPosA - queryPosB;
+  }
+  return aLower < bLower ? -1 : 1;
+}
+
+export function getStates() {
+    return [
+      { abbr: 'AL', name: 'Alabama' },
+      { abbr: 'AK', name: 'Alaska' },
+      { abbr: 'AZ', name: 'Arizona' },
+      { abbr: 'AR', name: 'Arkansas' },
+      { abbr: 'CA', name: 'California' },
+      { abbr: 'CO', name: 'Colorado' },
+      { abbr: 'CT', name: 'Connecticut' },
+      { abbr: 'DC', name: 'District of Columbia'},
+      { abbr: 'DE', name: 'Delaware' },
+      { abbr: 'FL', name: 'Florida' },
+      { abbr: 'GA', name: 'Georgia' },
+      { abbr: 'HI', name: 'Hawaii' },
+      { abbr: 'ID', name: 'Idaho' },
+      { abbr: 'IL', name: 'Illinois' },
+      { abbr: 'IN', name: 'Indiana' },
+      { abbr: 'IA', name: 'Iowa' },
+      { abbr: 'KS', name: 'Kansas' },
+      { abbr: 'KY', name: 'Kentucky' },
+      { abbr: 'LA', name: 'Louisiana' },
+      { abbr: 'ME', name: 'Maine' },
+      { abbr: 'MD', name: 'Maryland' },
+      { abbr: 'MA', name: 'Massachusetts' },
+      { abbr: 'MI', name: 'Michigan' },
+      { abbr: 'MN', name: 'Minnesota' },
+      { abbr: 'MS', name: 'Mississippi' },
+      { abbr: 'MO', name: 'Missouri' },
+      { abbr: 'MT', name: 'Montana' },
+      { abbr: 'NE', name: 'Nebraska' },
+      { abbr: 'NV', name: 'Nevada' },
+      { abbr: 'NH', name: 'New Hampshire' },
+      { abbr: 'NJ', name: 'New Jersey' },
+      { abbr: 'NM', name: 'New Mexico' },
+      { abbr: 'NY', name: 'New York' },
+      { abbr: 'NC', name: 'North Carolina' },
+      { abbr: 'ND', name: 'North Dakota' },
+      { abbr: 'OH', name: 'Ohio' },
+      { abbr: 'OK', name: 'Oklahoma' },
+      { abbr: 'OR', name: 'Oregon' },
+      { abbr: 'PA', name: 'Pennsylvania' },
+      { abbr: 'RI', name: 'Rhode Island' },
+      { abbr: 'SC', name: 'South Carolina' },
+      { abbr: 'SD', name: 'South Dakota' },
+      { abbr: 'TN', name: 'Tennessee' },
+      { abbr: 'TX', name: 'Texas' },
+      { abbr: 'UT', name: 'Utah' },
+      { abbr: 'VT', name: 'Vermont' },
+      { abbr: 'VA', name: 'Virginia' },
+      { abbr: 'WA', name: 'Washington' },
+      { abbr: 'WV', name: 'West Virginia' },
+      { abbr: 'WI', name: 'Wisconsin' },
+      { abbr: 'WY', name: 'Wyoming' }
+    ]
+  }


### PR DESCRIPTION
- States dropdown appears on first click
- States are sorted by entry in typeahead
- DrugTreatments dupes are prevented by removing selected items from the rendered menu
- added sorting to cancer types on basic form, and subtypes, stages and findings on advanced (filtered on first letter)
