### PR TITLE
Tracking added for clear form, start over, try a new search, and modify search criteria links

### DIFF
--- a/src/components/atomic/SearchCriteriaTable/SearchCriteriaTable.jsx
+++ b/src/components/atomic/SearchCriteriaTable/SearchCriteriaTable.jsx
@@ -1,9 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link } from 'react-router-dom';
-import { Accordion, AccordionItem, Table } from '../../atomic';
-import { updateFormField } from '../../../store/actions';
+
 import './SearchCriteriaTable.scss';
+
+import { Accordion, AccordionItem, Table } from '../../atomic';
+import { START_OVER_LINK } from '../../../constants';
+import { updateFormField } from '../../../store/actions';
 
 const SearchCriteriaTable = ({
   placement = 'results',
@@ -299,7 +302,7 @@ const SearchCriteriaTable = ({
       {placement === 'trial' ? (
         <Link
           to={`${formType === 'basic' ? '/about-cancer/treatment/clinical-trials/search/' : '/about-cancer/treatment/clinical-trials/search/advanced'}`}
-          onClick={handleReset}
+          onClick={() => handleReset(START_OVER_LINK)}
         >
           <strong>Start Over</strong>
         </Link>
@@ -307,7 +310,7 @@ const SearchCriteriaTable = ({
         <div className="reset-form">
           <Link
             to={`${formType === 'basic' ? '/about-cancer/treatment/clinical-trials/search/' : '/about-cancer/treatment/clinical-trials/search/advanced'}`}
-            onClick={handleReset}
+            onClick={() => handleReset(START_OVER_LINK)}
           >
             Start Over
           </Link>
@@ -327,7 +330,7 @@ const SearchCriteriaTable = ({
           <strong>This clinical trial matches: "all trials"</strong> |{' '}
           <Link
             to={`${formType === 'basic' ? '/about-cancer/treatment/clinical-trials/search/' : '/about-cancer/treatment/clinical-trials/search/advanced'}`}
-            onClick={handleReset}
+            onClick={() => handleReset(START_OVER_LINK)}
           >
             <strong>Start Over</strong>
           </Link>

--- a/src/components/atomic/StickySubmitBlock/StickySubmitBlock.jsx
+++ b/src/components/atomic/StickySubmitBlock/StickySubmitBlock.jsx
@@ -1,13 +1,19 @@
-import React, { useEffect, useRef } from 'react';
-import {useDispatch} from 'react-redux';
-import { clearForm } from '../../../store/actions';
-import { history } from '../../../services/history.service';
 import PropTypes from 'prop-types';
+import React, { useEffect, useRef } from 'react';
+import { useDispatch } from 'react-redux';
+import { useTracking } from 'react-tracking';
+import { clearForm } from '../../../store/actions';
+
 import './StickySubmitBlock.scss';
+
+import { trackedEvents } from '../../../tracking/index';
+
 
 const StickySubmitBlock = ({ sentinelRef, onSubmit }) => {
   const dispatch = useDispatch();
   const stickyEl = useRef(null);
+  const { trackEvent } = useTracking();
+  const { ClearFormLinkClick } = trackedEvents;
 
   useEffect(() => {
     intObserver.observe(stickyEl.current);
@@ -36,6 +42,7 @@ const StickySubmitBlock = ({ sentinelRef, onSubmit }) => {
     dispatch(clearForm());
     window.scrollTo(0, 0);
     window.location.reload(false);
+    trackEvent(ClearFormLinkClick);
   }
 
   const intObserver = new IntersectionObserver(callback, options);

--- a/src/components/atomic/StickySubmitBlock/StickySubmitBlock.jsx
+++ b/src/components/atomic/StickySubmitBlock/StickySubmitBlock.jsx
@@ -2,10 +2,10 @@ import PropTypes from 'prop-types';
 import React, { useEffect, useRef } from 'react';
 import { useDispatch } from 'react-redux';
 import { useTracking } from 'react-tracking';
-import { clearForm } from '../../../store/actions';
 
 import './StickySubmitBlock.scss';
 
+import { clearForm } from '../../../store/actions';
 import { trackedEvents } from '../../../tracking/index';
 
 

--- a/src/components/search-modules/Location/Location.jsx
+++ b/src/components/search-modules/Location/Location.jsx
@@ -161,6 +161,7 @@ const Location = ({ handleUpdate }) => {
           checked={limitToVA}
           label="Limit results to Veterans Affairs facilities"
           onClick={handleToggleChange}
+          onChange={()=>{}}
         />
         Limit results to Veterans Affairs facilities
       </div>

--- a/src/components/search-modules/TrialType/TrialType.jsx
+++ b/src/components/search-modules/TrialType/TrialType.jsx
@@ -65,6 +65,7 @@ const TrialType = ({ handleUpdate }) => {
           checked={hvToggle}
           label="Limit results to Veterans Affairs facilities"
           onClick={handleToggle}
+          onChange={()=>{}}
         />
         Limit results to trials accepting healthy volunteers
       </div>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -56,3 +56,5 @@ export const OTHER_MAIN_TYPES = [
 ];
 
 export const NIH_ZIPCODE = "20892";
+export const START_OVER_LINK = 'start_over_link';
+export const TRY_NEW_SEARCH_LINK = 'try_a_new_search_link';

--- a/src/tracking/events.js
+++ b/src/tracking/events.js
@@ -82,8 +82,19 @@ export const PrintMaxExceededClick = {
 };
 
 /**
+ * ModifySearchCriteriaLinkClick - Default analytics data dispatched  when "Modify Search Criteria" link is clicked on results page
+ * (data updated before trackEvent is triggered)
+ * @returns {BaseEvent}
+ */
+export const ModifySearchCriteriaLinkClick = {
+  ...getBaseEventObj(),
+  action: 'click',
+  source: 'modify_search_criteria_link',
+};
+
+/**
  * NewSearchLinkClick - Analytics data dispatched on clicking "Start Over" or "Try a new search" link on results page 
- * (data and source added before event trigger)
+ * (data and source updated before trackEvent is triggered)
  * @returns {BaseEvent}
  */
 export const NewSearchLinkClick = {

--- a/src/tracking/events.js
+++ b/src/tracking/events.js
@@ -20,6 +20,19 @@ function getBaseEventObj() {
 }
 
 /**
+ * ClearFormLinkClick - Default analytics data dispatched on clicking the clear form link on the search page
+ * @returns {BaseEvent}
+ */
+export const ClearFormLinkClick = {
+    ...getBaseEventObj(),
+    action: 'click',
+    data: {
+      formType: 'advanced',
+    },
+    source: 'clear_form_link',
+};
+
+/**
  * FindTrialsButtonClick - Default analytics data dispatched for basic and advanced trial search click (defaults to basic)
  * @returns {BaseEvent}
  */
@@ -66,4 +79,14 @@ export const PrintMaxExceededClick = {
     formType: 'basic',
   },
   source: 'print_selected_max_reached_button',
+};
+
+/**
+ * NewSearchLinkClick - Analytics data dispatched on clicking "Start Over" or "Try a new search" link on results page 
+ * (data and source added before event trigger)
+ * @returns {BaseEvent}
+ */
+export const NewSearchLinkClick = {
+    ...getBaseEventObj(),
+    action: 'click',
 };

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -2,6 +2,10 @@ import React, { useState, useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Helmet } from 'react-helmet';
+import track from 'react-tracking';
+
+import './ResultsPage.scss';
+
 import { updateFormField, clearForm, receiveData } from '../../store/actions';
 import {
   ChatOpener,
@@ -10,18 +14,16 @@ import {
   Modal,
   Pager,
 } from '../../components/atomic';
+import { TRY_NEW_SEARCH_LINK } from '../../constants';
 import { buildQueryString } from '../../utilities';
 import { useModal, useStoreToFindTrials } from '../../hooks';
 import ResultsPageHeader from './ResultsPageHeader';
 import ResultsList from './ResultsList';
 import { history } from '../../services/history.service';
 import PrintModalContent from './PrintModalContent';
-import track from 'react-tracking';
 import { trackedEvents } from '../../tracking';
-import './ResultsPage.scss';
+
 const queryString = require('query-string');
-
-
 
 const ResultsPage = ({ location, tracking }) => {
 
@@ -145,7 +147,11 @@ const ResultsPage = ({ location, tracking }) => {
     }
   };
 
-  const handleStartOver = () => {
+  const handleStartOver = (linkType) => {
+    const { NewSearchLinkClick } = trackedEvents;
+    NewSearchLinkClick.data.formType = formSnapshot.formType;
+    NewSearchLinkClick.source = linkType;
+    handleTracking(NewSearchLinkClick);
     dispatch(clearForm());
   };
 
@@ -340,7 +346,7 @@ const ResultsPage = ({ location, tracking }) => {
                 ? '/about-cancer/treatment/clinical-trials/search'
                 : '/about-cancer/treatment/clinical-trials/search/advanced'
             }`}
-            onClick={handleStartOver}
+            onClick={() => handleStartOver(TRY_NEW_SEARCH_LINK)}
           >
             Try a new search
           </Link>
@@ -366,7 +372,7 @@ const ResultsPage = ({ location, tracking }) => {
                 ? '/about-cancer/treatment/clinical-trials/search'
                 : '/about-cancer/treatment/clinical-trials/search/advanced'
             }`}
-            onClick={handleStartOver}
+            onClick={() => handleStartOver(TRY_NEW_SEARCH_LINK)}
           >
             Try a new search
           </Link>

--- a/src/views/ResultsPage/ResultsPageHeader.jsx
+++ b/src/views/ResultsPage/ResultsPageHeader.jsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
+import { useTracking } from 'react-tracking';
 
 import { SearchCriteriaTable } from '../../components/atomic';
 import { START_OVER_LINK } from '../../constants';
 import { history } from '../../services/history.service';
 import { getMainType } from '../../store/actions';
+import { trackedEvents } from '../../tracking';
 
 const ResultsPageHeader = ({
   handleUpdate,
@@ -23,10 +25,15 @@ const ResultsPageHeader = ({
     keywordPhrases,
     isDirty,
   } = useSelector(store => store.form);
+  const { trackEvent } = useTracking();
 
   const { maintypeOptions } = useSelector(store => store.cache);
 
   const handleRefineSearch = () => {
+    
+    const { ModifySearchCriteriaLinkClick } = trackedEvents;
+    ModifySearchCriteriaLinkClick.data.formType = formType;
+
     if (formType === 'basic') {
       //prefetch stuff
       if (!maintypeOptions || maintypeOptions.length < 1) {
@@ -46,8 +53,11 @@ const ResultsPageHeader = ({
       }
       handleUpdate('formType', 'advanced');
     }
+
     handleUpdate('refineSearch', true);
+    trackEvent(ModifySearchCriteriaLinkClick);
     history.push('/about-cancer/treatment/clinical-trials/search/advanced');
+  
   };
 
   return (

--- a/src/views/ResultsPage/ResultsPageHeader.jsx
+++ b/src/views/ResultsPage/ResultsPageHeader.jsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { getMainType } from '../../store/actions';
 import { Link } from 'react-router-dom';
+
 import { SearchCriteriaTable } from '../../components/atomic';
+import { START_OVER_LINK } from '../../constants';
 import { history } from '../../services/history.service';
+import { getMainType } from '../../store/actions';
 
 const ResultsPageHeader = ({
   handleUpdate,
@@ -69,7 +71,7 @@ const ResultsPageHeader = ({
                 for: "all trials" &nbsp; | &nbsp;
                 <Link
                   to={`${formType === 'basic' ? '/about-cancer/treatment/clinical-trials/search' : '/about-cancer/treatment/clinical-trials/search/advanced'}`}
-                  onClick={handleReset}
+                  onClick={() => handleReset(START_OVER_LINK)}
                 >
                   Start Over
                 </Link>


### PR DESCRIPTION
- Tracking added for click events:
 1. `Start Over` link on results page
 2. `Try a new search` link on results page
 3. `Modify Search Criteria` link on results page
 4. `Clear Form` link on advanced search page in sticky submit element
<br/>

- Resolved warning message in console on advanced search page