### PR TITLE
Modify search issue with subtypes

### DIFF
--- a/src/components/search-modules/CancerTypeCondition/CancerTypeCondition.jsx
+++ b/src/components/search-modules/CancerTypeCondition/CancerTypeCondition.jsx
@@ -124,7 +124,7 @@ const CancerTypeCondition = ({ handleUpdate }) => {
         // just retrieve descendents
         //switch off refineSearch
         handleUpdate('refineSearch', false);
-        retrieveDescendents(cancerType.name, cancerType.codes);
+        retrieveDescendents(cancerType.codes[0], cancerType.codes);
       } else {
         // use the parentDisease ID to select the primary cancer type
         let parentCancer = cache['maintypeOptions'].find(
@@ -152,9 +152,6 @@ const CancerTypeCondition = ({ handleUpdate }) => {
       }
     }
   };
-
-
-
 
   const matchItemToTerm = (item, value) => {
     return item.name.toLowerCase().indexOf(value.toLowerCase()) !== -1;


### PR DESCRIPTION
Subtypes were being cached under cancer type name instead of code where the selected cancer type keyword included type 'maintype'