### PR TITLE
Added CGDP Helper Analytics Functions

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,13 @@ import { ClinicalTrialsServiceFactory } from '@nciocpl/clinical-trials-search-cl
 import App from './App';
 import AnalyticsProvider from './AnalyticsProvider';
 
+import {
+  CommonAnalyticsActions,
+  DescriptionAnalyticsActions,
+  ResultsAnalyticsActions,
+  SearchAnalyticsActions
+} from './utilities/cgdp-analytics'
+
 const initialize = ({
   appId = '@@/DEFAULT_CTS_APP_ID',
   useSessionStorage = true,
@@ -127,3 +134,15 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 export default initialize;
+
+// This is kind of hacky. These are the mapping functions for this apps analytics
+// to Cgov-Digital-Platform Adobe Analytics structures. We have working tests here
+// so we put the functions here so we have tests for them. Instead of copy and
+// pasting the files, we are exporting them with the app. This *is* nice because
+// if someone raises a new event, then they can add the action for that event.
+export const AnalyticsActions = {
+  ...CommonAnalyticsActions,
+  ...DescriptionAnalyticsActions,
+  ...ResultsAnalyticsActions,
+  ...SearchAnalyticsActions
+}

--- a/src/utilities/__tests__/formToTrackingData.js
+++ b/src/utilities/__tests__/formToTrackingData.js
@@ -201,13 +201,15 @@ const testCases = [
   ],  
 
   // ZIP
-  [ "Zip - no radius",
+  [ "Zip - default radius",
     {
       zip: "20852",
+      zipRadius: "100",
       location: "search-location-zip"
     },
     {
       zip: "20852",
+      zipRadius: "100",
       location: "search-location-zip"      
     }
   ],
@@ -383,7 +385,6 @@ const testCases = [
       location: 'search-location-all'
     }
   ],
-
 ];
 
 describe("formToTrackingData", () => {

--- a/src/utilities/cgdp-analytics/README.md
+++ b/src/utilities/cgdp-analytics/README.md
@@ -1,0 +1,1 @@
+cgov-digital-platform does not have support for running tests yet. So I am creating the CTS analytics helpers here so that I can create tests. It is dirty as anything, but it also will help ensure code quality. These functions are NOT to be used in this app and NEED TO BE MOVED WHEN FIXED.

--- a/src/utilities/cgdp-analytics/__tests__/cts-analytics-common.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-analytics-common.js
@@ -1,0 +1,120 @@
+import {CommonAnalyticsActions} from '../cts-analytics-common';
+
+const TEST_CASES = [
+  // Start Over
+  [ "link_start_over_link",
+    "basic works",
+    {
+      formType: 'basic'
+    },
+    [{
+      type: "LINK",      
+      data: {
+        linkname: "CTStartOverClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_basic` },
+        props: {
+          '74': `clinicaltrials_basic|start over`
+        }
+      }
+    }]
+  ],
+  [ "link_start_over_link",
+    "adv works",
+    {
+      formType: 'advanced'
+    },
+    [{
+      type: "LINK",      
+      data: {
+        linkname: "CTStartOverClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_advanced` },
+        props: {
+          '74': `clinicaltrials_advanced|start over`
+        }
+      }
+    }]
+  ],
+  // Modify Search
+  [ "link_modify_search_criteria_link",
+    "basic works",
+    {
+      formType: 'basic'
+    },
+    [{
+      type: "LINK",      
+      data: {
+        linkname: "CTSModifyClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_basic` },
+        props: {
+          '74': `clinicaltrials_basic|modify`
+        }
+      }
+    }]
+  ],
+  [ "link_modify_search_criteria_link",
+    "adv works",
+    {
+      formType: 'advanced'
+    },
+    [{
+      type: "LINK",      
+      data: {
+        linkname: "CTSModifyClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_advanced` },
+        props: {
+          '74': `clinicaltrials_advanced|modify`
+        }
+      }
+    }]
+  ],  
+  // Try a new Search (Error page & on 0 results found)
+  [ "link_try_a_new_search_link",
+    "basic works",
+    {
+      formType: 'basic'
+    },
+    [{
+      type: "LINK",      
+      data: {
+        linkname: "CTSTryNewSearchClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_basic` },
+        props: {
+          '74': `clinicaltrials_basic|try a new search`
+        }
+      }
+    }]
+  ],
+  [ "link_try_a_new_search_link",
+    "adv works",
+    {
+      formType: 'advanced'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: "CTSTryNewSearchClick",
+        events: [49],
+        eVars: { '47': `clinicaltrials_advanced` },
+        props: {
+          '74': `clinicaltrials_advanced|try a new search`
+        }
+      }
+    }]
+  ],  
+
+]
+
+describe("CommonAnalyticsActions - Link Tests", () => {
+  test.each(TEST_CASES)(
+    "%# - %s - %s",
+    (actionName, scenario, eventdata, expected) => {
+      const actual = CommonAnalyticsActions[actionName](eventdata);
+      expect(actual).toEqual(expected);
+    }
+  );
+})

--- a/src/utilities/cgdp-analytics/__tests__/cts-description-page-analytics.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-description-page-analytics.js
@@ -1,0 +1,85 @@
+import {DescriptionAnalyticsActions} from '../cts-description-page-analytics';
+
+const TEST_CASES = [
+  // PAGE LOAD
+  [ "load_trial_description",
+    "basic works",
+    {
+      formType: 'basic',
+      nctId: 'NCT123456789'
+    },
+    [{
+      type: 'LOAD',
+      data: {
+        eVars: { '62': "Clinical Trials: Basic" },
+        props: {
+          '16': 'NCT123456789',
+          '62': "Clinical Trials: Basic"
+        }
+      }
+    }]
+  ],
+  [ "load_trial_description",
+    "advanced works",
+    {
+      formType: 'advanced',
+      nctId: 'NCT123456789'
+    },
+    [{
+      type: 'LOAD',
+      data: {
+        eVars: { '62': "Clinical Trials: Advanced" },
+        props: {
+          '16': 'NCT123456789',
+          '62': "Clinical Trials: Advanced"
+        }
+      }
+    }]
+  ],
+  // This is from a dynamic listing page.
+  [ "load_trial_description",
+    "custom works",
+    {
+      formType: 'custom',
+      nctId: 'NCT123456789'
+    },
+    [{
+      type: 'LOAD',
+      data: {
+        eVars: { '62': "Clinical Trials: Custom" },
+        props: {
+          '16': 'NCT123456789',
+          '62': "Clinical Trials: Custom"
+        }
+      }
+    }]
+  ],
+  // This is for something like google
+  [ "load_trial_description",
+    "direct works",
+    {
+      formType: '',
+      nctId: 'NCT123456789'
+    },
+    [{
+      type: 'LOAD',
+      data: {
+        eVars: { '62': "Clinical Trials: Direct" },
+        props: {
+          '16': 'NCT123456789',
+          '62': "Clinical Trials: Direct"
+        }
+      }
+    }]
+  ],
+];
+
+describe("DescriptionAnalyticsActions", () => {
+  test.each(TEST_CASES)(
+    "%# - %s - %s",
+    (actionName, scenario, eventdata, expected) => {
+      const actual = DescriptionAnalyticsActions[actionName](eventdata);
+      expect(actual).toEqual(expected);
+    }
+  );
+})

--- a/src/utilities/cgdp-analytics/__tests__/cts-results-page-analytics.linkevents.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-results-page-analytics.linkevents.js
@@ -1,0 +1,35 @@
+import { ResultsAnalyticsActions} from '../cts-results-page-analytics';
+
+const TEST_CASES = [
+  [ "link_results_page_link",
+    "basic - page 1 result 5",
+    {
+      formType: 'basic',
+      resultsPosition: 5,
+      pageNum: 1
+    },
+    [{
+      type: "LINK",
+      data: {
+        events: [42],
+        props: {
+          '12': 'clinicaltrials_basic',
+          '13': '5|page 1'
+        },
+        eVars: {
+          '12': 'clinicaltrials_basic'
+        }
+      }
+    }]
+  ]
+]
+
+describe("ResultsAnalyticsActions - Link Tests", () => {
+  test.each(TEST_CASES)(
+    "%# - %s - %s",
+    (actionName, scenario, eventdata, expected) => {
+      const actual = ResultsAnalyticsActions[actionName](eventdata);
+      expect(actual).toEqual(expected);
+    }
+  );
+})

--- a/src/utilities/cgdp-analytics/__tests__/cts-results-page-analytics.loadevents.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-results-page-analytics.loadevents.js
@@ -1,0 +1,504 @@
+import { ResultsAnalyticsActions} from '../cts-results-page-analytics';
+
+const DEFAULT_BASIC_PROPS = {
+  '11': 'clinicaltrials_basic',
+  '15': 'none',
+  '17': 'none|none',
+  '18': 'all',
+  // No 19 & 20 for basic
+  '62': 'Clinical Trials: Basic'
+}
+
+const DEFAULT_BASIC_EVARS = {
+  '10': 3000,
+  '11': 'clinicaltrials_basic',
+  '15': 'none',
+  '17': 'none|none',
+  '18': 'all',
+  // No 19 & 20 for basic
+  '62': 'Clinical Trials: Basic'
+}
+
+const DEFAULT_ADV_PROPS = {
+  '11': 'clinicaltrials_advanced',
+  '15': 'none',
+  '17': 'all|all|all|all|none|none',
+  '18': 'all',
+  '19': 'all|none|none',
+  '20': 'all|none|none|none',
+  '62': 'Clinical Trials: Advanced'  
+};
+
+const DEFAULT_ADV_EVARS = {
+  '10': 3000,
+  '11': 'clinicaltrials_advanced',
+  '15': 'none',
+  '17': 'all|all|all|all|none|none',
+  '18': 'all',
+  '19': 'all|none|none',
+  '20': 'all|none|none|none',
+  '62': 'Clinical Trials: Advanced'
+}
+
+const TEST_CASES = [
+  [ "basic - no params",
+    {
+      formType: 'basic',
+      numResults: 3000,
+      formData: {      
+        location: 'search-location-all',
+        formType: 'basic'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: DEFAULT_BASIC_EVARS,
+        props: DEFAULT_BASIC_PROPS,
+      }
+    }]
+  ],
+  [ "basic - keyword all",
+    {
+      formType: 'basic',
+      numResults: 3000,
+      formData: {
+        keywordPhrases: 'Breast cancer',
+        age: 35,
+        location: 'search-location-zip',
+        zip: 20874,
+        formType: 'basic'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_BASIC_EVARS,
+          '15': 'a:q:loc:z',
+          '17': 'keyword|breast cancer|35',
+          '18': 'zip|20874|none'
+        },
+        props: {
+          ...DEFAULT_BASIC_PROPS,
+          '15': 'a:q:loc:z',
+          '17': 'keyword|breast cancer|35',
+          '18': 'zip|20874|none'          
+        },
+      }
+    }]
+  ],
+  [ "basic - disease all",
+    {
+      formType: 'basic',
+      numResults: 3000,
+      formData: {
+        cancerType: ['c1111'],
+        age: 35,
+        location: 'search-location-zip',
+        zip: 20874,
+        formType: 'basic'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_BASIC_EVARS,
+          '15': 't:a:loc:z',
+          '17': 'typecondition|c1111|35',
+          '18': 'zip|20874|none'
+        },
+        props: {
+          ...DEFAULT_BASIC_PROPS,
+          '15': 't:a:loc:z',
+          '17': 'typecondition|c1111|35',
+          '18': 'zip|20874|none'          
+        },
+      }
+    }]
+  ],
+  [ "adv - no params",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-all',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: DEFAULT_ADV_EVARS,
+        props: DEFAULT_ADV_PROPS,
+      }
+    }]
+  ],
+  // "Location" -- VA Only
+  [ "adv - location - vaOnly",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-all',
+        vaOnly: true,
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:va',
+          '18': 'all|va-only',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:va',
+          '18': 'all|va-only',
+        },
+      }
+    }]
+  ],
+  // Location -- Zip Code
+  [ "adv - zip location",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-zip',
+        zip: '20852',
+        zipRadius: '100',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:z:zp',
+          '18': 'zip|20852|100',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:z:zp',
+          '18': 'zip|20852|100',
+        },
+      }
+    }]
+  ],
+  [ "adv - zip location + va",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-zip',
+        zip: '20852',
+        zipRadius: '100',
+        vaOnly: true,
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:va:z:zp',
+          '18': 'zip|20852|100|va-only',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:va:z:zp',
+          '18': 'zip|20852|100|va-only',
+        },
+      }
+    }]
+  ],
+  // Location -- NIH
+  [ "adv - location nih",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-nih',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc',
+          '18': 'at nih',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc',
+          '18': 'at nih',
+        },
+      }
+    }]
+  ],
+  // Location -- CSC
+  [ "adv - location CSC - Country",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-country',
+        country: 'United States',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:lcnty',
+          '18': 'csc|united states|none|none',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:lcnty',
+          '18': 'csc|united states|none|none',
+        },
+      }
+    }]
+  ],
+  [ "adv - location CSC - Country, City",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-country',
+        country: 'United States',
+        city: 'Baltimore',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:lcnty:lcty',
+          '18': 'csc|united states|none|baltimore',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:lcnty:lcty',
+          '18': 'csc|united states|none|baltimore',
+        },
+      }
+    }]
+  ],
+  [ "adv - location CSC - Country, State",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-country',
+        country: 'United States',
+        states: ['MD', 'VA'],
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:lcnty:lst',
+          '18': 'csc|united states|md,va|none',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:lcnty:lst',
+          '18': 'csc|united states|md,va|none',
+        },
+      }
+    }]
+  ],
+  [ "adv - location CSC - Country, State, City",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-country',
+        country: 'United States',
+        states: ['MD', 'VA'],
+        city: 'Baltimore',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:lcnty:lst:lcty',
+          '18': 'csc|united states|md,va|baltimore',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:lcnty:lst:lcty',
+          '18': 'csc|united states|md,va|baltimore',
+        },
+      }
+    }]
+  ],
+  [ "adv - location CSC - Country, State, City - VA",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        location: 'search-location-country',
+        country: 'United States',
+        states: ['MD', 'VA'],
+        city: 'Baltimore',
+        vaOnly: true,
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 'loc:va:lcnty:lst:lcty',
+          '18': 'csc|united states|md,va|baltimore|va-only',
+        },
+        props: {
+          ...DEFAULT_ADV_PROPS,
+          '15': 'loc:va:lcnty:lst:lcty',
+          '18': 'csc|united states|md,va|baltimore|va-only',
+        },
+      }
+    }]
+  ],
+
+
+  //https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?t=C3167&st=C8644%7CC9143%7CC9140&stg=C7883%7CC7784&fin=C3586&a=35&q=cancer&va=1&loc=0&hv=1&tt=treatment&tt=supportive_care&d=C1647&i=C65008&tp=I&tp=II&tid=nci&in=smith&lo=mayo&rl=2
+  [ "adv - minimum all non-location fields used",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        cancerType: ['c3167'],
+        subtypes: [['c8644','c9140','c9143']],
+        stages: [['c7784','c7883']],
+        findings: [['c3586']],
+        age: 35,
+        keywordPhrases: 'Cancer',
+        vaOnly: true,        
+        trialTypes: ['treatment', 'supportive_care'],
+        drugs: [['C1647']],
+        treatments: [['c65008']],
+        healthyVolunteers: true,
+        trialPhases: ['i', 'ii'],
+        trialId: 'NCI',
+        investigator: 'Smith',
+        leadOrg: 'Mayo',
+        location: 'search-location-all',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 't:st:stg:fin:a:q:loc:va:tt:d:i:hv:tp:tid:in:lo',
+          '17': 'c3167|c8644,c9140,c9143|c7784,c7883|c3586|35|cancer',
+          '18': 'all|va-only',
+          '19': 'tre,sup|c1647|c65008|hv',
+          '20': 'i,ii|single:nci|smith|mayo'
+        },
+        props: {          
+          ...DEFAULT_ADV_PROPS,
+          '15': 't:st:stg:fin:a:q:loc:va:tt:d:i:hv:tp:tid:in:lo',
+          '17': 'c3167|c8644,c9140,c9143|c7784,c7883|c3586|35|cancer',
+          '18': 'all|va-only',
+          '19': 'tre,sup|c1647|c65008|hv',
+          '20': 'i,ii|single:nci|smith|mayo'
+        },
+      }
+    }]
+  ],
+  //https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?t=C4872&st=C40367&st=C162648&st=C66719&st=C161830&st=C53558&st=C8287&st=C5214&st=C4017&st=C2924&st=C2918&st=C53556&st=C9245&stg=C139556%7CC139535%7CC88375&stg=C7768%7CC139538%7CC139569&stg=C139582%7CC139541%7CC88376%7CC7769&stg=C139542%7CC139583%7CC7770&stg=C139584%7CC139543%7CC7782&stg=C139545%7CC139587%7CC3995&fin=C150629&fin=C150630&fin=C68749&fin=C68748&fin=C118311&fin=C162184&fin=C162183&a=&q=&loc=0&tt=treatment&tt=supportive_care&tt=diagnostic&tt=basic_science&tt=prevention&tt=health_services_research&tt=screening&d=C855&d=C2039&d=C308%7CC15262&d=C1687&d=C307&d=C143250&i=C15722&i=C15329&i=C94626&i=C15751&i=C15358&i=C15313&tp=I&tp=II&tp=III&tp=IV&tid=nci%2Cnct%2Ccct%2Cdcp%2Cswog%2Cctep&in=&lo=&rl=2
+  [ "adv - Overload a bunch of fields",
+    {
+      formType: 'advanced',
+      numResults: 3000,
+      formData: {
+        cancerType: ['c4872'],
+        subtypes: [['c1111'],['c2222'],['c3333'],['c4444'], ['c5555']],
+        stages: [['c1111'],['c2222'],['c3333'],['c4444'], ['c5555']],
+        findings: [['c1111'],['c2222'],['c3333'],['c4444'], ['c5555']],
+        trialTypes: [
+          'treatment', 'prevention', 'supportive_care', 'health_services_research',
+          'diagnostic', 'screening', 'basic_science', 'other'
+        ],
+        drugs: [['c1111'],['c2222'],['c3333'],['c4444'], ['c5555']],
+        treatments: [['c1111'],['c2222'],['c3333'],['c4444'], ['c5555']],
+        trialPhases: ['i', 'ii', 'iii', 'iv'],
+        trialId: 'nci,nct,cct,dcp,swog,ctep',
+        location: 'search-location-all',
+        formType: 'advanced'
+      }
+    },
+    [{
+      type: "LOAD",
+      data: {
+        events: [2],
+        eVars: {
+          ...DEFAULT_ADV_EVARS,
+          '15': 't:st:stg:fin:tt:d:i:tp:tid',
+          '17': 'c4872|more than 5|more than 5|more than 5|none|none',
+          '18': 'all',
+          '19': 'tre,sup,dia,bas,pre,hea,scr,oth|more than 5|more than 5',
+          '20': 'i,ii,iii,iv|multiple:nci,nct,cct,dcp,swog,ctep|none|none'
+        },
+        props: {          
+          ...DEFAULT_ADV_PROPS,
+          '15': 't:st:stg:fin:tt:d:i:tp:tid',
+          '17': 'c4872|more than 5|more than 5|more than 5|none|none',
+          '18': 'all',
+          '19': 'tre,sup,dia,bas,pre,hea,scr,oth|more than 5|more than 5',
+          '20': 'i,ii,iii,iv|multiple:nci,nct,cct,dcp,swog,ctep|none|none'
+        },
+      }
+    }]
+  ]
+
+];
+
+describe("ResultsAnalyticsActions - load_results", () => {
+  test.each(TEST_CASES)(
+    "%# - %s",
+    (scenario, eventdata, expected) => {
+      const actual = ResultsAnalyticsActions['load_results'](eventdata);
+      expect(actual).toEqual(expected);
+    }
+  );
+})

--- a/src/utilities/cgdp-analytics/__tests__/cts-search-page-analytics.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-search-page-analytics.js
@@ -1,0 +1,349 @@
+import { SearchAnalyticsActions} from '../cts-search-page-analytics';
+
+const TEST_CASES = [
+  // PAGE LOAD
+  [ "load_basic_search",
+    "works",
+    {},
+    [
+      {
+        type: 'LOAD',
+        data: {
+          eVars: { '62': "Clinical Trials: Basic" },
+          props: { '62': "Clinical Trials: Basic" }
+        }
+      },
+      {
+        type: "LINK",
+        data: {
+          events: [37],
+          eVars: { '47': 'clinicaltrials_basic' },
+          props: { '74': 'clinicaltrials_basic|display'}
+        }
+      }
+    ]
+  ],
+  [ "load_advanced_search",
+    "works",
+    {},
+    [
+      {
+        type: 'LOAD',
+        data: {
+          eVars: { '62': "Clinical Trials: Advanced" },
+          props: { '62': "Clinical Trials: Advanced" }
+        }
+      },
+      {
+        type: "LINK",
+        data: {
+          events: [37],
+          eVars: { '47': 'clinicaltrials_advanced' },
+          props: { '74': 'clinicaltrials_advanced|display'}
+        }
+      }
+    ]
+  ],
+  // Start Event
+  [ "link_form_start",
+    "basic works",
+    {
+      formType: 'basic'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_basic|start',
+        events: [38],
+        eVars: { '47': `clinicaltrials_basic` },
+        props: { '74': `clinicaltrials_basic|start`}
+      }
+    }]
+  ],
+  [ "link_form_start",
+    "adv works",
+    {
+      formType: 'advanced'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_advanced|start',
+        events: [38],
+        eVars: { '47': `clinicaltrials_advanced` },
+        props: { '74': `clinicaltrials_advanced|start`}
+      }
+    }]
+  ],
+  // Validation Error
+  //
+  [ "link_form_validation_error",
+    "basic age",
+    {
+      formType: 'basic',
+      field: 'age',
+      message: 'Please enter a number between 1 and 120.'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_basic|error',
+        events: [41],
+        eVars: {
+          '47': `clinicaltrials_basic`
+        },
+        props: {
+          '74': `clinicaltrials_basic|error`,
+          '75': 'a|Please enter a number between 1 and 120.'
+        }
+      }
+    }]
+  ],
+  [ "link_form_validation_error",
+    "adv age",
+    {
+      formType: 'advanced',
+      field: 'age',
+      message: 'Please enter a number between 1 and 120.'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_advanced|error',
+        events: [41],
+        eVars: {
+          '47': `clinicaltrials_advanced`
+        },
+        props: {
+          '74': `clinicaltrials_advanced|error`,
+          '75': 'a|Please enter a number between 1 and 120.'
+        }
+      }
+    }]
+  ],
+  [ "link_form_validation_error",
+    "adv zip",
+    {
+      formType: 'advanced',
+      field: 'zip',
+      message: 'Please enter a valid 5 digit ZIP code.'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_advanced|error',
+        events: [41],
+        eVars: {
+          '47': `clinicaltrials_advanced`
+        },
+        props: {
+          '74': `clinicaltrials_advanced|error`,
+          '75': 'z|Please enter a valid 5 digit ZIP code.'
+        }
+      }
+    }]
+  ],
+  [ "link_form_validation_error",
+    "adv hospital",
+    {
+      formType: 'advanced',
+      field: 'hospital',
+      message: 'Please select a Hospital/Institution.'
+    },
+    [{
+      type: "LINK",
+      data: {
+        linkname: 'formAnalysis|clinicaltrials_advanced|error',
+        events: [41],
+        eVars: {
+          '47': `clinicaltrials_advanced`
+        },
+        props: {
+          '74': `clinicaltrials_advanced|error`,
+          '75': 'hos|Please select a Hospital/Institution.'
+        }
+      }
+    }]
+  ],
+  // Completion event
+  [ "link_form_submission_complete",
+    "basic works",
+    {
+      formType: 'basic',
+      wasScrolling: false
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_basic|complete',
+          events: [39],
+          eVars: { '47': `clinicaltrials_basic` },
+          props: { '74': `clinicaltrials_basic|complete`}
+        }
+      }
+    ]
+  ],  
+  [ "link_form_submission_complete",
+    "adv works",
+    {
+      formType: 'advanced',
+      wasScrolling: false
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_advanced|complete',
+          events: [39],
+          eVars: { '47': `clinicaltrials_advanced` },
+          props: { '74': `clinicaltrials_advanced|complete`}
+        }
+      }
+    ]
+  ],  
+  [ "link_form_submission_complete",
+    "basic works when floating button",
+    {
+      formType: 'basic',
+      wasScrolling: true
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_basic|complete',
+          events: [39],
+          eVars: { '47': `clinicaltrials_basic` },
+          props: { '74': `clinicaltrials_basic|complete_scrolling`}
+        }
+      }
+    ]
+  ],  
+  [ "link_form_submission_complete",
+    "adv works",
+    {
+      formType: 'advanced',
+      wasScrolling: true
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_advanced|complete',
+          events: [39],
+          eVars: { '47': `clinicaltrials_advanced` },
+          props: { '74': `clinicaltrials_advanced|complete_scrolling`}
+        }
+      }
+    ]
+  ],
+  // Submit with error
+  [ "link_form_submission_error",
+    "basic works",
+    {
+      formType: 'basic'
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_basic|error',
+          events: [41],
+          eVars: { '47': `clinicaltrials_basic` },
+          props: { 
+            '74': `clinicaltrials_basic|error`,
+            '75': 'submit|attempted form submit with errors'
+          }
+        }
+      }
+    ]
+  ],
+  [ "link_form_submission_error",
+    "adv works",
+    {
+      formType: 'advanced'
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_advanced|error',
+          events: [41],
+          eVars: { '47': `clinicaltrials_advanced` },
+          props: { 
+            '74': `clinicaltrials_advanced|error`,
+            '75': 'submit|attempted form submit with errors'
+          }
+        }
+      }
+    ]
+  ],
+  // Abandoned
+  [ "link_form_abandon",
+    "basic works",
+    {
+      formType: 'basic',
+      field: 'age',
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_basic|abandon',
+          events: [40],
+          eVars: { '47': `clinicaltrials_basic` },
+          props: { '74': `clinicaltrials_basic|abandon|a`}
+        }
+      }
+    ]
+  ],  
+  [ "link_form_abandon",
+    "adv works",
+    {
+      formType: 'advanced',
+      field: 'age',
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'formAnalysis|clinicaltrials_advanced|abandon',
+          events: [40],
+          eVars: { '47': `clinicaltrials_advanced` },
+          props: { '74': `clinicaltrials_advanced|abandon|a`}
+        }
+      }
+    ]
+  ],  
+  // Clear Form
+  [ "link_clear_form_link",
+    "adv works",
+    {
+      formType: 'advanced',      
+    },
+    [
+      {
+        type: "LINK",
+        data: {
+          linkname: 'clinicaltrials_advanced|clear',
+          events: [68],
+          eVars: { '47': `clinicaltrials_advanced` },
+          props: { 
+            '74': `clinicaltrials_advanced|clear`
+          }
+        }
+      }
+    ]
+  ],  
+]
+
+describe("SearchAnalyticsActions", () => {
+  test.each(TEST_CASES)(
+    "%# - %s - %s",
+    (actionName, scenario, eventdata, expected) => {
+      const actual = SearchAnalyticsActions[actionName](eventdata);
+      expect(actual).toEqual(expected);
+    }
+  );
+})

--- a/src/utilities/cgdp-analytics/cts-analytics-common.js
+++ b/src/utilities/cgdp-analytics/cts-analytics-common.js
@@ -1,0 +1,107 @@
+
+/**
+ * The types of events that can be dispatched
+ */
+export const EVENT_TYPES = {
+  Link: 'LINK',
+  Load: 'LOAD'
+}
+
+/**
+ * Gets the prop62 and evar62 contents
+ *
+ * This outputs the strinf "Clinical Trials: {PageType}"
+ * evar62: "Clinical Trials: {PageType}"
+ *   - PageType is dependent on whether a basic search or advanced search was performed.
+ *     - On the basic form: "Basic"
+ *     - On the Results or Details pages, coming from a basic search: "Basic"
+ *     - On the advanced form: "Advanced"
+ *     - On the Results or Details pages, coming from an advanced search: "Advanced"
+ *     - On the Results or Details pages, coming from neither search (a direct link without the rl URL param): "Unknown"
+ *     - If from a redirect (redirect URL param is true): "Custom"
+ *
+ * @param {string} formType - The form type
+ */
+export const get62Contents = (formType) => {
+  switch (formType) {
+    case "basic": return 'Clinical Trials: Basic'
+    case "advanced": return 'Clinical Trials: Advanced'
+    // This should only be for links to description pages
+    // from dynamic linking.
+    case "custom": return 'Clinical Trials: Custom'
+    // This should only work right for google links going
+    // directly to the description page.
+    default: return "Clinical Trials: Direct"
+  }
+}
+
+// Analytics use lots of letters, well, mainly the query
+// params, in order to track field usage. This is the
+// lookup for app data field -> key.
+export const FIELD_TO_KEY_MAP = {
+  // We removed gender, so no longer tracking it either
+  cancerType: "t", subtypes: "st", stages: "stg", findings: "fin",
+  age: "a", keywordPhrases: "q", location: "loc", vaOnly: "va",
+  zip: "z", zipRadius: "zp", country: "lcnty", states: "lst",
+  city: "lcty", hospital: "hos", nihOnly: "nih", healthyVolunteers: "hv",
+  trialTypes: "tt", drugs: "d", treatments: "i", trialPhases: "tp",
+  trialId: "tid", investigator: "in", leadOrg: "lo",
+};
+
+// There are events that can be called across multiple pages,
+// so we are going to put those here.
+export const CommonAnalyticsActions = {};
+
+CommonAnalyticsActions.link_start_over_link = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+
+  return [{
+    type: EVENT_TYPES.Link,    
+    data: {
+      linkname: 'CTStartOverClick',
+      events: [49],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },      
+      props: {
+        '74': `${searchForm}|start over`
+      }
+    }
+  }];
+};
+
+CommonAnalyticsActions.link_modify_search_criteria_link = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+
+  return [{
+    type: EVENT_TYPES.Link,    
+    data: {
+      linkname: 'CTSModifyClick',
+      events: [49],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `${searchForm}|modify`
+      }
+    }
+  }];
+};
+
+CommonAnalyticsActions.link_try_a_new_search_link = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+
+  return [{
+    type: EVENT_TYPES.Link,    
+    data: {
+      linkname: 'CTSTryNewSearchClick',
+      events: [49],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `${searchForm}|try a new search`
+      }
+    }
+  }];
+};

--- a/src/utilities/cgdp-analytics/cts-description-page-analytics.js
+++ b/src/utilities/cgdp-analytics/cts-description-page-analytics.js
@@ -1,0 +1,26 @@
+import { get62Contents, EVENT_TYPES } from './cts-analytics-common';
+
+/**********************
+ * DO NOT COPY ABOVE THIS LINE
+ **********************/
+
+
+export const DescriptionAnalyticsActions = {};
+
+//-------------------------
+// Description page events
+//-------------------------
+
+DescriptionAnalyticsActions.load_trial_description = (data) => {
+  return [{
+    type: EVENT_TYPES.Load,
+    data: {
+      eVars: { '62': get62Contents(data.formType) },
+      // Prop44 comes from elsewhere, so not including.
+      props: {
+        '16': data.nctId,
+        '62': get62Contents(data.formType)
+      }
+    }
+  }];
+};

--- a/src/utilities/cgdp-analytics/cts-results-page-analytics.js
+++ b/src/utilities/cgdp-analytics/cts-results-page-analytics.js
@@ -1,0 +1,401 @@
+import { get62Contents, EVENT_TYPES, FIELD_TO_KEY_MAP } from './cts-analytics-common';
+
+/**********************
+ * DO NOT COPY ABOVE THIS LINE
+ **********************/
+
+
+export const ResultsAnalyticsActions = {};
+
+//------------------
+// Results events
+//------------------
+
+// Only modern browsers guarantee key order so let's be sure
+// and use an array since order will matter in results list.
+const ADV_FIELD_ORDER = [
+  "cancerType", "subtypes", "stages", "findings", "age",
+  "keywordPhrases", "location", "vaOnly", "zip", "zipRadius",
+  "country", "states", "city", "hospital", "nihOnly",
+  "trialTypes", "drugs", "treatments", "healthyVolunteers",
+  "trialPhases", "trialId", "investigator", "leadOrg"
+]
+
+const BASIC_FIELD_ORDER = [
+  "cancerType", "age", "keywordPhrases", "location", "zip"
+]
+
+
+// This maps the location search type to the shortend tracking
+// key.
+const LOCATION_TRACK_KEYS = {
+  'search-location-all': 'all', 'search-location-zip': 'zip',
+  'search-location-hospital': 'hi', 'search-location-nih': 'At NIH',
+  'search-location-country': 'csc'
+}
+
+const TRIAL_TYPE_MAP = {
+  'treatment': "tre",
+  'prevention': "pre",
+  'supportive_care': "sup",
+  'health_services_research': "hea",
+  'diagnostic': "dia",
+  'screening': "scr",
+  'basic_science': "bas",
+  'other': "oth"
+}
+
+const TRIAL_TYPE_ORDER = [
+  'treatment', 'supportive_care', 'diagnostic', 'basic_science',
+  'prevention', 'health_services_research', 'screening', 'other'
+];
+
+/**
+ * Gets the string for a multicode field like
+ * stage, or drug.
+ * @param {*} fieldName 
+ * @param {*} formData 
+ */
+const getMultiCodeField = (fieldName, formData, unsetTxt = 'all') => {
+  return formData[fieldName] ?
+    (
+      formData[fieldName].length >= 5 ?
+      'more than 5' :
+      // Note these fields are multidimensional arrays of C-Codes
+      formData[fieldName].reduce((ac,codesArr) =>{
+          return [
+            ...ac,
+            ...codesArr
+          ];
+        },[])
+        .map(id => id.toLowerCase()).join(',')
+    ) : unsetTxt;
+};
+
+/**
+ * Maps a list of trial types to their short codes, in order.
+ * @param {*} trialTypes 
+ */
+const mapTrialTypeCodes = (trialTypes) => {
+  if (!trialTypes || trialTypes.length === 0) {
+    return 'all';
+  }
+
+  return TRIAL_TYPE_ORDER.reduce( (ac, type) => {
+    if (trialTypes.includes(type)) {
+      return [
+        ...ac,
+        TRIAL_TYPE_MAP[type]
+      ]
+    }
+    return ac;
+  },[]).join(',');
+};
+
+/**
+ * This is for prop18
+ * @param {*} data 
+ */
+const locationSearchParams = (data) => {
+  const formData = data.formData ? data.formData : {};
+
+  switch(formData['location']) {
+    case 'search-location-zip' : {
+      if (data.formType === 'basic') {
+        return `zip|${formData['zip']}|none`
+      } else {
+        const zipStr = `zip|${formData['zip']}|${formData['zipRadius']}`;
+        return (formData['vaOnly']) ? zipStr + '|va-only' : zipStr;
+      }
+    }
+    case 'search-location-country' : {      
+      // Country should never not exist, but just in case we don't want
+      // errors breaking the app.
+      const country = formData['country'] ? formData['country'].toLowerCase() : 'none';
+      const states = formData['states'] ? formData['states'].map(st => st.toLowerCase()).join(',') : 'none';
+      const city = formData['city'] ? formData['city'].toLowerCase() : 'none';
+
+      if (formData['vaOnly']) {
+        return `csc|${country}|${states}|${city}|va-only`;
+      } else {
+        return `csc|${country}|${states}|${city}`;
+      }
+    }
+    case 'search-location-hospital' : {
+      return `hi|${formData['hospital']}`;
+    }
+    case 'search-location-nih' : {
+      return 'at nih';
+    }
+    case 'search-location-all' : 
+    default: {
+      if (data.formType === 'basic' || !formData['vaOnly']) {
+        return 'all';
+      } else {
+        return 'all|va-only'
+      }  
+    }
+
+  }
+
+}
+
+/**
+ * Handles parsing of search params for advanced form.
+ * (This is complicated enough that if basic/adv then, blah
+ * checks were making it unreadable)
+ * @param {*} data 
+ */
+const searchParamsAdvanced = (data) => {
+  const formData = data.formData ? data.formData : {};
+
+  /******
+   * PROP 15: Field Usage (Basic differs from Advanced)
+   ******/
+  const searchParamKeys = ADV_FIELD_ORDER
+    .reduce((ac, fieldName) => {
+      if (formData[fieldName] && fieldName !== 'location') {
+        ac = [
+          ...ac,
+          FIELD_TO_KEY_MAP[fieldName]
+        ]
+      } else if (fieldName === 'location' && 
+        (
+          formData['location'] !== 'search-location-all' ||
+          formData['vaOnly']
+        )
+      ) {
+          ac = [
+            ...ac,
+            FIELD_TO_KEY_MAP['location']
+          ]
+      }
+      return ac;
+    }, [])
+    .join(':');
+
+  /******
+   * Prop 17: Basic Form Data
+   ******/
+  const ct = formData['cancerType'] ?
+    formData['cancerType'].map(code => code.toLowerCase()).join(',') :
+    'all';
+  const st = getMultiCodeField('subtypes', formData);
+  const stg = getMultiCodeField('stages', formData);
+  const fin = getMultiCodeField('findings', formData);
+  const age = formData['age'] ? formData['age']: 'none';
+  const kw = formData['keywordPhrases'] ? formData['keywordPhrases'].toLowerCase() : 'none';
+
+  const prop17 = `${ct}|${st}|${stg}|${fin}|${age}|${kw}`;
+
+  /******
+   * Prop 19: Other fields pt 1
+   ******/
+
+  const tt = mapTrialTypeCodes(formData['trialTypes']);
+  const drug = getMultiCodeField('drugs', formData, 'none');
+  const treat = getMultiCodeField('treatments', formData, 'none');
+  //all|none|none'
+  //all|none|none|hv'
+  const prop19 = formData['healthyVolunteers'] ?
+    `${tt}|${drug}|${treat}|hv` :
+    `${tt}|${drug}|${treat}`;
+  
+  /******
+   * Prop 20: Other fields pt 2
+   ******/
+  
+  //'all|none|none|none',   
+  const tp = formData['trialPhases'] ? formData['trialPhases'].join(',') : 'all';
+  const tid = formData['trialId'] ?
+    (
+      formData['trialId'].includes(',') ?
+        `multiple:${formData['trialId'].toLowerCase()}` :
+        `single:${formData['trialId'].toLowerCase()}`
+    ) : 'none';
+  const inv = formData['investigator'] ? formData['investigator'].toLowerCase() : 'none';
+  const lo = formData['leadOrg'] ? formData['leadOrg'].toLowerCase() : 'none';
+  const prop20 = `${tp}|${tid}|${inv}|${lo}`;
+
+  return {
+    eVars: {
+      '15': (searchParamKeys !== '') ? searchParamKeys : 'none',
+      '17': prop17,
+      '18': locationSearchParams(data),
+      '19': prop19,
+      '20': prop20,
+    },
+    props: {
+      '15': (searchParamKeys !== '') ? searchParamKeys : 'none',
+      '17': prop17,
+      '18': locationSearchParams(data),
+      '19': prop19,
+      '20': prop20,
+    },
+  }
+  
+}
+
+/**
+ * Handles parsing of search params for basic form.
+ * (This is complicated enough that if basic then, blah
+ * checks were making it unreadable)
+ * @param {*} data 
+ */
+const searchParamsBasic = (data) => {
+  const formData = data.formData ? data.formData : {};
+
+  /******
+   * PROP 15: Field Usage (Basic differs from Advanced)
+   ******/
+  const searchParamKeys = BASIC_FIELD_ORDER
+    .reduce((ac, fieldName) => {
+      if (formData[fieldName] && fieldName !== 'location') {
+        ac = [
+          ...ac,
+          FIELD_TO_KEY_MAP[fieldName]
+        ]
+      } else if (fieldName === 'location' && formData['location'] === 'search-location-zip') {
+          ac = [
+            ...ac,
+            FIELD_TO_KEY_MAP['location']
+          ]
+      }
+      return ac;
+    }, [])
+    .join(':');
+
+  /******
+   * Prop 17: Basic Form Data
+   ******/
+  const prop17Main = formData['cancerType'] ?
+    'typecondition|' + formData['cancerType'].map(code => code.toLowerCase()).join(',') : 
+    (
+      formData['keywordPhrases'] ?
+      'keyword|' + formData['keywordPhrases'].toLowerCase() :
+      'none'
+    );
+  const prop17Age = formData['age'] ?
+      formData['age'] :
+      'none';
+
+  /******
+   * Prop 18: Location
+   ******/
+  
+
+  return {
+    eVars: {
+      '15': (searchParamKeys !== '') ? searchParamKeys : 'none',
+      '17': prop17Main + '|' + prop17Age,
+      '18': locationSearchParams(data)
+    },
+    props: {
+      '15': (searchParamKeys !== '') ? searchParamKeys : 'none',
+      '17': prop17Main + '|' + prop17Age,
+      '18': locationSearchParams(data)
+    },
+  }
+
+}
+
+
+ResultsAnalyticsActions.load_results = (data) => {
+
+  const searchFormParams = data.formType === 'advanced' ?
+    searchParamsAdvanced(data) :
+    searchParamsBasic(data);
+
+  const trackData = {
+    events: [ 2 ],
+    eVars: {
+      ...searchFormParams.eVars,
+      '10': data.numResults,
+      '11': `clinicaltrials_${data.formType}`,
+      '62': get62Contents(data.formType)
+    },
+    // Prop44 comes from elsewhere, so not including.
+    props: {
+      ...searchFormParams.eVars,
+      '11': `clinicaltrials_${data.formType}`,
+      '62': get62Contents(data.formType),
+    }
+  };
+
+  return [{
+    type: EVENT_TYPES.Load,
+    data: trackData
+  }];
+};
+
+// Clicking on a result in the results pages.
+ResultsAnalyticsActions.link_results_page_link = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+  const rank = `${data.resultsPosition}|page ${data.pageNum}`;
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      events: [42],
+      props: {
+        '12': searchForm,
+        '13': rank
+      },
+      eVars: {
+        '12': searchForm
+      }
+    }
+  }];
+};
+
+ResultsAnalyticsActions.link_print_selected_button = (data) => {
+  const location = data.buttonPos;
+  const selectAllText = data.selectAll ? "selectall" : "noselectall";
+  const totalChecked = data.selectedCount;
+  const checkedPages = data.pagesWithSelected ? data.pagesWithSelected.join(',') : '';
+  const searchForm = `clinicaltrials_${data.formType}`;
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: 'CTSResultsPrintSelectedClick',
+      events: [48],
+      props: {
+        '21': `CTSPrintSelected_${location}_${selectAllText}_${totalChecked}_${checkedPages}`,
+        '74': `${searchForm}|print selected`
+      }
+    }
+  }];
+};
+
+ResultsAnalyticsActions.link_print_selected_none_selected_button = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: 'CTSResultsSelectedErrorClick',
+      events: [41],
+      props: {
+        '74': `${searchForm}|error`,
+        '75': 'printselected|noneselected',
+      }
+    }
+  }];
+};
+
+ResultsAnalyticsActions.link_print_selected_max_reached_button = (data) => {
+  const searchForm = `clinicaltrials_${data.formType}`;
+ 
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: 'CTSResultsSelectedErrorClick',
+      events: [41],
+      props: {
+        '74': `${searchForm}|error`,
+        '75': 'printselected|maxselectionreached',
+      }
+    }
+  }];
+}

--- a/src/utilities/cgdp-analytics/cts-search-page-analytics.js
+++ b/src/utilities/cgdp-analytics/cts-search-page-analytics.js
@@ -1,0 +1,174 @@
+import { get62Contents, EVENT_TYPES, FIELD_TO_KEY_MAP } from './cts-analytics-common';
+
+/**********************
+ * DO NOT COPY ABOVE THIS LINE
+ **********************/
+
+export const SearchAnalyticsActions = {};
+
+//--------------------
+// Search Forms
+//--------------------
+SearchAnalyticsActions.load_basic_search = (data) => {
+
+  return [
+    {
+      type: EVENT_TYPES.Load,
+      data: {
+        eVars: { '62': get62Contents('basic') },
+        // Prop44 comes from elsewhere, so not including.
+        props: { '62': get62Contents('basic') }
+      }
+    },
+    // Because of legacy reasons, there is a link
+    // track on page load as well.
+    {
+      type: EVENT_TYPES.Link,
+      data: {
+        events: [37],
+        eVars: { '47': 'clinicaltrials_basic' },
+        // Prop67 seems to come for free, so not including
+        props: { '74': 'clinicaltrials_basic|display'}
+      }
+    }
+  ]
+};
+
+SearchAnalyticsActions.load_advanced_search = (data) => {
+  return [
+    {
+      type: EVENT_TYPES.Load,
+      data: {
+        eVars: { '62': get62Contents('advanced') },
+        // Prop44 comes from elsewhere, so not including.
+        props: { '62': get62Contents('advanced')}
+      }
+    },
+    // Because of legacy reasons, there is a link
+    // track on page load as well.
+    {
+      type: EVENT_TYPES.Link,
+      data: {
+        events: [37],
+        eVars: { '47': 'clinicaltrials_advanced' },
+        // Prop67 seems to come for free, so not including
+        props: { '74': 'clinicaltrials_advanced|display'}
+      }
+    }
+  ];
+};
+
+SearchAnalyticsActions.link_form_start = (data) => {
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `formAnalysis|clinicaltrials_${data.formType}|start`,
+      events: [38],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `clinicaltrials_${data.formType}|start`,
+      }
+    }
+  }];
+
+};
+
+SearchAnalyticsActions.link_clear_form_link = (data) => {
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `clinicaltrials_advanced|clear`,
+      events: [68],
+      eVars: { '47': `clinicaltrials_${data.formType}` },
+      props: { '74': `clinicaltrials_${data.formType}|clear`}
+    }
+  }];
+};
+
+SearchAnalyticsActions.link_form_submission_complete = (data) => {
+
+  // TODO: logic for event46 did we do the Levenshtein distance thing for
+  // a basic form's keyword
+
+  const completion = data['wasScrolling'] ? 'complete_scrolling' : 'complete';
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `formAnalysis|clinicaltrials_${data.formType}|complete`,
+      events: [39],
+      eVars: { '47': `clinicaltrials_${data.formType}` },
+      props: { '74': `clinicaltrials_${data.formType}|${completion}`}
+    }
+  }];
+};
+
+SearchAnalyticsActions.link_form_submission_error = (data) => {
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `formAnalysis|clinicaltrials_${data.formType}|error`,
+      events: [41],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `clinicaltrials_${data.formType}|error`,
+        '75': 'submit|attempted form submit with errors'
+      }
+    }
+  }];
+
+};
+
+
+SearchAnalyticsActions.link_form_validation_error = (data) => {
+
+  const fieldName = FIELD_TO_KEY_MAP[data.field] ?
+    FIELD_TO_KEY_MAP[data.field] :
+    data.field;
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `formAnalysis|clinicaltrials_${data.formType}|error`,
+      events: [41],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `clinicaltrials_${data.formType}|error`,
+        '75': `${fieldName}|${data.message}`
+      }
+    }
+  }];
+
+};
+
+SearchAnalyticsActions.link_form_abandon = (data) => {
+
+  const fieldName = FIELD_TO_KEY_MAP[data.field] ?
+    FIELD_TO_KEY_MAP[data.field] :
+    data.field;
+
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      linkname: `formAnalysis|clinicaltrials_${data.formType}|abandon`,
+      events: [40],
+      eVars: {
+        '47': `clinicaltrials_${data.formType}`
+      },
+      props: {
+        '74': `clinicaltrials_${data.formType}|abandon|${fieldName}`
+      }
+    }
+  }];
+
+};
+

--- a/src/utilities/cgdp-analytics/index.js
+++ b/src/utilities/cgdp-analytics/index.js
@@ -1,0 +1,4 @@
+export { CommonAnalyticsActions } from './cts-analytics-common';
+export { SearchAnalyticsActions } from './cts-search-page-analytics';
+export { ResultsAnalyticsActions } from './cts-results-page-analytics';
+export { DescriptionAnalyticsActions } from './cts-description-page-analytics';

--- a/src/utilities/formToTrackingData.js
+++ b/src/utilities/formToTrackingData.js
@@ -52,9 +52,9 @@ export const formToTrackingData = formStore => {
       // Assume zip exists
       rtnObj['zip'] = formStore['zip'];
 
-      if (formStore['zipRadius'] !== '100') {
-        rtnObj["zipRadius"] = formStore["zipRadius"];
-      }
+      // Proximity is required on advanced search analytics
+      // even if using default value
+      rtnObj["zipRadius"] = formStore["zipRadius"];
       break;
     }
     case "search-location-country" : {

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -64,6 +64,7 @@ const TrialDescriptionPage = ({ location, tracking }) => {
     tracking.trackEvent({
       action: 'pageLoad',
       data: {
+        formType: formType,
         nctId: trial.nctID,
       },
     });


### PR DESCRIPTION
I added utility functions that are *almost* the same as an action. Unfortunately a couple of app events yield MULTIPLE actions for CGDP. Something for someone to fix someday.
However, the functions, with their tests also live with the code that raises the events. So this way we can import them in CGDP and not have to worry too much about keeping 2 codebases in sync. (Which I like a lot... also I smell a pattern here...)
