### PR TITLE
Added error page tracking

### DIFF
--- a/src/hooks/useAppInitializer.js
+++ b/src/hooks/useAppInitializer.js
@@ -31,8 +31,9 @@ export const useAppInitializer = (ctsapiclient, zipcodeEndpoint) => {
     // TODO: FIX THIS! BAD BAD BAD!
     const querystring = window.location.search;
   
-    // Only try and rehydrate the store if there are actual query params.
-    if (querystring.length > 0) {
+    // Only try and rehydrate the store if there are actual query params OR,
+    // this is a results page. (A results page REQUIRES query params)
+    if (window.location.pathname.endsWith('/r') || querystring.length > 0) {
       const initResults = await queryStringToFormObject(querystring, diseaseFetcher, interventionFetcher, zipFetcher);
   
       if (initResults.errors.length === 0) {

--- a/src/utilities/__tests__/buildQueryString.js
+++ b/src/utilities/__tests__/buildQueryString.js
@@ -1,4 +1,4 @@
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { buildQueryString } from '../buildQueryString';
 
 /****************

--- a/src/utilities/__tests__/defaultStateCopy.js
+++ b/src/utilities/__tests__/defaultStateCopy.js
@@ -1,0 +1,59 @@
+
+export const defaultState = {
+  age: '', // (a) Age
+  cancerType: { name: '', codes: [] }, // (ct) Cancer Type/Condition
+  subtypes: [], // (st) Subtype
+  stages: [], // (stg) Stage
+  findings: [], // (fin) Side effects
+  keywordPhrases: '', // (q) Cancer Type Keyword (ALSO Keyword Phrases)
+  zip: '', // (z) Zipcode
+  zipCoords: {lat: '', long: ''},
+  zipRadius: '100', //(zp) Radius
+  country: 'United States', // (lcnty) Country
+  states: [], // (lst) State
+  city: '', // (lcty) City
+  hospital: { term: '', termKey: '' }, // (hos) Hospital
+  healthyVolunteers: false, // (hv) Healthy Volunteers,
+  trialTypes: [
+    { label: 'Treatment', value: 'treatment', checked: false },
+    { label: 'Prevention', value: 'prevention', checked: false },
+    { label: 'Supportive Care', value: 'supportive_care', checked: false },
+    {
+      label: 'Health Services Research',
+      value: 'health_services_research',
+      checked: false,
+    },
+    { label: 'Diagnostic', value: 'diagnostic', checked: false },
+    { label: 'Screening', value: 'screening', checked: false },
+    { label: 'Basic Science', value: 'basic_science', checked: false },
+    { label: 'Other', value: 'other', checked: false },
+  ], // (tt) Trial Type
+  trialPhases: [
+    { label: 'Phase I', value: 'i', checked: false },
+    { label: 'Phase II', value: 'ii', checked: false },
+    { label: 'Phase III', value: 'iii', checked: false },
+    { label: 'Phase IV', value: 'iv', checked: false },
+  ], // (tp) Trial phase
+  nihOnly: false, // (nih) At NIH only
+  vaOnly: false, // (va) VA facilities only
+  drugs: [], // (dt) Drug/Drug family
+  treatments: [], // (ti) Treatment/Interventions
+  trialId: '', // (tid) Trial ID,
+  investigator: { term: '', termKey: '' }, // (in) Trial investigators ('in' is legacy but is a keyword and does not work well as a key name; be ready to handle both in query string)
+  leadOrg: { term: '', termKey: '' }, // (lo) Lead Organization
+  resultsPage: 0,
+  
+  formType: '', // (empty string (default) | basic | advanced)
+  isDirty: false, // only updated after submission of either form
+  zipModified: false,
+  hasInvalidZip: false, // zip does not return coodinates
+  refineSearch: false, //is the form in refine search mode
+  ageModified: false,
+  cancerTypeModified: false,
+  subtypeModified: false,
+  stagesModified: false,
+  keywordPhrasesModified: false,
+  location: 'search-location-all', // active location option (search-location-all | search-location-zip | search-location-country | search-location-hospital | search-location-nih)
+};
+
+test("placeholder", () => {expect(true).toEqual(true)});

--- a/src/utilities/__tests__/formToTrackingData.js
+++ b/src/utilities/__tests__/formToTrackingData.js
@@ -1,5 +1,5 @@
 import {formToTrackingData} from '../formToTrackingData';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 
 import {API_DISEASE_MOCKS, API_INTERVENTION_MOCKS} from './queryStringToFormObject.common';
 

--- a/src/utilities/__tests__/formatTrialSearchQuery.js
+++ b/src/utilities/__tests__/formatTrialSearchQuery.js
@@ -1,4 +1,4 @@
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { formatTrialSearchQuery } from '../formatTrialSearchQuery';
 import {
   ACTIVE_TRIAL_STATUSES,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.disease.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.disease.negative.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { getDiseaseFetcher} from './queryStringToFormObject.common';
 
 describe('Adv - Disease - Negative - queryStringToFormObject maps query to form', () => {

--- a/src/utilities/__tests__/queryStringToFormObject.adv.disease.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.disease.positive.js
@@ -1,6 +1,6 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
 import { getDiseaseFetcher, TYPE_EXPECTATION} from './queryStringToFormObject.common';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 
 
 

--- a/src/utilities/__tests__/queryStringToFormObject.adv.interventions.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.interventions.negative.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { getInterventionFetcher, INTERVENTION_EXPECTATION} from './queryStringToFormObject.common';
 
 describe('Advanced - Interventions - Negative - queryStringToFormObject maps query to form', () => {

--- a/src/utilities/__tests__/queryStringToFormObject.adv.interventions.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.interventions.positive.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { getInterventionFetcher, INTERVENTION_EXPECTATION} from './queryStringToFormObject.common';
 
 describe('Adv - Interventions - queryStringToFormObject maps query to form', () => {

--- a/src/utilities/__tests__/queryStringToFormObject.adv.loc.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.loc.positive.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 
 describe('Adv - Locations - queryStringToFormObject maps query to form', () => {
 

--- a/src/utilities/__tests__/queryStringToFormObject.adv.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.negative.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { getDiseaseFetcher} from './queryStringToFormObject.common';
 
 describe('Adv - Negative - queryStringToFormObject maps query to form', () => {

--- a/src/utilities/__tests__/queryStringToFormObject.adv.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.positive.js
@@ -1,6 +1,6 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
 import { getDiseaseFetcher, TYPE_EXPECTATION} from './queryStringToFormObject.common';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 
 // We want to test mapping the trial types, so we should not
 // really use the default state.

--- a/src/utilities/__tests__/queryStringToFormObject.basic.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.basic.negative.js
@@ -1,5 +1,5 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 import { getDiseaseFetcher} from './queryStringToFormObject.common';
 
 describe('Basic - Negative - queryStringToFormObject maps query to form', () => {

--- a/src/utilities/__tests__/queryStringToFormObject.basic.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.basic.positive.js
@@ -1,19 +1,12 @@
 import { queryStringToFormObject } from '../queryStringToFormObject';
 import { getDiseaseFetcher, TYPE_EXPECTATION} from './queryStringToFormObject.common';
-import {defaultState} from '../../store/reducers/form';
+import {defaultState} from './defaultStateCopy';
 
 
 
 describe('Basic - queryStringToFormObject maps query to form', () => {
 
   const goodMappingTestCases = [
-    [ "no query params",
-      '',
-      async () => [],
-      async () => [],
-      async () => null,
-      {}
-    ],
     [ "basic - no params",
       'rl=1',
       async () => [],

--- a/src/utilities/__tests__/queryStringToFormObject.common.js
+++ b/src/utilities/__tests__/queryStringToFormObject.common.js
@@ -1,4 +1,3 @@
-import { testNameToKey } from "jest-snapshot/build/utils";
 
 // Mocks for what the API /disease endpoint will return
 export const API_DISEASE_MOCKS = {

--- a/src/utilities/__tests__/queryStringToFormObject.other.js
+++ b/src/utilities/__tests__/queryStringToFormObject.other.js
@@ -1,0 +1,100 @@
+import { queryStringToFormObject } from '../queryStringToFormObject';
+import { getDiseaseFetcher, TYPE_EXPECTATION} from './queryStringToFormObject.common';
+import {defaultState} from './defaultStateCopy';
+
+
+
+describe('Basic - queryStringToFormObject maps query to form', () => {
+
+  const diseaseFetcher = async () => [];
+  const interventionsFetcher = async () => [];
+  const zipcodeFetcher = async () => null;
+
+  test("No Query works for details", () => {
+
+    const expected = {
+      formState: defaultState,
+      errors: []
+    }
+
+    return queryStringToFormObject(
+      '',
+      diseaseFetcher,
+      interventionsFetcher,
+      zipcodeFetcher,
+    ).then(actual => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  test("R=1 param works for details", () => {
+    jsdom.reconfigure({
+      url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI1234&r=1',
+    });
+
+    const expected = {
+      formState: {
+        ...defaultState,
+        formType: 'custom'
+      },
+      errors: []
+    }
+
+    return queryStringToFormObject(
+      'r=1',
+      diseaseFetcher,
+      interventionsFetcher,
+      zipcodeFetcher,
+    ).then(actual => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  test("R=1 param fails for results", () => {
+    jsdom.reconfigure({
+      url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?r=1',
+    });
+
+    const expected = {
+      formState: null,
+      errors: [{
+        fieldName: 'formType',
+        message: 'Results Link Flag cannot be empty on results page.'
+      }]
+    }
+
+    return queryStringToFormObject(
+      'r=1',
+      diseaseFetcher,
+      interventionsFetcher,
+      zipcodeFetcher,
+    ).then(actual => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  test("No rl fails for results", () => {
+    jsdom.reconfigure({
+      url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r',
+    });
+
+    const expected = {
+      formState: null,
+      errors: [{
+        fieldName: 'formType',
+        message: 'Results Link Flag cannot be empty on results page.'
+      }]
+    }
+
+    return queryStringToFormObject(
+      '',
+      diseaseFetcher,
+      interventionsFetcher,
+      zipcodeFetcher,
+    ).then(actual => {
+      expect(actual).toEqual(expected);
+    });
+
+  });
+
+});

--- a/src/utilities/cgdp-analytics/__tests__/cts-analytics-common.js
+++ b/src/utilities/cgdp-analytics/__tests__/cts-analytics-common.js
@@ -1,6 +1,26 @@
-import {CommonAnalyticsActions} from '../cts-analytics-common';
+import {CommonAnalyticsActions, get62Contents} from '../cts-analytics-common';
 
 const TEST_CASES = [
+  // Error page load
+  [ "load_error_page",
+    "Error page",
+    {},
+    [{
+      type: "LINK",
+      data: {        
+        events: [41],
+        eVars: { 
+          '47': `clinicaltrials_direct`,
+          '62': 'Clinical Trials: Direct'
+        },
+        props: {
+          '74': `clinicaltrials_direct|error`,
+          '75': `apperror|invalidparams`,
+          '62': 'Clinical Trials: Direct'
+        }
+      }
+    }]
+  ],
   // Start Over
   [ "link_start_over_link",
     "basic works",

--- a/src/utilities/cgdp-analytics/cts-analytics-common.js
+++ b/src/utilities/cgdp-analytics/cts-analytics-common.js
@@ -52,6 +52,24 @@ export const FIELD_TO_KEY_MAP = {
 // so we are going to put those here.
 export const CommonAnalyticsActions = {};
 
+CommonAnalyticsActions.load_error_page = (data) => {
+  return [{
+    type: EVENT_TYPES.Link,
+    data: {
+      events: [41],
+      eVars: { 
+        '47': `clinicaltrials_direct`,
+        '62': get62Contents('')
+      },
+      props: {
+        '74': `clinicaltrials_direct|error`,
+        '75': `apperror|invalidparams`,
+        '62': get62Contents('')
+      }
+    }
+  }];
+}
+
 CommonAnalyticsActions.link_start_over_link = (data) => {
   const searchForm = `clinicaltrials_${data.formType}`;
 

--- a/src/utilities/queryStringToFormObject.js
+++ b/src/utilities/queryStringToFormObject.js
@@ -79,8 +79,32 @@ export const queryStringToFormObject = async (urlQuery, diseaseFetcher, interven
         }]
       };
     }
+  }
+  // Details page can take in a r=1 param
+  else if (window.location.pathname.endsWith('/v') && query['r']) {
+    return {
+      formState: {
+        ...rtnFormState,
+        formType: "custom"
+      },
+      errors: rtnErrorsList
+    };
+  }
+  // Results URL requires rl
+  else if (window.location.pathname.endsWith('/r')) {
+    // HARD STOP. BAIL. DO NOT PASS GO.
+    return {
+      formState: null,
+      errors: [{ 
+        fieldName: "formType",
+        message: "Results Link Flag cannot be empty on results page."
+      }]
+    };
   } else {
-    // No rl, was not from a search, exit.
+    // No rl, and this is not the results page, so we
+    // don't need to keep processing params. So for the
+    // details page we would assume this is just a direct
+    // request.
     return {
       formState: rtnFormState,
       errors: rtnErrorsList

--- a/src/views/ErrorPage/ErrorPage.jsx
+++ b/src/views/ErrorPage/ErrorPage.jsx
@@ -4,6 +4,8 @@ import { updateGlobal } from '../../store/actions';
 import { Helmet } from 'react-helmet';
 import { ChatOpener, Delighter } from '../../components/atomic';
 import track from 'react-tracking';
+import { trackedEvents } from '../../tracking';
+import { TRY_NEW_SEARCH_LINK } from '../../constants';
 
 import './ErrorPage.scss';
 
@@ -11,7 +13,15 @@ const ErrorPage = ({ initErrorsList, tracking }) => {
   const dispatch = useDispatch();
   const formSnapshot = useSelector(store => store.form);
 
+  // Fire off page load event
+  tracking.trackEvent({action: 'pageLoad'})
+
   const handleStartOver = () => {
+    const { NewSearchLinkClick } = trackedEvents;    
+    NewSearchLinkClick.data.formType = '';
+    NewSearchLinkClick.source = TRY_NEW_SEARCH_LINK;
+    tracking.trackEvent(NewSearchLinkClick);
+
     dispatch(updateGlobal({
       field: 'initErrorsList',
       value: []
@@ -97,7 +107,7 @@ const ErrorPage = ({ initErrorsList, tracking }) => {
       <article className="error-page">
         <h1>Clinical Trials Search</h1>
 
-        <div class="error-page__content">
+        <div className="error-page__content">
           <div className="error-page__control --top">
             <div className="error-page__list">
               <div className="error-list">


### PR DESCRIPTION
- Added load events for page tracking with tests
- Updated a few places to force the error page if URL is bad. (Results
   missing rl param for example)
- Added r=1 param for description for custom tracking.
- Updated tests to reflect new requirements
- Changed tests to use a copy of the form default state so when
  someone changes the actual default state we know what breaks. :)
  (Since we are just being lazy and not trying to copy it over and
  over again into every test.)