### PR TITLE
Disabled tracking for checkboxes on Results page

### DIFF
--- a/src/components/atomic/Checkbox/Checkbox.jsx
+++ b/src/components/atomic/Checkbox/Checkbox.jsx
@@ -12,10 +12,17 @@ const Checkbox = ({
   classes,
   disabled,
   hideLabel,
+  disableTracking,
   ...otherProps
 }) => {
   
   const dispatch = useDispatch();
+
+  const handleInput = (event) => {
+    if ( !disableTracking ) {
+      trackInteraction(event);
+    }
+  };
 
   const trackInteraction = (event) => {
     const { target } = event;
@@ -38,7 +45,7 @@ const Checkbox = ({
       className="cts-checkbox__input"
       type="checkbox"
       name={name}
-      onInput={trackInteraction}
+      onInput={handleInput}
       value={value ? value : id}
       disabled={disabled || false}
       {...otherProps}
@@ -58,12 +65,14 @@ Checkbox.propTypes = {
   disabled: PropTypes.bool,
   classes: PropTypes.string,
   hideLabel: PropTypes.bool,
+  disableTracking: PropTypes.bool
 };
 
 Checkbox.defaultProps = {
   classes: '',
   name: 'checkboxes',
-  hideLabel: false
+  hideLabel: false,
+  disableTracking: false
 };
 
 export default Checkbox;

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -256,6 +256,7 @@ const ResultsListItem = ({
           label="Select this article for print"
           hideLabel
           onChange={() => onCheckChange(id)}
+          disableTracking={true}
         />
       </div>
       <div className="results-list-item__contents">


### PR DESCRIPTION
- Added `disableTracking` flag for `Checkbox` component, 

- Disabled tracking for checkboxes in `ResultsListItem` component