### PR TITLE
Changed URL strings to match prod

### DIFF
--- a/src/utilities/__tests__/queryStringToFormObject.adv.disease.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.disease.negative.js
@@ -18,7 +18,7 @@ describe('Adv - Disease - Negative - queryStringToFormObject maps query to form'
       ]
     ],
     [ "adv - bad multiple main types",
-      't=C1111,C1112&rl=2',
+      't=C1111&t=C1112&rl=2',
       async () => [],
       async () => [],
       async () => null,
@@ -91,7 +91,7 @@ describe('Adv - Disease - Negative - queryStringToFormObject maps query to form'
       ]
     ],
     [ "adv - bad subtypes with 1 good",
-      'st=C1111,chicken&rl=2',
+      'st=C1111&st=chicken&rl=2',
       async () => [],
       async () => [],
       async () => null,
@@ -164,7 +164,7 @@ describe('Adv - Disease - Negative - queryStringToFormObject maps query to form'
       ]
     ],
     [ "adv - bad stage after good",
-      'stg=C1111,chicken&rl=2',
+      'stg=C1111&stg=chicken&rl=2',
       async () => [],
       async () => [],
       async () => null,
@@ -237,7 +237,7 @@ describe('Adv - Disease - Negative - queryStringToFormObject maps query to form'
       ]
     ],
     [ "adv - bad finding following good",
-      'fin=C4444,chicken&rl=2',
+      'fin=C4444&fin=chicken&rl=2',
       async () => [],
       async () => [],
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.disease.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.disease.positive.js
@@ -89,7 +89,7 @@ describe('Advanced - Disease - queryStringToFormObject maps query to form', () =
       }
     ],
     [ "adv - multiple subtypes",
-      "?st=C2222,C2223|C2224&rl=2",
+      "?st=C2222&st=C2223|C2224&rl=2",
       getDiseaseFetcher(["C2222","C2223", "C2224"], ["Subtype A", "Subtype B"]),
       async () => [],
       async () => null,
@@ -153,7 +153,7 @@ describe('Advanced - Disease - queryStringToFormObject maps query to form', () =
       }
     ],
     [ "adv - multiple stages",
-      "?stg=C3333,C3334|C3335&rl=2",
+      "?stg=C3333&stg=C3334|C3335&rl=2",
       getDiseaseFetcher(["C3333","C3334","C3335"], ["Stage A", "Stage B"]),
       async () => [],
       async () => null,
@@ -207,7 +207,7 @@ describe('Advanced - Disease - queryStringToFormObject maps query to form', () =
       }
     ],
     [ "adv - multiple findings",
-      "?fin=C4444,C4445|C4446&rl=2",
+      "?fin=C4444&fin=C4445|C4446&rl=2",
       getDiseaseFetcher(["C4444","C4445","C4446"], ["Finding A", "Finding B"]),
       async () => [],
       async () => null,
@@ -225,7 +225,7 @@ describe('Advanced - Disease - queryStringToFormObject maps query to form', () =
     // makes sure that we are fetching a bunch of things and
     // picking out the correct concepts.
     [ "adv - multiple diseases",
-      "?t=C1111&st=C2222&stg=C3336|C3337&fin=C4444,C4445|C4446&rl=2",
+      "?t=C1111&st=C2222&stg=C3336|C3337&fin=C4444&fin=C4445|C4446&rl=2",
       getDiseaseFetcher(
         ["C1111","C2222","C3336","C3337","C4444","C4445","C4446"],
         ["Main Type A","Subtype A","Stage C","Finding A","Finding B"]

--- a/src/utilities/__tests__/queryStringToFormObject.adv.interventions.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.interventions.negative.js
@@ -13,7 +13,7 @@ describe('Advanced - Interventions - Negative - queryStringToFormObject maps que
       [{fieldName: "drugs", message: "Please enter a valid parameter"}]
     ],
     [ "bad drug id with one good",
-      'd=C1111,chicken&rl=2',
+      'd=C1111&d=chicken&rl=2',
       async () => [],
       async () => [],
       async () => null,
@@ -57,7 +57,7 @@ describe('Advanced - Interventions - Negative - queryStringToFormObject maps que
       [{fieldName: "treatments", message: "Please enter a valid parameter"}]
     ],
     [ "bad treatment id with one good",
-      'i=C1111,chicken&rl=2',
+      'i=C1111&i=chicken&rl=2',
       async () => [],
       async () => [],
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.interventions.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.interventions.positive.js
@@ -57,7 +57,7 @@ describe('Adv - Interventions - queryStringToFormObject maps query to form', () 
       }
     ],
     [ "multiple drugs",
-      "?d=C5555,C5556|C5557&rl=2",
+      "?d=C5555&d=C5556|C5557&rl=2",
       async () => [],
       getInterventionFetcher(["C5555","C5556","C5557"], ["Drug A", "Drug B"]),
       async () => null,
@@ -111,7 +111,7 @@ describe('Adv - Interventions - queryStringToFormObject maps query to form', () 
       }
     ],
     [ "multiple drugs",
-      "?i=C6666,C6667|C6668&rl=2",
+      "?i=C6666&i=C6667|C6668&rl=2",
       async () => [],
       getInterventionFetcher(["C6666","C6667","C6668"], ["Treatment A", "Treatment B"]),
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.loc.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.loc.negative.js
@@ -60,7 +60,7 @@ describe('Advanced - Locations - Negative - queryStringToFormObject maps query t
       [{fieldName: 'zip', message: 'Invalid Parameter'}]
     ],
     ["Zip - Multizip",
-      "?loc=1&z=20852,20874&rl=2",
+      "?loc=1&z=20852&z=20874&rl=2",
       async () => [],
       async () => [],
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.loc.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.loc.positive.js
@@ -72,7 +72,37 @@ describe('Adv - Locations - queryStringToFormObject maps query to form', () => {
       }
     ],
     ["CCS - states only, multi state",
+      "?loc=2&lcnty=United+States&lst=MD&lst=VA&rl=2",
+      async () => [],
+      async () => [],
+      async () => null,
+      {
+        location: 'search-location-country',
+        states: [
+          {abbr: 'MD', name: 'Maryland'},
+          {abbr: 'VA', name: 'Virginia'}
+        ],
+        country: 'United States',
+        formType: 'advanced'
+      }
+    ],
+    ["CCS - states only, multi state - old description page style",
       "?loc=2&lcnty=United+States&lst=MD,VA&rl=2",
+      async () => [],
+      async () => [],
+      async () => null,
+      {
+        location: 'search-location-country',
+        states: [
+          {abbr: 'MD', name: 'Maryland'},
+          {abbr: 'VA', name: 'Virginia'}
+        ],
+        country: 'United States',
+        formType: 'advanced'
+      }
+    ],
+    ["CCS - states only, multi state - old description page style spaces and commas",
+      "?loc=2&lcnty=United+States&lst=MD,  ,  ,VA&rl=2",
       async () => [],
       async () => [],
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.adv.positive.js
+++ b/src/utilities/__tests__/queryStringToFormObject.adv.positive.js
@@ -182,7 +182,7 @@ describe('Adv - queryStringToFormObject maps query to form', () => {
     ],
     [
       "Trial Type - multi",
-      "rl=2&tt=basic_science,Treatment,supportive_care",
+      "rl=2&tt=basic_science&tt=Treatment&tt=supportive_care",
       async () => [],
       async () => [],
       async () => null,
@@ -204,7 +204,7 @@ describe('Adv - queryStringToFormObject maps query to form', () => {
     ],
     [
       "Trial Type - multi",
-      "rl=2&tp=II,III",
+      "rl=2&tp=II&tp=III",
       async () => [],
       async () => [],
       async () => null,

--- a/src/utilities/__tests__/queryStringToFormObject.basic.negative.js
+++ b/src/utilities/__tests__/queryStringToFormObject.basic.negative.js
@@ -30,7 +30,7 @@ describe('Basic - Negative - queryStringToFormObject maps query to form', () => 
       ]
     ],
     [ "basic - bad multiple main types",
-      't=C1111,C1112&rl=1',
+      't=C1111&t=C1112&rl=1',
       async () => [],
       async () => [],
       async () => null,

--- a/src/views/ResultsPage/PrintModalContent.jsx
+++ b/src/views/ResultsPage/PrintModalContent.jsx
@@ -9,8 +9,16 @@ const PrintModalContent = ({ selectedList = [], handleClose = () => {} }) => {
   const printUrl = useSelector(store => store.globals.printCacheEndpoint);
   const formSnapshot = useSelector(store => store.form);
 
-  const queryParams = queryString.stringify(buildQueryString(formSnapshot), {
-    arrayFormat: 'comma',
+  const queryParams = buildQueryString(formSnapshot);
+
+  // Support for legacy things
+  const queryParamsModified = {
+    ...queryParams,
+    tp: queryParams['tp']? queryParams['tp'].map(tp=>tp.toUpperCase()) : []
+  };
+  
+  const queryParamsString = queryString.stringify(queryParamsModified, {
+    arrayFormat: 'none',
   })
 
   const printIds =  selectedList.map(({id})=> id);
@@ -18,7 +26,7 @@ const PrintModalContent = ({ selectedList = [], handleClose = () => {} }) => {
     { TrialIDs: printIds },
     // Make sure URL gets query params for search criteria on
     // print!!!
-    queryParams.length > 0 ? printUrl + '?' + queryParams : printUrl
+    queryParamsString.length > 0 ? printUrl + '?' + queryParamsString : printUrl
   );
 
   // on component mount, check for selected IDs,

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -34,7 +34,7 @@ const ResultsListItem = ({
   const qsQbj = queryString.parse(queryParams);
   qsQbj.id = item.nciID;
   const itemQueryString = queryString.stringify(qsQbj, {
-    arrayFormat: 'comma',
+    arrayFormat: 'none',
   });
 
   //compare site values against user criteria

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -43,7 +43,7 @@ const ResultsPage = ({ location, tracking }) => {
   const locsearch = location.search.replace('?', '');
   const [qs, setQs] = useState(
     queryString.stringify(buildQueryString(formSnapshot), {
-      arrayFormat: 'comma',
+      arrayFormat: 'none',
     })
   );
   const [storeRehydrated, setStoreRehydrated] = useState(false);
@@ -193,7 +193,7 @@ const ResultsPage = ({ location, tracking }) => {
       // update qs
       const parsed = queryString.parse(location.search);
       parsed.pn = currentPage + 1;
-      let newqs = queryString.stringify(parsed, { arrayFormat: 'comma' });
+      let newqs = queryString.stringify(parsed, { arrayFormat: 'none' });
       setQs(newqs);
       setCurrCacheKey(newqs);
       history.push({


### PR DESCRIPTION
- I originally had looked at URLs on a description page, which come
  to find out does NOT match how they are generated for the results
  pages. So changed the URL pattern to match results pages.
- Added in a mix of methods for states. (command and multiple params)
- Old prod wants trial phases uppercased for print search criteria, so added
   in that bit.