### PR TITLE
(#317)  Linting - Fix children as props

### DIFF
--- a/src/components/atomic/Autocomplete/Autocomplete.jsx
+++ b/src/components/atomic/Autocomplete/Autocomplete.jsx
@@ -204,9 +204,7 @@ class Autocomplete extends React.Component {
 			return true;
 		},
 		renderMenu(items, value, style, classes) {
-			return (
-				<div className={`cts-autocomplete__menu ${classes}`} children={items} />
-			);
+			return <div className={`cts-autocomplete__menu ${classes}`}>{items}</div>;
 		},
 		autoHighlight: true,
 		selectOnBlur: false,


### PR DESCRIPTION
 Nests children between open/close tags instead of as a prop.

Closes #317