### PR TITLE
(#358)  Autocomplete, Modal Linting Errors -- Props validation, interactive listener 

### DIFF
--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "jest-watch-typeahead": "^0.4.2",
     "nock": "^11.7.0",
     "node-sass": "^4.14.1",
+    "prop-types": "^15.7.2",
     "redux-devtools-extension": "^2.13.8",
     "redux-mock-store": "^1.5.3",
     "sinon": "^7.4.2",

--- a/src/components/atomic/Modal/Modal.jsx
+++ b/src/components/atomic/Modal/Modal.jsx
@@ -16,7 +16,7 @@ const Modal = ({ children, isShowing, hide }) => {
 	return isShowing
 		? ReactDOM.createPortal(
 				<React.Fragment>
-					<div
+					<div // eslint-disable-line jsx-a11y/no-noninteractive-element-interactions
 						className="cts-modal__overlay"
 						onClick={hide}
 						onKeyDown={hide}


### PR DESCRIPTION
Closes #358

- Adds props validation to Autocomplte.jsx

- Adds ignore for catch-22 on Modal interactive listener 
    - src/components/atomic/Modal/Modal.jsx
    - Non-interactive elements should not be assigned mouse or keyboard event listeners
