### PR TITLE
(#382) Add Clniclal Trials API from CTL App to CTS App

### DIFF
--- a/src/hooks/ctsApiSupport/__tests__/reducer.test.js
+++ b/src/hooks/ctsApiSupport/__tests__/reducer.test.js
@@ -1,0 +1,102 @@
+import reducer from '../reducer';
+import {
+	setSuccessfulFetch,
+	setFailedFetch,
+	setLoading,
+	setAborted,
+} from '../actions';
+
+import { getClinicalTrialsQuery } from '../../../services/api/actions/getClinicalTrialsQuery';
+
+describe('useCtsApi reducer', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const requestFilters = {
+		'arms.interventions.intervention_code': ['C1234'],
+	};
+	const requestQuery = getClinicalTrialsQuery({
+		from: 0,
+		requestFilters,
+		size: 50,
+	});
+
+	it('should handle successful fetch action', () => {
+		const actual = reducer({}, setSuccessfulFetch(requestQuery));
+		expect(actual).toEqual({
+			loading: false,
+			error: null,
+			payload: requestQuery,
+			aborted: false,
+		});
+	});
+
+	it('should handle failed fetch action', () => {
+		const err = new Error(`Error`);
+		const actual = reducer({}, setFailedFetch(err));
+		expect(actual).toEqual({
+			loading: false,
+			error: err,
+			payload: null,
+			aborted: false,
+		});
+	});
+
+	it('should handle set loading action', () => {
+		const actual = reducer({}, setLoading());
+		expect(actual).toEqual({
+			loading: true,
+			error: null,
+			payload: null,
+			aborted: false,
+		});
+	});
+
+	it('should handle set aborted action', () => {
+		const actual = reducer({}, setAborted());
+		expect(actual).toEqual({
+			loading: false,
+			error: null,
+			payload: null,
+			aborted: true,
+		});
+	});
+
+	it('handles an initial state', () => {
+		const actual = reducer(undefined, setAborted());
+		expect(actual).toEqual({
+			loading: false,
+			error: null,
+			payload: null,
+			aborted: true,
+		});
+	});
+
+	it('handles an already loading state', () => {
+		const loadingState = {
+			loading: true,
+			payload: null,
+			error: null,
+			aborted: false,
+		};
+
+		const actual = reducer(loadingState, setLoading());
+		expect(actual).toBe(loadingState);
+	});
+
+	it('handles an outlier case', () => {
+		const loadingState = {
+			loading: true,
+			payload: null,
+			error: null,
+			aborted: false,
+		};
+
+		const action = {
+			type: 'OUTLIER',
+		};
+		const actual = reducer(loadingState, action);
+		expect(actual).toBe(loadingState);
+	});
+});

--- a/src/hooks/ctsApiSupport/__tests__/useCtsApi.test.js
+++ b/src/hooks/ctsApiSupport/__tests__/useCtsApi.test.js
@@ -1,0 +1,230 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { render } from '@testing-library/react';
+import { useCtsApi } from '../useCtsApi';
+import { useAppSettings } from '../../../store/store';
+import { getClinicalTrialsQuery } from '../../../services/api/actions/getClinicalTrialsQuery';
+import { getClinicalTrials } from '../../../services/api/clinical-trials-search-api/getClinicalTrials';
+
+jest.mock('../../../store/store');
+jest.mock(
+	'../../../services/api/clinical-trials-search-api/getClinicalTrials.js'
+);
+
+describe('tests for useCtsApi', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	const UseCtsApiSupportSample = ({ query }) => {
+		const { loading, payload, error, aborted } = useCtsApi(query);
+
+		return (
+			<div>
+				{(() => {
+					if (!loading && payload) {
+						return (
+							<>
+								<h1>Payload</h1>
+								Total: {payload.total}
+							</>
+						);
+					} else if (!loading && error) {
+						return <h1>Error: {error.message}</h1>;
+					} else if (!loading && aborted) {
+						return <h1>Aborted: This should not happen</h1>;
+					} else {
+						return <h1>Loading</h1>;
+					}
+				})()}
+			</div>
+		);
+	};
+
+	it('should fetch the data with one requestFilter in the query', async () => {
+		useAppSettings.mockReturnValue([
+			{
+				appId: 'mockAppId',
+				apiClients: { trialListingSupportClient: true },
+			},
+		]);
+
+		getClinicalTrials.mockReturnValue({
+			total: 1,
+			trials: [
+				{
+					brief_summary: 'first summary',
+					brief_title: 'first title',
+					current_trial_status: 'Active',
+					nci_id: 'NCI-2015-00054',
+					sites: 0,
+				},
+			],
+		});
+
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1234'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			from: 0,
+			requestFilters,
+			size: 1,
+		});
+
+		const expected = {
+			current_trial_status: [
+				'Active',
+				'Approved',
+				'Enrolling by Invitation',
+				'In Review',
+				'Temporarily Closed to Accrual',
+				'Temporarily Closed to Accrual and Intervention',
+			],
+			include: [
+				'brief_summary',
+				'brief_title',
+				'current_trial_status',
+				'nci_id',
+				'nct_id',
+				'sites.org_name',
+				'sites.org_country',
+				'sites.org_state_or_province',
+				'sites.org_city',
+				'sites.recruitment_status',
+			],
+			'arms.interventions.intervention_code': ['C1234'],
+			from: 0,
+			size: 1,
+		};
+
+		render(<UseCtsApiSupportSample query={query} />);
+
+		expect(getClinicalTrials.mock.calls).toHaveLength(1);
+		expect(getClinicalTrials.mock.calls[0][1]).toEqual(expected);
+		// Todo: check that the expected text is on the page.
+	});
+
+	it('should handle an AbortError when calling getClinicalTrials with client and query params', async () => {
+		useAppSettings.mockReturnValue([
+			{
+				appId: 'mockAppId',
+				apiClients: { trialListingSupportClient: true },
+			},
+		]);
+
+		let isErrorThrown = false;
+
+		getClinicalTrials.mockImplementation(() => {
+			isErrorThrown = true;
+			const err = new Error('AbortError');
+			err.name = 'AbortError';
+			throw err;
+		});
+
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1234'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			from: 0,
+			requestFilters,
+			size: 1,
+		});
+
+		const expected = {
+			current_trial_status: [
+				'Active',
+				'Approved',
+				'Enrolling by Invitation',
+				'In Review',
+				'Temporarily Closed to Accrual',
+				'Temporarily Closed to Accrual and Intervention',
+			],
+			include: [
+				'brief_summary',
+				'brief_title',
+				'current_trial_status',
+				'nci_id',
+				'nct_id',
+				'sites.org_name',
+				'sites.org_country',
+				'sites.org_state_or_province',
+				'sites.org_city',
+				'sites.recruitment_status',
+			],
+			'arms.interventions.intervention_code': ['C1234'],
+			from: 0,
+			size: 1,
+		};
+
+		render(<UseCtsApiSupportSample query={query} />);
+
+		expect(getClinicalTrials.mock.calls).toHaveLength(1);
+		expect(getClinicalTrials.mock.calls[0][1]).toEqual(expected);
+		expect(isErrorThrown).toEqual(true);
+	});
+
+	it('should handle any other kind of error when calling getClinicalTrials with client and query params', async () => {
+		useAppSettings.mockReturnValue([
+			{
+				appId: 'mockAppId',
+				apiClients: { trialListingSupportClient: true },
+			},
+		]);
+
+		let isErrorThrown = false;
+
+		getClinicalTrials.mockImplementation(() => {
+			isErrorThrown = true;
+			const err = new Error('WIERDERROR');
+			err.name = 'WEIRDERROR';
+			throw err;
+		});
+
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1234'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			from: 0,
+			requestFilters,
+			size: 1,
+		});
+
+		const expected = {
+			current_trial_status: [
+				'Active',
+				'Approved',
+				'Enrolling by Invitation',
+				'In Review',
+				'Temporarily Closed to Accrual',
+				'Temporarily Closed to Accrual and Intervention',
+			],
+			include: [
+				'brief_summary',
+				'brief_title',
+				'current_trial_status',
+				'nci_id',
+				'nct_id',
+				'sites.org_name',
+				'sites.org_country',
+				'sites.org_state_or_province',
+				'sites.org_city',
+				'sites.recruitment_status',
+			],
+			'arms.interventions.intervention_code': ['C1234'],
+			from: 0,
+			size: 1,
+		};
+
+		render(<UseCtsApiSupportSample query={query} />);
+
+		expect(getClinicalTrials.mock.calls).toHaveLength(1);
+		expect(getClinicalTrials.mock.calls[0][1]).toEqual(expected);
+		expect(isErrorThrown).toEqual(true);
+	});
+	UseCtsApiSupportSample.propTypes = {
+		query: PropTypes.object,
+	};
+});

--- a/src/hooks/ctsApiSupport/actions.js
+++ b/src/hooks/ctsApiSupport/actions.js
@@ -1,0 +1,34 @@
+// Action type declarations
+export const SET_LOADING = 'SET_LOADING';
+export const SET_ABORTED = 'SET_ABORTED';
+export const FETCH_SUCCESS = 'FETCH_SUCCESS';
+export const FETCH_ERROR = 'FETCH_ERROR';
+
+// Actions
+export const setSuccessfulFetch = (fetchResponse) => {
+	return {
+		type: FETCH_SUCCESS,
+		payload: {
+			fetchResponse,
+		},
+	};
+};
+
+export const setFailedFetch = (error) => {
+	return {
+		type: FETCH_ERROR,
+		payload: error,
+	};
+};
+
+export const setLoading = () => {
+	return {
+		type: SET_LOADING,
+	};
+};
+
+export const setAborted = () => {
+	return {
+		type: SET_ABORTED,
+	};
+};

--- a/src/hooks/ctsApiSupport/index.js
+++ b/src/hooks/ctsApiSupport/index.js
@@ -1,0 +1,1 @@
+export { useCtsApi } from './useCtsApi';

--- a/src/hooks/ctsApiSupport/reducer.js
+++ b/src/hooks/ctsApiSupport/reducer.js
@@ -1,0 +1,53 @@
+import {
+	FETCH_SUCCESS,
+	FETCH_ERROR,
+	SET_LOADING,
+	SET_ABORTED,
+} from './actions';
+
+// Reducer
+const reducer = (state = {}, action) => {
+	switch (action.type) {
+		case FETCH_SUCCESS:
+			return {
+				loading: false,
+				payload: action.payload.fetchResponse,
+				error: null,
+				aborted: false,
+			};
+		case FETCH_ERROR:
+			return {
+				loading: false,
+				payload: null,
+				error: action.payload,
+				aborted: false,
+			};
+		case SET_LOADING:
+			if (
+				state.loading === true &&
+				state.payload === null &&
+				state.error === null &&
+				state.aborted === false
+			) {
+				return state;
+			} else {
+				return {
+					loading: true,
+					payload: null,
+					error: null,
+					aborted: false,
+				};
+			}
+		case SET_ABORTED:
+			return {
+				loading: false,
+				payload: null,
+				error: null,
+				aborted: true,
+			};
+		default:
+			return state;
+	}
+};
+
+export default reducer;

--- a/src/hooks/ctsApiSupport/useCtsApi.js
+++ b/src/hooks/ctsApiSupport/useCtsApi.js
@@ -1,0 +1,136 @@
+import { useEffect, useReducer, useRef, useCallback } from 'react';
+
+import {
+	setSuccessfulFetch,
+	setFailedFetch,
+	setLoading,
+	setAborted,
+} from './actions';
+import reducer from './reducer';
+import { getClinicalTrials } from '../../services/api/clinical-trials-search-api';
+import { convertObjectToBase64 } from '../../utilities/objects';
+import { useAppSettings } from '../../store/store';
+
+/**
+ * An action representing a CTS API request.
+ * @typedef {Object} CtsApiRequestAction
+ * @property {string} type - The type of request (fetchTrials).
+ * @property {Object} payload - the CTS API query object.
+ */
+
+/**
+ * The hook response for the CTS API. Each property of the object is a state value.
+ * @typedef {Object} CtsApiResponse
+ * @property {bool} loading - is the request currently loading.
+ * @property {Array<object>} payload the responses from the api.
+ * @property {Error} error The first error to have been returned.
+ */
+
+/**
+ * Given a fetch trial action this will fetch results from the CTS API.
+ *
+ * This was borrowed heavily from React Fetching Library's useQuery hook. We did not implement
+ * any of the abort controlling as it would not work with Axios. See
+ * https://github.com/marcin-piela/react-fetching-library/blob/1.7.6/src/hooks/useQuery/useQuery.ts
+ *
+ * @param {CtsApiRequestAction} trialQueryAction a fetchTrials action, this is basically the CTS API request.
+ * @returns {CtsApiResponse} the stateful data
+ */
+export const useCtsApi = (trialQueryAction) => {
+	const [
+		{
+			apiClients: { clinicalTrialsSearchClient },
+		},
+	] = useAppSettings();
+
+	// Indicates if the component this was called from is
+	// still mounted or not. Important to avoid
+	// "Can only update a mounted..." errors.
+	const isMounted = useRef(true);
+
+	const [state, dispatch] = useReducer(reducer, {
+		loading: true,
+		payload: null,
+		error: null,
+		aborted: false,
+	});
+
+	const queryActionHash = convertObjectToBase64(trialQueryAction);
+
+	// This call back handles the fetch to the api. We use is call back
+	// so the query does not execute except when any of the actions have
+	// changed. Otherwise this gets called pretty much an infinite amount
+	// of times.
+	const handleQuery = useCallback(async () => {
+		//TODO: Abort any pending requests.
+
+		// If we are handling the query, but the component that called this
+		// affect is no longer being referenced, then we need to leave quickly.
+		if (!isMounted.current) {
+			return { error: false };
+		}
+
+		// Reset our state to the loading state.
+		dispatch(setLoading());
+
+		// Make the request, the response object will either be the payload
+		// or it will be an error object. This allows us to have one object
+		// that we return for the useCallback to "cache".
+		// TODO: Pass in a cancellation token for this request to handle aborts
+		let response;
+
+		try {
+			response = await getClinicalTrials(
+				clinicalTrialsSearchClient,
+				trialQueryAction.payload
+			);
+			if (isMounted.current) {
+				// We successfully fetched from the API, and our component is still loaded,
+				// so go send back results.
+				dispatch(setSuccessfulFetch(response));
+			}
+		} catch (err) {
+			if (isMounted.current) {
+				if (err.name === 'AbortError') {
+					// NOTE: The original react fetching code handle a condition here in which the
+					// calling component was still mounted and the request was aborted. In this
+					// case it reset the reducer state to the default state, which is not loading
+					// and queryResponse is an object with a false error.
+					//
+					// We will just return a state with aborted, which really should not be called
+					// unless our component unmounted AND a fetch was in progress, in which case
+					// we really don't care about the response. So we can set an aborted flag in
+					// case we will.
+					dispatch(setAborted());
+				} else {
+					// Our component is going to have to show the user an error message because
+					// something went horribly wrong with the fetch.
+					dispatch(setFailedFetch(err));
+				}
+			}
+		}
+	}, [queryActionHash]);
+
+	// This callback is for aborting the requests.
+	const handleAbort = useCallback(() => {
+		// TODO: We should cancel the Axios request here.
+	}, []);
+
+	// We only want to fire this the first time useCtsApi
+	// is called.
+	useEffect(() => {
+		isMounted.current = true;
+
+		// Fire off the query.
+		handleQuery();
+
+		// This is a function to be called when the component is
+		// unmounted.
+		return () => {
+			isMounted.current = false;
+			handleAbort();
+		};
+	}, [handleQuery]);
+
+	return state;
+};

--- a/src/services/api/actions/__tests__/getClinicalTrials.test.js
+++ b/src/services/api/actions/__tests__/getClinicalTrials.test.js
@@ -1,0 +1,87 @@
+import { getClinicalTrialsQuery } from '../getClinicalTrialsQuery';
+
+describe('testing getClinicalTrials', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it('creates a query, when given requestFilters', async () => {
+		const expectedQuery = {
+			type: 'getClinicalTrials',
+			payload: {
+				current_trial_status: [
+					'Active',
+					'Approved',
+					'Enrolling by Invitation',
+					'In Review',
+					'Temporarily Closed to Accrual',
+					'Temporarily Closed to Accrual and Intervention',
+				],
+				include: [
+					'brief_summary',
+					'brief_title',
+					'current_trial_status',
+					'nci_id',
+					'nct_id',
+					'sites.org_name',
+					'sites.org_country',
+					'sites.org_state_or_province',
+					'sites.org_city',
+					'sites.recruitment_status',
+				],
+				'arms.interventions.intervention_code': ['C1234'],
+				'primary_purpose.primary_purpose_code': 'treatment',
+				from: 0,
+				size: 50,
+			},
+		};
+
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1234'],
+			'primary_purpose.primary_purpose_code': 'treatment',
+		};
+
+		const requestQuery = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		expect(requestQuery).toMatchObject(expectedQuery);
+	});
+
+	it('creates a query without any requestFilters', async () => {
+		const expectedQuery = {
+			type: 'getClinicalTrials',
+			payload: {
+				current_trial_status: [
+					'Active',
+					'Approved',
+					'Enrolling by Invitation',
+					'In Review',
+					'Temporarily Closed to Accrual',
+					'Temporarily Closed to Accrual and Intervention',
+				],
+				include: [
+					'brief_summary',
+					'brief_title',
+					'current_trial_status',
+					'nci_id',
+					'nct_id',
+					'sites.org_name',
+					'sites.org_country',
+					'sites.org_state_or_province',
+					'sites.org_city',
+					'sites.recruitment_status',
+				],
+				from: 5,
+				size: 20,
+			},
+		};
+
+		const requestQuery = getClinicalTrialsQuery({
+			from: 5,
+			size: 20,
+		});
+
+		expect(requestQuery).toMatchObject(expectedQuery);
+	});
+});

--- a/src/services/api/actions/getClinicalTrialsQuery.js
+++ b/src/services/api/actions/getClinicalTrialsQuery.js
@@ -1,0 +1,47 @@
+/**
+ * Gets a list of clinical trials from the Clinical Trials API matching the request filters
+ *
+ * @param {Number} from the offset to start results from
+ * @param {Object} requestFilters the request filters to match
+ * @param {Number} size the number of results
+ *
+ */
+
+export const getClinicalTrialsQuery = ({
+	from = 0,
+	requestFilters = {},
+	size = 50,
+}) => {
+	// Set up query for Clinical Trials API.
+	// Include only active trial statuses, requestFilters, from, and size.
+	const requestQuery = {
+		current_trial_status: [
+			'Active',
+			'Approved',
+			'Enrolling by Invitation',
+			'In Review',
+			'Temporarily Closed to Accrual',
+			'Temporarily Closed to Accrual and Intervention',
+		],
+		include: [
+			'brief_summary',
+			'brief_title',
+			'current_trial_status',
+			'nci_id',
+			'nct_id',
+			'sites.org_name',
+			'sites.org_country',
+			'sites.org_state_or_province',
+			'sites.org_city',
+			'sites.recruitment_status',
+		],
+		...requestFilters,
+		from,
+		size,
+	};
+
+	return {
+		type: 'getClinicalTrials',
+		payload: requestQuery,
+	};
+};

--- a/src/services/api/actions/index.js
+++ b/src/services/api/actions/index.js
@@ -1,0 +1,1 @@
+export { getClinicalTrialsQuery } from './getClinicalTrialsQuery';

--- a/src/services/api/clinical-trials-search-api/__tests__/getClinicalTrials.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/getClinicalTrials.test.js
@@ -1,0 +1,122 @@
+import axios from 'axios';
+import nock from 'nock';
+
+import { getClinicalTrialsQuery } from '../../actions/getClinicalTrialsQuery';
+import clinicalTrialsSearchClientFactory from '../clinicalTrialsSearchClientFactory';
+import { getClinicalTrials } from '../getClinicalTrials';
+
+// Required for unit tests to not have CORS issues
+axios.defaults.adapter = require('axios/lib/adapters/http');
+
+const client = clinicalTrialsSearchClientFactory('http://example.org');
+
+describe('testing getClinicalTrials', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	it('makes a request to api and returns 57 trials, for trastuzumab', async () => {
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1647'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/clinical-trials', query.payload)
+			.reply(200, { total: 57, trials: [{}] });
+		const response = await getClinicalTrials(client, query.payload);
+		expect(response.total).toEqual(57);
+		scope.isDone();
+	});
+
+	it.each([
+		['empty object', {}],
+		['null total', { total: null }],
+		['count with null trials', { total: 32 }],
+		['count with empty trials', { total: 32, trials: [] }],
+		['zero count with trials', { total: 0, trials: [1] }],
+	])('Invalid trial responses - %s', async (testCase, resObj) => {
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1647'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/clinical-trials', query.payload)
+			.reply(200, resObj);
+
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow(
+			'Trial count mismatch from the API'
+		);
+		scope.isDone();
+	});
+
+	it('makes a request where the response is 201', async () => {
+		const requestFilters = {
+			'bad_request.interventions.intervention_code_request': ['BAD404'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/clinical-trials', query.payload)
+			.reply(201);
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow(
+			'Unexpected status 201 for fetching clinical trials'
+		);
+		scope.isDone();
+	});
+
+	it('throws a 500 error status', async () => {
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1647'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/clinical-trials', query.payload)
+			.reply(500);
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow(
+			'Unexpected status 500 for fetching clinical trials'
+		);
+		scope.isDone();
+	});
+
+	it('handles an error thrown by http client', async () => {
+		const requestFilters = {
+			'arms.interventions.intervention_code': ['C1647'],
+		};
+
+		const query = getClinicalTrialsQuery({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/clinical-trials', query.payload)
+			.replyWithError('connection refused');
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow(
+			'connection refused'
+		);
+		scope.isDone();
+	});
+});

--- a/src/services/api/clinical-trials-search-api/clinicalTrialsSearchClientFactory.js
+++ b/src/services/api/clinical-trials-search-api/clinicalTrialsSearchClientFactory.js
@@ -1,0 +1,15 @@
+import axios from 'axios';
+
+/**
+ * Gets an instance of a Clinical Trial Search API client
+ *
+ * @param {string} apiBase the base url of the API
+ */
+const clinicalTrialsSearchClientFactory = (apiBase) => {
+	return axios.create({
+		baseURL: apiBase,
+		timeout: 15000,
+	});
+};
+
+export default clinicalTrialsSearchClientFactory;

--- a/src/services/api/clinical-trials-search-api/getClinicalTrials.js
+++ b/src/services/api/clinical-trials-search-api/getClinicalTrials.js
@@ -1,0 +1,36 @@
+/**
+ * Fetches listing information matching the requested concept ID(s)
+ *
+ * @param {import("axios").AxiosInstance} client An axios instance with the correct baseURL
+ * @param {object} query the cts query
+ */
+export const getClinicalTrials = async (client, query) => {
+	try {
+		const res = await client.post(`/clinical-trials`, query);
+		if (res.status === 200) {
+			if (
+				res.data.total === null ||
+				typeof res.data.total === 'undefined' ||
+				(res.data.total > 0 && !res.data?.trials?.length) ||
+				(res.data.total === 0 && res.data?.trials?.length !== 0)
+			) {
+				throw new Error(`Trial count mismatch from the API`);
+			} else {
+				return res.data;
+			}
+		} else {
+			// This condition will be hit for anything < 300.
+			throw new Error(
+				`Unexpected status ${res.status} for fetching clinical trials`
+			);
+		}
+	} catch (error) {
+		// This conditional will be hit for any status >= 300.
+		if (error.response) {
+			throw new Error(
+				`Unexpected status ${error.response.status} for fetching clinical trials`
+			);
+		}
+		throw error;
+	}
+};

--- a/src/services/api/clinical-trials-search-api/index.js
+++ b/src/services/api/clinical-trials-search-api/index.js
@@ -1,0 +1,2 @@
+export { default as default } from './clinicalTrialsSearchClientFactory';
+export { getClinicalTrials } from './getClinicalTrials';

--- a/src/utilities/__tests__/objects.tests.js
+++ b/src/utilities/__tests__/objects.tests.js
@@ -1,0 +1,15 @@
+import { getKeyValueFromObject } from '../objects';
+
+const testObject = {
+	termId: 467848,
+	termName: 'methodology',
+};
+
+describe('getKeyValueFromObject', () => {
+	it(`should retrieve termId value ${testObject.termId} from test object`, () => {
+		expect(getKeyValueFromObject('termId', testObject)).toEqual(467848);
+	});
+	it('should return "undefined" for key that does not exist in test object', () => {
+		expect(getKeyValueFromObject('termKey', testObject)).toBeUndefined();
+	});
+});

--- a/src/utilities/objects.js
+++ b/src/utilities/objects.js
@@ -1,0 +1,18 @@
+export const getKeyValueFromObject = (key, obj) => {
+	let retValue;
+	Object.keys(obj).forEach((thisKey) => {
+		if (thisKey === key) {
+			retValue = obj[key];
+		}
+	});
+	return retValue;
+};
+
+/**
+ * Gets a hash for an object.
+ *
+ * @param {object} obj the object to hash
+ */
+export const convertObjectToBase64 = (obj) => {
+	return Buffer.from(JSON.stringify(obj)).toString('base64');
+};


### PR DESCRIPTION
* Adds Clinical Trials API's from Clinical Trials Listing App repo
   * Copies over hooks/ctsApiSupport from CTL
      * Updates useStateValue to useAppSettings in useCTSApi.js / tests
   * Copies over the req'd  utils/objects.js and it's tests from utils/ to utilities/
      * Updates tests to use 'it' instead of 'test' for linter
   * Copies over services/api/actions from CTL
      *  Renames query action from getClinicalTrials to getClinicalTrialsQuery
   * Copies over /services/api/clinical-trials-search-api

* Updates failing CTSApi tests
   * Removes surrounding act(), testing-library handles it in it's render function. Async is both not allowed or req'd.
      * Resolves:
                    ```It looks like you wrote ReactTestUtils.act(async () => ...),
                       or returned a Promise from the callback passed to it.
                      Putting asynchronous logic inside ReactTestUtils.act(...) is not supported.```
   * Updates expect(isErrorThrown) statments to have an explicit expectation
      * Resolves :
                   ```error  Expect must have a corresponding matcher call  jest/valid-expect```

Closes #382

