### PR TITLE
(#416, #426) Build CTS v2 Middleware and implement searchLeadOrg Fetcher

### DIFF
--- a/cypress/integration/AdvancedSearchPage/LeadOrganizationSection/index.js
+++ b/cypress/integration/AdvancedSearchPage/LeadOrganizationSection/index.js
@@ -3,7 +3,7 @@ import { And, Then, When } from 'cypress-cucumber-preprocessor/steps';
 
 And('user selects {string} from dropdown', (autosuggestTerm) => {
 	cy.get('div.cts-autocomplete__menu.--leadOrg').should('be.visible');
-	cy.get('div.cts-autocomplete__menu.--leadOrg div:visible')
+	cy.get('div.cts-autocomplete__menu.--leadOrg div.highlighted:visible')
 		.should('have.text', autosuggestTerm)
 		.click();
 });

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -12,6 +12,7 @@ beforeEach(() => {
 			baseHost: 'http://localhost:3000',
 			basePath: '/about-cancer/treatment/clinical-trials/search',
 			canonicalHost: 'https://www.cancer.gov',
+			ctsApiEndpointV1: '/v1',
 			ctsTitle: 'Find NCI-Supported Clinical Trials',
 			language: 'en',
 			rootId: 'NCI-CTS-root',

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -13,6 +13,7 @@ beforeEach(() => {
 			basePath: '/about-cancer/treatment/clinical-trials/search',
 			canonicalHost: 'https://www.cancer.gov',
 			ctsApiEndpointV1: '/v1',
+			ctsApiEndpointV2: '/cts/mock-api/v2',
 			ctsTitle: 'Find NCI-Supported Clinical Trials',
 			language: 'en',
 			rootId: 'NCI-CTS-root',

--- a/public/index.html
+++ b/public/index.html
@@ -68,6 +68,8 @@
           baseHost: 'http://localhost:3000',
           basePath: '/about-cancer/treatment/clinical-trials/search',
           canonicalHost: 'https://www.cancer.gov',
+					ctsApiEndpointV1: 'https://clinicaltrialsapi.cancer.gov/v1',
+					ctsApiEndpointV2: 'https://clinicaltrialsapi.cancer.gov/api/v2',
           language: 'en',
           printCacheEndpoint: '/CTS.Print/GenCache',
           rootId: 'NCI-CTS-root',

--- a/src/components/search-modules/LeadOrganization/LeadOrganization.jsx
+++ b/src/components/search-modules/LeadOrganization/LeadOrganization.jsx
@@ -3,19 +3,28 @@ import { useDispatch, useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import Fieldset from '../../atomic/Fieldset';
 import { Autocomplete } from '../../atomic';
-import { searchLeadOrg } from '../../../store/actions';
-import { matchItemToTerm, sortItems } from '../../../utilities';
+import { getLeadOrgAction } from '../../../store/actionsV2';
+import {
+	createTermDataFromAggregate,
+	matchItemToTerm,
+	sortItems,
+} from '../../../utilities';
 
 const LeadOrganization = ({ handleUpdate }) => {
 	const dispatch = useDispatch();
 	const { leadOrg } = useSelector((store) => store.form);
-	const { leadorgs = [] } = useSelector((store) => store.cache);
+	const { leadorgs = {} } = useSelector((store) => store.cache);
+	// Forcibly limit results returned from api as there is currently
+	// no way to limit aggregate results returned.
+	const lead_org = leadorgs.aggregations
+		? createTermDataFromAggregate(leadorgs.aggregations.lead_org.slice(0, 10))
+		: [];
 
 	const [orgName, setOrgName] = useState({ value: leadOrg.term });
 
 	useEffect(() => {
 		if (orgName.value.length > 2) {
-			dispatch(searchLeadOrg({ searchText: orgName.value }));
+			dispatch(getLeadOrgAction({ searchText: orgName.value }));
 		}
 	}, [orgName, dispatch]);
 
@@ -31,7 +40,7 @@ const LeadOrganization = ({ handleUpdate }) => {
 				value={orgName.value}
 				inputProps={{ id: 'lo', placeholder: 'Organization name' }}
 				wrapperStyle={{ position: 'relative', display: 'inline-block' }}
-				items={leadorgs}
+				items={lead_org}
 				getItemValue={(item) => item.term}
 				shouldItemRender={matchItemToTerm}
 				sortItems={sortItems}
@@ -46,7 +55,7 @@ const LeadOrganization = ({ handleUpdate }) => {
 				renderMenu={(children) => (
 					<div className="cts-autocomplete__menu --leadOrg">
 						{orgName.value.length > 2 ? (
-							leadorgs.length ? (
+							lead_org.length ? (
 								children
 							) : (
 								<div className="cts-autocomplete__menu-item">

--- a/src/index.js
+++ b/src/index.js
@@ -198,8 +198,8 @@ const integrationTestOverrides = window.INT_TEST_APP_PARAMS || {};
 if (process.env.NODE_ENV !== 'production') {
 	const ctsSettings = {
 		...appParams,
-		...integrationTestOverrides,
 		ctsApiEndpointV2: 'http://localhost:3000/cts/proxy-api/v2',
+		...integrationTestOverrides,
 	};
 	initialize(ctsSettings);
 } else if (window?.location?.host === 'react-app-dev.cancer.gov') {

--- a/src/middleware/CTSMiddlewareV2.js
+++ b/src/middleware/CTSMiddlewareV2.js
@@ -1,0 +1,46 @@
+import { receiveData } from '../store/actions';
+
+/**
+ * This middleware serves two purposes (and could perhaps be broken into two pieces).
+ * 1. To set up API requests with all the appropriate settings
+ * 2. To handle the attendant responses and failures. Successful requests will need to be cached and then
+ * sent to the store. Failures will need to be taken round back and shot.
+ * @param {Object} services
+ */
+const createCTSMiddlewareV2 =
+	(client) =>
+	({ dispatch }) =>
+	(next) =>
+	async (action) => {
+		next(action);
+
+		if (action.type !== '@@api/CTSv2') {
+			return;
+		}
+
+		const getAllRequests = async (fetchAction) => {
+			const requests = () => {
+				const { method } = fetchAction.payload;
+
+				// Switch block for api calls with default case
+				switch (method) {
+					default: {
+						throw new Error(`Unknown CTS API request`);
+					}
+				}
+			};
+			const responses = await requests();
+			return responses;
+		};
+
+		if (client !== null && action.payload) {
+			try {
+				const results = await getAllRequests(action);
+				dispatch(receiveData(action.payload.cacheKey, ...results));
+			} catch (err) {
+				console.log(err);
+			}
+		}
+	};
+
+export default createCTSMiddlewareV2;

--- a/src/middleware/CTSMiddlewareV2.js
+++ b/src/middleware/CTSMiddlewareV2.js
@@ -1,4 +1,5 @@
 import { receiveData } from '../store/actions';
+import { getLeadOrg } from '../services/api/clinical-trials-search-api';
 
 /**
  * This middleware serves two purposes (and could perhaps be broken into two pieces).
@@ -20,10 +21,13 @@ const createCTSMiddlewareV2 =
 
 		const getAllRequests = async (fetchAction) => {
 			const requests = () => {
-				const { method } = fetchAction.payload;
+				const { method, requestParams } = fetchAction.payload;
 
 				// Switch block for api calls with default case
 				switch (method) {
+					case 'getLeadOrg': {
+						return getLeadOrg(client, requestParams);
+					}
 					default: {
 						throw new Error(`Unknown CTS API request`);
 					}
@@ -36,7 +40,7 @@ const createCTSMiddlewareV2 =
 		if (client !== null && action.payload) {
 			try {
 				const results = await getAllRequests(action);
-				dispatch(receiveData(action.payload.cacheKey, ...results));
+				dispatch(receiveData(action.payload.cacheKey, results));
 			} catch (err) {
 				console.log(err);
 			}

--- a/src/services/api/clinical-trials-search-api/__tests__/getLeadOrg.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/getLeadOrg.test.js
@@ -1,0 +1,176 @@
+import axios from 'axios';
+import querystring from 'querystring';
+import nock from 'nock';
+
+import clinicalTrialsSearchClientFactory from '../clinicalTrialsSearchClientFactory';
+import { ACTIVE_TRIAL_STATUSES } from '../../../../constants';
+import { getLeadOrg } from '../getLeadOrg';
+import { getLeadOrgAction } from '../../../../store/actionsV2';
+
+// Required for unit tests to not have CORS issues
+axios.defaults.adapter = require('axios/lib/adapters/http');
+
+const client = clinicalTrialsSearchClientFactory('http://example.org');
+
+describe('getLeadOrg', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	it('makes a request to the api and matches returned result for specified search text', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const result = {
+			total: 7358,
+			aggregations: {
+				doc_count: 419,
+				lead_org: [
+					{
+						key: 'Barretos Cancer Hospital',
+						doc_count: 1,
+					},
+					{
+						key: "Boston Children's Hospital",
+						doc_count: 1,
+					},
+					{
+						key: "Children's Hospital Colorado",
+						doc_count: 11,
+					},
+					{
+						key: "Children's Hospital Los Angeles",
+						doc_count: 4,
+					},
+					{
+						key: "Children's Hospital and Medical Center of Omaha",
+						doc_count: 1,
+					},
+					{
+						key: "Children's Hospital of Philadelphia",
+						doc_count: 12,
+					},
+					{
+						key: "Children's Hospital of Pittsburgh of UPMC",
+						doc_count: 5,
+					},
+					{
+						key: "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+						doc_count: 3,
+					},
+					{
+						key: "Cincinnati Children's Hospital Medical Center",
+						doc_count: 2,
+					},
+					{
+						key: 'Emory University Hospital/Winship Cancer Institute',
+						doc_count: 71,
+					},
+				],
+			},
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(200, result);
+		const response = await getLeadOrg(client, query.payload.requestParams);
+		expect(response).toEqual(result);
+		scope.isDone();
+	});
+
+	it('throws a 404 error', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(404);
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('Unexpected status 404 for fetching lead organization');
+		scope.isDone();
+	});
+
+	it('throws a 500 error status', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(500);
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('Unexpected status 500 for fetching lead organization');
+		scope.isDone();
+	});
+
+	it('handles an error thrown by http client', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.replyWithError('connection refused');
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('connection refused');
+		scope.isDone();
+	});
+});

--- a/src/services/api/clinical-trials-search-api/getLeadOrg.js
+++ b/src/services/api/clinical-trials-search-api/getLeadOrg.js
@@ -1,0 +1,29 @@
+import querystring from 'query-string';
+
+/**
+ * Fetches lead orgs to populate the Lead Organization field
+ *
+ * @param {import("axios").AxiosInstance} client An axios instance with the correct baseURL
+ * @param {object} query the cts query
+ */
+export const getLeadOrg = async (client, query) => {
+	try {
+		const res = await client.get(`/trials?${querystring.stringify(query)}`);
+		if (res.status === 200) {
+			return res.data;
+		} else {
+			// This condition will be hit for anything < 300.
+			throw new Error(
+				`Unexpected status ${res.status} for fetching lead organization`
+			);
+		}
+	} catch (error) {
+		// This conditional will be hit for any status >= 300.
+		if (error.response) {
+			throw new Error(
+				`Unexpected status ${error.response.status} for fetching lead organization`
+			);
+		}
+		throw error;
+	}
+};

--- a/src/services/api/clinical-trials-search-api/index.js
+++ b/src/services/api/clinical-trials-search-api/index.js
@@ -1,3 +1,4 @@
 export { default as default } from './clinicalTrialsSearchClientFactory';
 export { getClinicalTrialDescription } from './getClinicalTrialDescription';
 export { getClinicalTrials } from './getClinicalTrials';
+export { getLeadOrg } from './getLeadOrg';

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -437,33 +437,6 @@ export function searchTrialInvestigators({ searchText, size = 10 } = {}) {
 	};
 }
 
-/**
- * Gets lead orgs to populate the Lead Organization field
- */
-export function searchLeadOrg({ searchText, size = 10 } = {}) {
-	return {
-		type: '@@api/CTS',
-		payload: {
-			service: 'ctsSearch',
-			cacheKey: 'leadorgs',
-			requests: [
-				{
-					method: 'getTerms',
-					requestParams: {
-						category: 'lead_org',
-						additionalParams: {
-							term: searchText,
-							sort: 'term',
-							current_trial_statuses: ACTIVE_TRIAL_STATUSES,
-						},
-						size,
-					},
-				},
-			],
-		},
-	};
-}
-
 export function searchTrials({ cacheKey, data }) {
 	return {
 		type: '@@api/CTS',

--- a/src/store/actionsV2/__tests__/getLeadOrgAction.test.js
+++ b/src/store/actionsV2/__tests__/getLeadOrgAction.test.js
@@ -1,0 +1,37 @@
+import { ACTIVE_TRIAL_STATUSES } from '../../../constants';
+import { getLeadOrgAction } from '../getLeadOrgAction';
+
+describe('getLeadOrgAction', () => {
+	it('should match returned object', () => {
+		const searchText = 'brown';
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const expectedAction = {
+			type: '@@api/CTSv2',
+			payload: {
+				service: 'ctsSearchV2',
+				cacheKey: 'leadorgs',
+				method: 'getLeadOrg',
+				requestParams: requestQuery,
+			},
+		};
+
+		expect(getLeadOrgAction({ searchText })).toEqual(expectedAction);
+	});
+
+	it('handles exception when called without a search text parameter', () => {
+		expect(() => {
+			getLeadOrgAction({ searchText: null });
+		}).toThrow('You must specify a lead org in order to fetch it.');
+	});
+});

--- a/src/store/actionsV2/getLeadOrgAction.js
+++ b/src/store/actionsV2/getLeadOrgAction.js
@@ -1,0 +1,35 @@
+import { ACTIVE_TRIAL_STATUSES } from '../../constants';
+
+/**
+ * Gets a list of lead org from the CTS api matching the search text and request filters provided
+ * @param {Number} from - the offset to start results from
+ * @param {String} searchText - free text string matching lead org name
+ * @param size - the number of results
+ * @return {{payload: {cacheKey: string, service: string, requests: [{method: string, requestParams: {include: [string], current_trial_status: string[], size: number, name: *, from: number}}]}, type: string}}
+ */
+export const getLeadOrgAction = ({ from = 0, searchText, size = 10 }) => {
+	if (!searchText || searchText === '') {
+		throw new Error('You must specify a lead org in order to fetch it.');
+	}
+
+	const requestQuery = {
+		agg_field: 'lead_org',
+		agg_name: searchText,
+		agg_field_sort: 'agg_field',
+		agg_field_order: 'asc',
+		current_trial_status: ACTIVE_TRIAL_STATUSES,
+		include: ['none'],
+		from,
+		size,
+	};
+
+	return {
+		type: '@@api/CTSv2',
+		payload: {
+			service: 'ctsSearchV2',
+			cacheKey: 'leadorgs',
+			method: 'getLeadOrg',
+			requestParams: requestQuery,
+		},
+	};
+};

--- a/src/store/actionsV2/index.js
+++ b/src/store/actionsV2/index.js
@@ -1,0 +1,1 @@
+export { getLeadOrgAction } from './getLeadOrgAction';

--- a/src/utilities/__tests__/createTermDataFromAggregate.js
+++ b/src/utilities/__tests__/createTermDataFromAggregate.js
@@ -1,0 +1,34 @@
+import { createTermDataFromAggregate } from '../createTermDataFromAggregate';
+
+describe('createTermDataFromAggregate', () => {
+	it('should check returned array matches expected shape', () => {
+		const data = [
+			{ key: 'Test Key 1' },
+			{ key: 'Test Key 2' },
+			{ key: 'Test Key 3' },
+		];
+
+		const expectedData = [
+			{ term: 'Test Key 1', termKey: 'Test Key 1' },
+			{ term: 'Test Key 2', termKey: 'Test Key 2' },
+			{ term: 'Test Key 3', termKey: 'Test Key 3' },
+		];
+
+		expect(createTermDataFromAggregate(data)).toEqual(expectedData);
+	});
+
+	it('should return an empty array when key property is not present in array of objects', () => {
+		const data = [
+			{ item: 'Test Key 1' },
+			{ item: 'Test Key 2' },
+			{ item: 'Test Key 3' },
+		];
+
+		expect(createTermDataFromAggregate(data)).toEqual([]);
+	});
+
+	it('should return an empty array if called without a parameter, or if array parameter provided is empty', () => {
+		expect(createTermDataFromAggregate()).toEqual([]);
+		expect(createTermDataFromAggregate([])).toEqual([]);
+	});
+});

--- a/src/utilities/createTermDataFromAggregate.js
+++ b/src/utilities/createTermDataFromAggregate.js
@@ -1,0 +1,23 @@
+/**
+ * Creates an array of objects with "term" and "termKey" as object properties
+ * populated with value of "key" property from an array of objects provided as parameter
+ * @param {array} data - An array containing objects with a "key" property
+ * @return {({termKey: *, term: *})[]|*[]}
+ */
+export const createTermDataFromAggregate = (data = []) => {
+	const retArray = data
+		.map((dataObj) => {
+			const { key } = dataObj;
+
+			// Early exit and return null if key is undefined
+			if (!key) {
+				return null;
+			}
+
+			const retObj = { term: key, termKey: key };
+			return retObj;
+		})
+		.filter(Boolean);
+
+	return retArray.length ? retArray : [];
+};

--- a/src/utilities/index.js
+++ b/src/utilities/index.js
@@ -29,3 +29,4 @@ export { EDDLAnalyticsHandler } from './eddl-analytics-handler';
 export { runQueryFetchers } from './runQueryFetchers';
 export { hasSCOBeenUpdated } from './hasSCOBeenUpdated';
 export { filterSitesByActiveRecruitment } from './filterSitesByActiveRecruitment';
+export { createTermDataFromAggregate } from './createTermDataFromAggregate';

--- a/src/utilities/matchItemToTerm.js
+++ b/src/utilities/matchItemToTerm.js
@@ -1,15 +1,3 @@
 export function matchItemToTerm(item, value) {
 	return item.term.toLowerCase().indexOf(value.toLowerCase()) !== -1;
 }
-
-export function sortItems(a, b, value) {
-	const aLower = a.term.toLowerCase();
-	const bLower = b.term.toLowerCase();
-	const valueLower = value.toLowerCase();
-	const queryPosA = aLower.indexOf(valueLower);
-	const queryPosB = bLower.indexOf(valueLower);
-	if (queryPosA !== queryPosB) {
-		return queryPosA - queryPosB;
-	}
-	return aLower < bLower ? -1 : 1;
-}

--- a/support/mock-data/v2/trials/lead_org__bar__10.json
+++ b/support/mock-data/v2/trials/lead_org__bar__10.json
@@ -1,0 +1,12 @@
+{
+	"total":7363,
+	"aggregations":{
+		"doc_count":1,
+		"lead_org":[
+			{
+				"key":"Barretos Cancer Hospital",
+				"doc_count":1
+			}
+		]
+	}
+}

--- a/support/mock-data/v2/trials/lead_org__barretos cancer hospital__10.json
+++ b/support/mock-data/v2/trials/lead_org__barretos cancer hospital__10.json
@@ -1,0 +1,12 @@
+{
+	"total":7363,
+	"aggregations":{
+		"doc_count":1,
+		"lead_org":[
+			{
+				"key":"Barretos Cancer Hospital",
+				"doc_count":1
+			}
+		]
+	}
+}

--- a/support/mock-data/v2/trials/lead_org__bro__10.json
+++ b/support/mock-data/v2/trials/lead_org__bro__10.json
@@ -1,0 +1,20 @@
+{
+	"total":7357,
+	"aggregations":{
+		"doc_count":4,
+		"lead_org":[
+			{
+				"key":"Brown University",
+				"doc_count":2
+			},
+			{
+				"key":"Stony Brook University Medical Center",
+				"doc_count":1
+			},
+			{
+				"key":"The James Graham Brown Cancer Center at University of Louisville",
+				"doc_count":1
+			}
+		]
+	}
+}

--- a/support/mock-data/v2/trials/lead_org__brow__10.json
+++ b/support/mock-data/v2/trials/lead_org__brow__10.json
@@ -1,0 +1,16 @@
+{
+	"total":7357,
+	"aggregations":{
+		"doc_count":3,
+		"lead_org":[
+			{
+				"key":"Brown University",
+				"doc_count":2
+			},
+			{
+				"key":"The James Graham Brown Cancer Center at University of Louisville",
+				"doc_count":1
+			}
+		]
+	}
+}

--- a/support/mock-data/v2/trials/lead_org__brown university__10.json
+++ b/support/mock-data/v2/trials/lead_org__brown university__10.json
@@ -1,0 +1,12 @@
+{
+	"total":7357,
+	"aggregations":{
+		"doc_count":2,
+		"lead_org":[
+			{
+				"key":"Brown University",
+				"doc_count":2
+			}
+		]
+	}
+}

--- a/support/mock-data/v2/trials/lead_org__brown__10.json
+++ b/support/mock-data/v2/trials/lead_org__brown__10.json
@@ -1,0 +1,16 @@
+{
+	"total":7357,
+	"aggregations":{
+		"doc_count":3,
+		"lead_org":[
+			{
+				"key":"Brown University",
+				"doc_count":2
+			},
+			{
+				"key":"The James Graham Brown Cancer Center at University of Louisville",
+				"doc_count":1
+			}
+		]
+	}
+}

--- a/support/src/mock-clinical-trials/trials.js
+++ b/support/src/mock-clinical-trials/trials.js
@@ -10,82 +10,81 @@ const accessAsync = util.promisify(fs.access);
 
 /**
  * Mock handler for posting to /v1/terms endpoint
- * 
+ *
  * @param {Express.Request} req
  * @param {Express.Response} res
  * @param {Function} next
  */
 const trialsPost = async (req, res, next) => {
-  res.status(501).end();
-}
+	res.status(501).end();
+};
 
 /**
  * Mock handler for posting to /trials endpoint
- * 
+ *
  * @param {Express.Request} req
  * @param {Express.Response} res
  * @param {Function} next
  */
 const trialsGet = async (req, res, next) => {
-  const { agg_field, current_trial_status, agg_name, size } = req.query;
+	const { agg_field, current_trial_status, agg_name, size } = req.query;
 
-  // First strip off current_trial_status and ensure it matches our required types.
-  // This way we don't have to make it part of the file name.
-  if (!isValidTrialStatusList(current_trial_status)) {
-    // Let's do a 400 here instead of 404 given it is less a mock is not found
-    // but your request is broken.
-    res.status(400).end();
-    return;
-  }
+	// First strip off current_trial_status and ensure it matches our required types.
+	// This way we don't have to make it part of the file name.
+	if (!isValidTrialStatusList(current_trial_status)) {
+		// Let's do a 400 here instead of 404 given it is less a mock is not found
+		// but your request is broken.
+		res.status(400).end();
+		return;
+	}
 
-  // File naming is
-  // <term>_<term_type>_<size>_<sort>
+	// File naming is
+	// <term>_<term_type>_<size>_<sort>
 
-  // TODO: This needs to be sanitized.
+	// TODO: This needs to be sanitized.
 
-  const agg_name_fragment = agg_name ? agg_name.toLowerCase() : "empty";
-  const size_fragment = size ? size : "empty";
-  const agg_field_fragment = agg_field ? agg_field : "empty";
-  const fileName = `${agg_field_fragment}__${agg_name_fragment}__${size_fragment}.json`;
+	const agg_name_fragment = agg_name ? agg_name.toLowerCase() : 'empty';
+	const size_fragment = size ? size : 'empty';
+	const agg_field_fragment = agg_field ? agg_field : 'empty';
+	const fileName = `${agg_field_fragment}__${agg_name_fragment}__${size_fragment}.json`;
 
-  const mockFile = path.join(
-    __dirname,
-    '..',
-    '..',
-    'mock-data',
-    'v2',
-    'trials',
-    fileName
-  )
+	const mockFile = path.join(
+		__dirname,
+		'..',
+		'..',
+		'mock-data',
+		'v2',
+		'trials',
+		fileName
+	);
 
-  try {
-    await accessAsync(mockFile);
-    res.sendFile(mockFile);
-  } catch (err) {
-      // Access denied to open file, or not found.
-      // treat at 404, or your choice.
-      console.error(err);
-      res.status(404).end();
-  }
-
-}
+	try {
+		await accessAsync(mockFile);
+		res.sendFile(mockFile);
+	} catch (err) {
+		// Access denied to open file, or not found.
+		// treat at 404, or your choice.
+		console.error(err);
+		res.status(404).end();
+	}
+};
 
 /**
  * Entry point for /v2/trials requests.
- * 
+ *
  * @param {Express.Request} req
  * @param {Express.Response} res
  * @param {Function} next
  */
 const mockTrials = async (req, res, next) => {
-  if (req.method === 'GET') {
-    return trialsGet(req, res, next);
-  } else if (req.method === 'POST') {
-    return trialsPost(req, res, next);
-  } else {
-    // Method not allowed
-    res.status(405).end();
-  }
-} 
+	if (req.method === 'GET') {
+		return trialsGet(req, res, next);
+	} else if (req.method === 'POST') {
+		return trialsPost(req, res, next);
+	} else {
+		// Method not allowed
+		res.status(405).end();
+	}
+};
 
 module.exports = mockTrials;


### PR DESCRIPTION
Closes #416

* Created clone `CTSMiddlewareV2.js` from `CTSMiddleware.js` and updated name in file
* Added `ctsMiddlewarev2` to store
* Updated `ctsSearch` helper function to support multiple version
* Removed support on cts client library for `CTSMiddlewareV2`
* No longer passing in version to `ctsSearch`
* Added `ctsApiEndpointV1` and `ctsApiEndpointV2` initialization parameters
* Removed test case for getLeadOrg call
* Fixed api endpoint in `index.html` and added `ctsApiEndpointV1` to beforeEach to fix failing tests

Closes #426

* Added fetch action `getLeadOrgAction`
* Added fetch action call to `LeadOrganization.jsx`
* Updated utilities `matchItemToTerm` and `sortItems` to reflect key name change from api
* Removed `searchLeadOrg` action from `actions.js`
* Added unit tests
* Added `getLeadOrg` call to `CTSMiddlewareV2`
* Updated comment
* Added v2 endpoint to `beforeEach` for mocks
* Fixed override order in `src/index.js`
* Added `createTermDataFromKey` to transform api data for ui
* Added mock files
* Added `.highlight` class selector to step definition to fix failing test
* Updated name from `createTermDataFromKey` to `createTermDataFromAggregate`
* Fixed import for `querystring` to `query-string`
* Split v2 fetch actions into individual files and added unit test