### PR TITLE
(#426) Create searchLeadOrg Fetcher

### DIFF
--- a/src/services/api/clinical-trials-search-api/__tests__/getLeadOrg.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/getLeadOrg.test.js
@@ -1,0 +1,176 @@
+import axios from 'axios';
+import querystring from 'querystring';
+import nock from 'nock';
+
+import clinicalTrialsSearchClientFactory from '../clinicalTrialsSearchClientFactory';
+import { ACTIVE_TRIAL_STATUSES } from '../../../../constants';
+import { getLeadOrg } from '../getLeadOrg';
+import { getLeadOrgAction } from '../../../../store/actionsV2';
+
+// Required for unit tests to not have CORS issues
+axios.defaults.adapter = require('axios/lib/adapters/http');
+
+const client = clinicalTrialsSearchClientFactory('http://example.org');
+
+describe('getLeadOrg', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	it('makes a request to the api and matches returned result for specified search text', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const result = {
+			total: 7358,
+			aggregations: {
+				doc_count: 419,
+				lead_org: [
+					{
+						key: 'Barretos Cancer Hospital',
+						doc_count: 1,
+					},
+					{
+						key: "Boston Children's Hospital",
+						doc_count: 1,
+					},
+					{
+						key: "Children's Hospital Colorado",
+						doc_count: 11,
+					},
+					{
+						key: "Children's Hospital Los Angeles",
+						doc_count: 4,
+					},
+					{
+						key: "Children's Hospital and Medical Center of Omaha",
+						doc_count: 1,
+					},
+					{
+						key: "Children's Hospital of Philadelphia",
+						doc_count: 12,
+					},
+					{
+						key: "Children's Hospital of Pittsburgh of UPMC",
+						doc_count: 5,
+					},
+					{
+						key: "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+						doc_count: 3,
+					},
+					{
+						key: "Cincinnati Children's Hospital Medical Center",
+						doc_count: 2,
+					},
+					{
+						key: 'Emory University Hospital/Winship Cancer Institute',
+						doc_count: 71,
+					},
+				],
+			},
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(200, result);
+		const response = await getLeadOrg(client, query.payload.requestParams);
+		expect(response).toEqual(result);
+		scope.isDone();
+	});
+
+	it('throws a 404 error', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(404);
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('Unexpected status 404 for fetching lead organization');
+		scope.isDone();
+	});
+
+	it('throws a 500 error status', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.reply(500);
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('Unexpected status 500 for fetching lead organization');
+		scope.isDone();
+	});
+
+	it('handles an error thrown by http client', async () => {
+		const searchText = 'hos';
+
+		const query = getLeadOrgAction({ searchText });
+
+		const requestQuery = {
+			agg_field: 'lead_org',
+			agg_name: searchText,
+			agg_field_sort: 'agg_field',
+			agg_field_order: 'asc',
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			include: ['none'],
+			from: 0,
+			size: 10,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/trials?${querystring.stringify(requestQuery)}`)
+			.replyWithError('connection refused');
+		await expect(
+			getLeadOrg(client, query.payload.requestParams)
+		).rejects.toThrow('connection refused');
+		scope.isDone();
+	});
+});

--- a/src/services/api/clinical-trials-search-api/getLeadOrg.js
+++ b/src/services/api/clinical-trials-search-api/getLeadOrg.js
@@ -1,0 +1,29 @@
+import querystring from 'querystring';
+
+/**
+ * Fetches lead orgs to populate the Lead Organization field
+ *
+ * @param {import("axios").AxiosInstance} client An axios instance with the correct baseURL
+ * @param {object} query the cts query
+ */
+export const getLeadOrg = async (client, query) => {
+	try {
+		const res = await client.get(`/trials?${querystring.stringify(query)}`);
+		if (res.status === 200) {
+			return res.data;
+		} else {
+			// This condition will be hit for anything < 300.
+			throw new Error(
+				`Unexpected status ${res.status} for fetching lead organization`
+			);
+		}
+	} catch (error) {
+		// This conditional will be hit for any status >= 300.
+		if (error.response) {
+			throw new Error(
+				`Unexpected status ${error.response.status} for fetching lead organization`
+			);
+		}
+		throw error;
+	}
+};

--- a/src/services/api/clinical-trials-search-api/index.js
+++ b/src/services/api/clinical-trials-search-api/index.js
@@ -1,3 +1,4 @@
 export { default as default } from './clinicalTrialsSearchClientFactory';
 export { getClinicalTrialDescription } from './getClinicalTrialDescription';
 export { getClinicalTrials } from './getClinicalTrials';
+export { getLeadOrg } from './getLeadOrg';

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -437,33 +437,6 @@ export function searchTrialInvestigators({ searchText, size = 10 } = {}) {
 	};
 }
 
-/**
- * Gets lead orgs to populate the Lead Organization field
- */
-export function searchLeadOrg({ searchText, size = 10 } = {}) {
-	return {
-		type: '@@api/CTS',
-		payload: {
-			service: 'ctsSearch',
-			cacheKey: 'leadorgs',
-			requests: [
-				{
-					method: 'getTerms',
-					requestParams: {
-						category: 'lead_org',
-						additionalParams: {
-							term: searchText,
-							sort: 'term',
-							current_trial_statuses: ACTIVE_TRIAL_STATUSES,
-						},
-						size,
-					},
-				},
-			],
-		},
-	};
-}
-
 export function searchTrials({ cacheKey, data }) {
 	return {
 		type: '@@api/CTS',

--- a/src/store/actionsV2.js
+++ b/src/store/actionsV2.js
@@ -1,0 +1,31 @@
+import { ACTIVE_TRIAL_STATUSES } from '../constants';
+
+/**
+ * Gets a list of lead org from the CTS api matching the search text and request filters provided
+ * @param {Number} from - the offset to start results from
+ * @param {String} searchText - free text string matching lead org name
+ * @param size - the number of results
+ * @return {{payload: {cacheKey: string, service: string, requests: [{method: string, requestParams: {include: [string], current_trial_status: string[], size: number, name: *, from: number}}]}, type: string}}
+ */
+export const getLeadOrgAction = ({ from = 0, searchText, size = 10 }) => {
+	const requestQuery = {
+		agg_field: 'lead_org',
+		agg_name: searchText,
+		agg_field_sort: 'agg_field',
+		agg_field_order: 'asc',
+		current_trial_status: ACTIVE_TRIAL_STATUSES,
+		include: ['none'],
+		from,
+		size,
+	};
+
+	return {
+		type: '@@api/CTSv2',
+		payload: {
+			service: 'ctsSearchV2',
+			cacheKey: 'leadorgs',
+			method: 'getLeadOrg',
+			requestParams: requestQuery,
+		},
+	};
+};

--- a/src/utilities/matchItemToTerm.js
+++ b/src/utilities/matchItemToTerm.js
@@ -1,15 +1,3 @@
 export function matchItemToTerm(item, value) {
-	return item.term.toLowerCase().indexOf(value.toLowerCase()) !== -1;
-}
-
-export function sortItems(a, b, value) {
-	const aLower = a.term.toLowerCase();
-	const bLower = b.term.toLowerCase();
-	const valueLower = value.toLowerCase();
-	const queryPosA = aLower.indexOf(valueLower);
-	const queryPosB = bLower.indexOf(valueLower);
-	if (queryPosA !== queryPosB) {
-		return queryPosA - queryPosB;
-	}
-	return aLower < bLower ? -1 : 1;
+	return item.key.toLowerCase().indexOf(value.toLowerCase()) !== -1;
 }

--- a/src/utilities/sortItems.js
+++ b/src/utilities/sortItems.js
@@ -1,6 +1,6 @@
 export function sortItems(a, b, value) {
-	const aLower = a.term.toLowerCase();
-	const bLower = b.term.toLowerCase();
+	const aLower = a.key.toLowerCase();
+	const bLower = b.key.toLowerCase();
 	const valueLower = value.toLowerCase();
 	const queryPosA = aLower.indexOf(valueLower);
 	const queryPosB = bLower.indexOf(valueLower);


### PR DESCRIPTION
Closes #426

* Added fetch action `getLeadOrgAction`
* Added fetch action call to `LeadOrganization.jsx`
* Updated utilities `matchItemToTerm` and `sortItems` to reflect key name change from api
* Removed `searchLeadOrg` action from `actions.js`
* Added unit tests