### PR TITLE
(#403, #447) Change ResultsListItem to use Location Data from SCO, Remove Title Caching from TrialDescrip

### DIFF
--- a/cypress/integration/AdvancedSearchPage/LocationSection/LocationLimitedToVA.feature
+++ b/cypress/integration/AdvancedSearchPage/LocationSection/LocationLimitedToVA.feature
@@ -65,8 +65,8 @@ Scenario: User has an option to limit results to VA facilities and all locations
             | rl        | 2     |
             | zp        | 500   |
             | va        | 1     |
-        # Same as above for disabled step
-				# And the 1 result item has a "Location:" info with "1390 locations, including 5 near you"
+
+			  And the 1 result item has a "Location:" info with "1390 locations, including 5 near you"
         When user clicks on Modify Search Criteria button
         Then "U.S. ZIP Code" input field has a value "22182"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "Yes"
@@ -88,8 +88,7 @@ Scenario: User has an option to limit results to VA facilities and all locations
             | rl        | 2     |
             | zp        | 200   |
             | va        | 1     |
-        # Same as above for disabled step
-	      # And the 1 result item has a "Location:" info with "703 locations, including 1 near you"
+			  And the 1 result item has a "Location:" info with "703 locations, including 1 near you"
         When user clicks on 1 trial link
         When user clicks on "Locations & Contacts" section of accordion
         And button "Show all locations" is displayed
@@ -126,8 +125,7 @@ Scenario: User has an option to limit results to VA facilities and all locations
             | lcty      | Richmond      |
             | lst       | VA            |
             | va        | 1             |
-        # Same as above for disabled step
-	      # And the 1 result item has a "Location:" info with "703 locations, including 1 near you"
+			  And the 1 result item has a "Location:" info with "703 locations, including 1 near you"
         When user clicks on 1 trial link
         When user clicks on "Locations & Contacts" section of accordion
         And button "Show all locations" is displayed

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -107,4 +107,5 @@ export const defaultSCOState = {
 	resultsPage: 0,
 	formType: '', // (empty string (default) | basic | advanced)
 	location: 'search-location-all', // active location option (search-location-all | search-location-zip | search-location-country | search-location-hospital | search-location-nih)
+	qs: '', // the query string associated with this SCO, defaults to loc=0&rl=1
 };

--- a/src/utilities/__tests__/defaultStateCopy.js
+++ b/src/utilities/__tests__/defaultStateCopy.js
@@ -44,6 +44,7 @@ export const defaultState = {
 
 	formType: '', // (empty string (default) | basic | advanced)
 	location: 'search-location-all', // active location option (search-location-all | search-location-zip | search-location-country | search-location-hospital | search-location-nih)
+	qs: '', // The query string associated with this SCO
 };
 describe('placeholder', () => {
 	it('placeholder', () => {

--- a/src/utilities/__tests__/queryStringToSearchCriteria.adv.disease.positive.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.adv.disease.positive.js
@@ -284,6 +284,7 @@ describe('Advanced - Disease - queryStringToSearchCriteria maps query to form', 
 				searchCriteria: {
 					...defaultState,
 					...additionalExpectedQuery,
+					qs: urlQuery,
 				},
 				errors: [],
 			};

--- a/src/utilities/__tests__/queryStringToSearchCriteria.adv.interventions.positive.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.adv.interventions.positive.js
@@ -156,6 +156,7 @@ describe('Adv - Interventions - queryStringToSearchCriteria maps query to form',
 				searchCriteria: {
 					...defaultState,
 					...additionalExpectedQuery,
+					qs: urlQuery,
 				},
 				errors: [],
 			};

--- a/src/utilities/__tests__/queryStringToSearchCriteria.adv.loc.positive.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.adv.loc.positive.js
@@ -174,6 +174,7 @@ describe('Adv - Locations - queryStringToSearchCriteria maps query to form', () 
 				searchCriteria: {
 					...defaultState,
 					...additionalExpectedQuery,
+					qs: urlQuery,
 				},
 				errors: [],
 			};

--- a/src/utilities/__tests__/queryStringToSearchCriteria.adv.positive.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.adv.positive.js
@@ -270,6 +270,7 @@ describe('Adv - queryStringToSearchCriteria maps query to form', () => {
 				searchCriteria: {
 					...defaultState,
 					...additionalExpectedQuery,
+					qs: urlQuery,
 				},
 				errors: [],
 			};

--- a/src/utilities/__tests__/queryStringToSearchCriteria.basic.positive.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.basic.positive.js
@@ -135,6 +135,7 @@ describe('Basic - queryStringToSearchCriteria maps query to form', () => {
 				searchCriteria: {
 					...defaultState,
 					...additionalExpectedQuery,
+					qs: urlQuery,
 				},
 				errors: [],
 			};

--- a/src/utilities/__tests__/queryStringToSearchCriteria.other.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.other.js
@@ -30,6 +30,7 @@ describe('Basic - queryStringToSearchCriteria maps query to form', () => {
 			searchCriteria: {
 				...defaultState,
 				formType: 'custom',
+				qs: 'r=1',
 			},
 			errors: [],
 		};

--- a/src/utilities/hasSCOBeenUpdated.js
+++ b/src/utilities/hasSCOBeenUpdated.js
@@ -1,10 +1,13 @@
 import { defaultSCOState } from '../constants';
 
 export const hasSCOBeenUpdated = (searchCriteriaObject) => {
+	// We are overriding the formType, resultsPage, and qs since they
+	// are allowed to differ compared to the defaultSCOState
 	const SCOcomparator = {
 		...searchCriteriaObject,
 		formType: '',
 		resultsPage: 0,
+		qs: '',
 	};
 	return JSON.stringify(defaultSCOState) === JSON.stringify(SCOcomparator);
 };

--- a/src/utilities/queryStringToSearchCriteria.js
+++ b/src/utilities/queryStringToSearchCriteria.js
@@ -70,6 +70,7 @@ const defaultState = {
 	resultsPage: 0,
 	formType: '', // (empty string (default) | basic | advanced)
 	location: 'search-location-all', // active location option (search-location-all | search-location-zip | search-location-country | search-location-hospital | search-location-nih)
+	qs: '', //store the incoming QS
 };
 
 /**
@@ -86,9 +87,15 @@ export const queryStringToSearchCriteria = async (
 	interventionsFetcher,
 	zipcodeFetcher
 ) => {
+	// Store the incoming queryString
 	// Setup the two items we will be modifying throughout the parsing.
 	let rtnErrorsList = [];
 	let rtnSearchCriteria = { ...defaultState };
+
+	rtnSearchCriteria = {
+		...rtnSearchCriteria,
+		qs: urlQuery,
+	};
 
 	const query = queryString.parse(urlQuery, {
 		parseBooleans: true,

--- a/src/views/ResultsPage/ResultsList.jsx
+++ b/src/views/ResultsPage/ResultsList.jsx
@@ -6,7 +6,6 @@ const ResultsList = ({
 	selectedResults,
 	setSelectedResults,
 	setSelectAll,
-	queryParams,
 	searchCriteriaObject,
 }) => {
 	const { resultsPage, formType } = searchCriteriaObject;
@@ -34,7 +33,7 @@ const ResultsList = ({
 			{results.map((item, idx) => {
 				return (
 					<ResultsListItem
-						queryParams={queryParams}
+						searchCriteria={searchCriteriaObject}
 						key={item.nci_id}
 						id={item.nci_id}
 						item={item}
@@ -58,7 +57,6 @@ ResultsList.propTypes = {
 	selectedResults: PropTypes.array,
 	results: PropTypes.array,
 	setSelectAll: PropTypes.func,
-	queryParams: PropTypes.string,
 };
 
 ResultsList.defaultProps = {

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { useSelector, useDispatch } from 'react-redux';
+import * as queryString from 'query-string';
+import { useDispatch } from 'react-redux';
 import { receiveData } from '../../store/actions';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
@@ -12,26 +13,26 @@ import {
 import { NIH_ZIPCODE } from '../../constants';
 import { useTracking } from 'react-tracking';
 import { useAppSettings } from '../../store/store.js';
-const queryString = require('query-string');
 
 const ResultsListItem = ({
 	id,
 	item,
 	isChecked,
 	onCheckChange,
-	queryParams,
+	searchCriteria,
 	itemIndex,
 	resultsPage,
 	formType,
 }) => {
 	const dispatch = useDispatch();
-	// TODO -- https://github.com/NCIOCPL/clinical-trials-search-app/issues/403
-	const { zipCoords, zipRadius, location, country, states, city, vaOnly } =
-		useSelector((store) => store.form);
+
+	const { zipCoords, zipRadius, location, country, states, city, vaOnly, qs } =
+		searchCriteria;
+
 	const [{ analyticsName }] = useAppSettings();
 	const tracking = useTracking();
 
-	const qsQbj = queryString.parse(queryParams);
+	const qsQbj = queryString.parse(qs);
 	qsQbj.id = item.nci_id;
 	const itemQueryString = queryString.stringify(qsQbj, {
 		arrayFormat: 'none',
@@ -300,7 +301,7 @@ ResultsListItem.propTypes = {
 	item: PropTypes.object,
 	isChecked: PropTypes.bool,
 	onCheckChange: PropTypes.func.isRequired,
-	queryParams: PropTypes.string,
+	searchCriteria: PropTypes.object,
 	itemIndex: PropTypes.number,
 	resultsPage: PropTypes.number,
 	formType: PropTypes.string,

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import * as queryString from 'query-string';
-import { useDispatch } from 'react-redux';
-import { receiveData } from '../../store/actions';
 import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 import Checkbox from '../../components/atomic/Checkbox';
@@ -24,8 +22,6 @@ const ResultsListItem = ({
 	resultsPage,
 	formType,
 }) => {
-	const dispatch = useDispatch();
-
 	const { zipCoords, zipRadius, location, country, states, city, vaOnly, qs } =
 		searchCriteria;
 
@@ -233,10 +229,6 @@ const ResultsListItem = ({
 		}`;
 	};
 
-	const setCachedTitle = () => {
-		dispatch(receiveData('currentTrialTitle', item.brief_title));
-	};
-
 	const handleLinkClick = () => {
 		tracking.trackEvent({
 			// These properties are required.
@@ -250,7 +242,6 @@ const ResultsListItem = ({
 			formType,
 			linkName: 'UnknownLinkName',
 		});
-		setCachedTitle();
 	};
 
 	return (
@@ -270,6 +261,7 @@ const ResultsListItem = ({
 				<div className="results-list-item__title">
 					<Link
 						to={`/about-cancer/treatment/clinical-trials/search/v?${itemQueryString}`}
+						state={{ result: item }}
 						onClick={handleLinkClick}>
 						{item.brief_title}
 					</Link>

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -36,7 +36,7 @@ import {
 	setSelectAll,
 	setFetchActions,
 	setSearchCriteriaObject,
-} from '../resultsPageReducer';
+} from './resultsPageReducer';
 
 import { useCtsApi } from '../../hooks/ctsApiSupport';
 import { getClinicalTrialsAction } from '../../services/api/actions';
@@ -627,7 +627,6 @@ const ResultsPage = () => {
 									<>{renderNoResults()}</>
 								) : (
 									<ResultsList
-										queryParams={qs}
 										results={trialResults.trials}
 										selectedResults={selectedResults}
 										setSelectedResults={setSelectedResults}
@@ -652,12 +651,14 @@ const ResultsPage = () => {
 					{renderDelighters()}
 				</aside>
 			</article>
-			<Modal isShowing={isShowing} hide={toggleModal}>
-				<PrintModalContent
-					selectedList={selectedResults}
-					searchCriteriaObject={searchCriteriaObject}
-				/>
-			</Modal>
+			{searchCriteriaObject && (
+				<Modal isShowing={isShowing} hide={toggleModal}>
+					<PrintModalContent
+						selectedList={selectedResults}
+						searchCriteriaObject={searchCriteriaObject}
+					/>
+				</Modal>
+			)}
 		</>
 	);
 };

--- a/src/views/ResultsPage/resultsPageReducer.js
+++ b/src/views/ResultsPage/resultsPageReducer.js
@@ -1,4 +1,4 @@
-import { convertObjectToBase64 } from '../utilities/objects';
+import { convertObjectToBase64 } from '../../utilities/objects';
 
 // Action type declarations
 // Let's use some constants for our state var so we can handle

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -1,7 +1,7 @@
 import queryString from 'query-string';
 import React, { useEffect, useReducer } from 'react';
 import { Helmet } from 'react-helmet';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useTracking } from 'react-tracking';
 import { START_OVER_LINK } from '../../constants';
@@ -35,9 +35,11 @@ const TrialDescriptionPage = () => {
 	const parsed = queryString.parse(qs);
 	const currId = parsed.id;
 
-	const trialTitle = useSelector((store) => store.cache.currentTrialTitle);
+	// Note: Location state only exists if navigating.
+	// If the trial description is directly navigated to this will be empty
+	// on first render
+	const trialTitle = location.state ? location.state.result.brief_title : '';
 	const tracking = useTracking();
-
 	const initialState = {
 		errors: [],
 		fetchActions: [],
@@ -269,35 +271,42 @@ const TrialDescriptionPage = () => {
 	};
 
 	const renderTrialDescriptionHeader = (searchCriteriaObject) => {
-		return (
-			<div className="trial-description-page__header">
-				{searchCriteriaObject && searchCriteriaObject.formType != '' && (
-					<div className="back-to-search btnAsLink">
-						<span
-							onClick={() => navigate(-1)}
-							onKeyDown={() => navigate(-1)}
-							tabIndex="0"
-							role="button">
-							&lt; Back to search results
-						</span>
-					</div>
-				)}
-				{searchCriteriaObject && !hasSCOBeenUpdated(searchCriteriaObject) ? (
-					<>
-						<strong>This clinical trial matches:</strong>
-						<SearchCriteriaTableUpdated
-							searchCriteriaObject={searchCriteriaObject}
-						/>
-					</>
-				) : (
-					<>
-						<strong>This clinical trial matches: &quot;all trials&quot;</strong>{' '}
-						|{' '}
-					</>
-				)}
-				{renderStartOver(searchCriteriaObject)}
-			</div>
-		);
+		if (
+			searchCriteriaObject.formType === 'basic' ||
+			searchCriteriaObject.formType === 'advanced'
+		) {
+			return (
+				<div className="trial-description-page__header">
+					{searchCriteriaObject && searchCriteriaObject.formType != '' && (
+						<div className="back-to-search btnAsLink">
+							<span
+								onClick={() => navigate(-1)}
+								onKeyDown={() => navigate(-1)}
+								tabIndex="0"
+								role="button">
+								&lt; Back to search results
+							</span>
+						</div>
+					)}
+					{searchCriteriaObject && !hasSCOBeenUpdated(searchCriteriaObject) ? (
+						<>
+							<strong>This clinical trial matches:</strong>
+							<SearchCriteriaTableUpdated
+								searchCriteriaObject={searchCriteriaObject}
+							/>
+						</>
+					) : (
+						<>
+							<strong>
+								This clinical trial matches: &quot;all trials&quot;
+							</strong>{' '}
+							|{' '}
+						</>
+					)}
+					{renderStartOver(searchCriteriaObject)}
+				</div>
+			);
+		}
 	};
 
 	const renderEligibilityCriteria = () => {
@@ -464,12 +473,7 @@ const TrialDescriptionPage = () => {
 						) : (
 							<>
 								<h1>{trialDescription.brief_title}</h1>
-								{searchCriteriaObject.formType === 'basic' ||
-								searchCriteriaObject.formType === 'advanced' ? (
-									renderTrialDescriptionHeader(searchCriteriaObject)
-								) : (
-									<></>
-								)}
+								{renderTrialDescriptionHeader(searchCriteriaObject)}
 							</>
 						)}
 


### PR DESCRIPTION
(#403) Change ResultsListItem to use Location Data from SCO

* Passes SCO into ResultsListItem
* Add QS to SCO
* Removes the related Redux from ResultsListItem
* Un-comments Location tests
* Moves reducer underneath ResultsPage folder

    Closes #403


---------------



(#447) Remove the Title Caching on ResultsListItem and Trial Description Page

 * Adds the trial result to the LocationState in ResultsListItem
 * Updates TrialDescriptionPage to use the passed in item for the initial brieftitle
* Removes related redux bits

    Closes #447