### PR TITLE
(#486) Interventions - Remove Term Name From Synonyms

### DIFF
--- a/cypress/integration/AdvancedSearchPage/DrugTreatmentSection.feature
+++ b/cypress/integration/AdvancedSearchPage/DrugTreatmentSection.feature
@@ -22,7 +22,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 		When user clicks on "Treatment" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
 		And user types "polymo" in "Treatment" field
-		And user selects "Polymorphism AnalysisOther Names: Polymorphism AnalysisPolymorphism Detection" from dropdown
+		And user selects "Polymorphism AnalysisOther Names: Polymorphism Detection" from dropdown
 		When user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displays "Results 1-4  of 4 for your search "
@@ -65,7 +65,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 		And user selects "Bevacizumab" from dropdown
 		When user clicks on "Treatment" field
 		And user types "polymo" in "Treatment" field
-		And user selects "Polymorphism AnalysisOther Names: Polymorphism AnalysisPolymorphism Detection" from dropdown
+		And user selects "Polymorphism AnalysisOther Names: Polymorphism Detection" from dropdown
 		When user clicks on "Treatment" field
 		And user types "orc" in "Treatment" field
 		And user selects "Orchiectomy" from dropdown

--- a/src/services/api/clinical-trials-search-api/__tests__/getOtherInterventions.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/getOtherInterventions.test.js
@@ -47,7 +47,7 @@ describe('getOtherInterventions', () => {
 					codes: ['C64263'],
 					category: ['other'],
 					type: ['other', 'procedure/surgery'],
-					synonyms: ['Laboratory Biomarker Analysis'],
+					synonyms: [],
 					count: 836,
 				},
 				{
@@ -55,7 +55,7 @@ describe('getOtherInterventions', () => {
 					codes: ['C70945'],
 					category: ['other'],
 					type: ['procedure/surgery', 'other'],
-					synonyms: ['Biological Sample Collection', 'Biospecimen Collection'],
+					synonyms: ['Biological Sample Collection'],
 					count: 465,
 				},
 			],

--- a/src/services/api/clinical-trials-search-api/getOtherInterventions.js
+++ b/src/services/api/clinical-trials-search-api/getOtherInterventions.js
@@ -12,7 +12,17 @@ export const getOtherInterventions = async (client, query) => {
 			`/interventions?${querystring.stringify(query)}`
 		);
 		if (res.status === 200) {
-			return res.data;
+			const filteredResults = Array.isArray(res.data?.data)
+				? res.data.data.map((intervention) => {
+						return {
+							...intervention,
+							synonyms: intervention.synonyms.filter(
+								(s) => s !== intervention.name
+							),
+						};
+				  })
+				: res.data?.data;
+			return { data: filteredResults };
 		} else {
 			// This condition will be hit for anything < 300.
 			throw new Error(


### PR DESCRIPTION
Closes #486

* Added filter for `getOtherInterventions` to remove searched term name from synonym
* Updated `DrugTreatment.feature` file to remove term name from dropdown in scenario