### PR TITLE
(#494) Trial description shows blank page instead of invalid criteria page

### DIFF
--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -615,7 +615,6 @@ const ResultsPage = () => {
 				/>
 			</Helmet>
 			<article className="results-page">
-				<h1>Clinical Trials Search Results</h1>
 				{error.length && error.filter((err) => err.fieldName === 'zip') ? (
 					<>{renderInvalidZip()}</>
 				) : (
@@ -625,15 +624,19 @@ const ResultsPage = () => {
 						) : isLoading || !searchCriteriaObject ? (
 							<div className="loader__pageheader"></div>
 						) : (
-							<ResultsPageHeader
-								resultsCount={trialResults.total}
-								pageNum={currentPage}
-								onModifySearchClick={handleRefineSearch}
-								onStartOverClick={handleStartOver}
-								searchCriteriaObject={searchCriteriaObject}
-								isLoading={isLoading}
-								trialResults={trialResults}
-							/>
+							<>
+								<h1>Clinical Trials Search Results</h1>
+
+								<ResultsPageHeader
+									resultsCount={trialResults.total}
+									pageNum={currentPage}
+									onModifySearchClick={handleRefineSearch}
+									onStartOverClick={handleStartOver}
+									searchCriteriaObject={searchCriteriaObject}
+									isLoading={isLoading}
+									trialResults={trialResults}
+								/>
+							</>
 						)}
 						<div className="results-page__content">
 							{checkIfInvalidPage() ? <> </> : <>{renderControls()}</>}

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -27,6 +27,7 @@ import {
 	queryStringToSearchCriteria,
 	runQueryFetchers,
 } from '../../utilities';
+import ErrorPage from '../ErrorPage';
 
 const TrialDescriptionPage = () => {
 	const rdx_dispatch = useDispatch();
@@ -132,8 +133,17 @@ const TrialDescriptionPage = () => {
 			};
 			searchCriteria().then((res) => {
 				setSearchCriteriaObject(res.searchCriteria);
-				setFetchActions(getClinicalTrialDescriptionAction(currId));
-				rdx_dispatch(updateFormSearchCriteria(res.searchCriteria));
+
+				if (res.errors.length) {
+					ls_dispatch({
+						type: 'SET_ERRORS',
+						payload: res.errors,
+					});
+					rdx_dispatch(res.errors);
+				} else {
+					setFetchActions(getClinicalTrialDescriptionAction(currId));
+					rdx_dispatch(updateFormSearchCriteria(res.searchCriteria));
+				}
 			});
 		}
 	}, [loading, payload, searchCriteriaObject]);
@@ -382,6 +392,10 @@ const TrialDescriptionPage = () => {
 		);
 	};
 
+	const renderInvalidSearchCriteria = () => {
+		return <ErrorPage initErrorsList={localState.errors} />;
+	};
+
 	const prettifyDescription = () => {
 		let formattedStr =
 			'<p>' +
@@ -438,6 +452,7 @@ const TrialDescriptionPage = () => {
 
 	return (
 		<>
+			{localState.errors.length !== 0 && <>{renderInvalidSearchCriteria()}</>}
 			{!isTrialLoading && error && <>Error Occurred!</>}
 			{!error && (
 				<>
@@ -658,5 +673,4 @@ const TrialDescriptionPage = () => {
 		</>
 	);
 };
-
 export default TrialDescriptionPage;


### PR DESCRIPTION
 (#494) Trial description shows blank page instead of invalid criteria page
       - given invalid search Params, an invalid error page will be shown, displaying what is invalid
       - checks the localState for any errors and will render an ErrorPage accordingly
    
 Closes #494 