### PR TITLE
(#196) Remove 'no results' div from Results Page Header

### DIFF
--- a/cypress/integration/AdvancedSearchPage/LocationSection/LocationByZipcode/locationSection.js
+++ b/cypress/integration/AdvancedSearchPage/LocationSection/LocationByZipcode/locationSection.js
@@ -67,7 +67,7 @@ And('user types {string} in {string} field', (text, fieldLabel) => {
 });
 
 And('{string} no trial info is displayed', (noTrialsText) => {
-	cy.get('.no-trials-found').should('have.text', noTrialsText);
+	cy.get('.no-results').should('have.text', noTrialsText);
 });
 
 And('{string} text is displayed as results header', (resHeader) => {

--- a/cypress/integration/AdvancedSearchPage/LocationSection/LocationCountryStateCity.feature
+++ b/cypress/integration/AdvancedSearchPage/LocationSection/LocationCountryStateCity.feature
@@ -217,7 +217,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying cou
 
     Scenario: User has an option navigate directly to url with a country that doesn't return a match
         Given the user navigates to "/r?lcnty=Russia&loc=2&rl=2"
-        And "No clinical trials matched your search." no trial info is displayed
+        And "No clinical trials matched your search.For assistance, please contact the Cancer Information Service. You can chat online or call 1-800-4-CANCER (1-800-422-6237).Try a new search" no trial info is displayed
         And the criteria table displays the following
             | Category | Selection |
             | Country  | Russia    |

--- a/cypress/integration/AdvancedSearchPage/LocationSection/LocationLimitedToVA/locationSection.js
+++ b/cypress/integration/AdvancedSearchPage/LocationSection/LocationLimitedToVA/locationSection.js
@@ -67,7 +67,7 @@ And('user types {string} in {string} field', (text, fieldLabel) => {
 });
 
 And('{string} no trial info is displayed', (noTrialsText) => {
-	cy.get('.no-trials-found').should('have.text', noTrialsText);
+	cy.get('.no-results').should('have.text', noTrialsText);
 });
 
 And('{string} text is displayed as results header', (resHeader) => {

--- a/cypress/integration/Components/Autocomplete.feature
+++ b/cypress/integration/Components/Autocomplete.feature
@@ -78,7 +78,7 @@ Feature: As a user, I want to be able to use autocomplete features to it's full 
         Then autocomplete dropdown is displayed
         When user types "bre" in "Cancer Type/Keyword" field
         When user presses "enter" key from "Cancer Type/Keyword" field
-        Then "No clinical trials matched your search." no trial info is displayed
+			 Then "No clinical trials matched your search.For assistance, please contact the Cancer Information Service. You can chat online or call 1-800-4-CANCER (1-800-422-6237).Try a new search" no trial info is displayed
         And the criteria table displays the following
             | Category         | Selection |
             | Keywords/Phrases | bre       |

--- a/cypress/integration/Components/Autocomplete/index.js
+++ b/cypress/integration/Components/Autocomplete/index.js
@@ -81,7 +81,7 @@ And('the criteria table displays the following', (dataTable) => {
 });
 
 And('{string} no trial info is displayed', (noTrialsText) => {
-	cy.get('.no-trials-found').should('have.text', noTrialsText);
+	cy.get('.no-results').should('have.text', noTrialsText);
 });
 
 When('user selects {string} by touching the menu', (value) => {

--- a/cypress/integration/SearchResultsPage/GeneralPageComponents.feature
+++ b/cypress/integration/SearchResultsPage/GeneralPageComponents.feature
@@ -188,7 +188,7 @@ Feature: Clinical Trials Search Results Page Components
 	#### no results page ######
 	Scenario: user navigates to no Trials found page, modifies search and able to see results found
 		Given the user navigates to "/r?fin=C18673&loc=0&rl=2&st=C8287&stg=C94774&t=C4872"
-		And "No clinical trials matched your search." no trial info is displayed
+		And "No clinical trials matched your search.For assistance, please contact the Cancer Information Service. You can chat online or call 1-800-4-CANCER (1-800-422-6237).Try a new search" no trial info is displayed
 		And the criteria table displays the following
 			| Category                                           | Selection                 |
 			| Primary Cancer Type/Condition                      | Breast Cancer             |

--- a/cypress/integration/SearchResultsPage/GeneralPageComponents/index.js
+++ b/cypress/integration/SearchResultsPage/GeneralPageComponents/index.js
@@ -158,7 +158,7 @@ And('the following delighters are displayed', (dataTable) => {
 });
 
 And('{string} no trial info is displayed', (noTrialsText) => {
-	cy.get('.no-trials-found').should('have.text', noTrialsText);
+	cy.get('.no-results').should('have.text', noTrialsText);
 });
 
 And('{string} text is displayed as results header', (resHeader) => {

--- a/cypress/integration/common/locationSection.js
+++ b/cypress/integration/common/locationSection.js
@@ -69,7 +69,7 @@ And('user types {string} in {string} field', (text, fieldLabel) => {
 });
 
 And('{string} no trial info is displayed', (noTrialsText) => {
-	cy.get('.no-trials-found').should('have.text', noTrialsText);
+	cy.get('.no-results').should('have.text', noTrialsText);
 });
 
 And('{string} text is displayed as results header', (resHeader) => {

--- a/src/views/ResultsPage/ResultsPageHeader.jsx
+++ b/src/views/ResultsPage/ResultsPageHeader.jsx
@@ -34,11 +34,7 @@ const ResultsPageHeader = ({
 
 	return (
 		<div className="cts-results-header">
-			{resultsCount === 0 ? (
-				<div className="no-trials-found">
-					<strong>No clinical trials matched your search.</strong>
-				</div>
-			) : (
+			{resultsCount !== 0 && (
 				<div className="all-trials">
 					<strong>
 						Results{' '}


### PR DESCRIPTION
* Removes the div containing the extra no results text

  Closes #196