### PR TITLE
(#514) Update Browser Title to Use siteName Parameter

### DIFF
--- a/cypress/integration/AdvancedSearchPage/AdvancedSearchForm.feature
+++ b/cypress/integration/AdvancedSearchPage/AdvancedSearchForm.feature
@@ -54,7 +54,7 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 		Scenario: As a search engine I want to have access to the meta data on a page
 		Given the user navigates to "/advanced"
 		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |

--- a/cypress/integration/Analytics/AdvancedTrialSearchPage.feature
+++ b/cypress/integration/Analytics/AdvancedTrialSearchPage.feature
@@ -1,466 +1,466 @@
 Feature: Clinical Trials Search Page - Advanced
 
-   Scenario: Page Load Analytics fires when a user views an Advanced Search form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/advanced"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    Then there should be an analytics event with the following details
-        | key                                  | value                                                                            |
-        | type                                 | PageLoad                                                                         |
-        | event                                | ClinicalTrialsSearchApp:Load:AdvancedSearch                                      |
-        | page.name                            | www.cancer.gov/advanced            																							|
-        | page.title                           | Find NCI-Supported Clinical Trials - Advanced Search                             |
-        | page.metaTitle                       | Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute |
-        | page.language                        | english                                                                          |
-        | page.type                            | nciAppModulePage                                                                 |
-        | page.channel                         | About Cancer                                                                     |
-        | page.contentGroup                    | Clinical Trials                                                                  |
-        | page.publishedDate                   | 02/02/2011                                                                       |
-        | page.additionalDetails.analyticsName | Clinical Trials                                                                  |
-        | page.additionalDetails.formType      | advanced                                                                         |
+	Scenario: Page Load Analytics fires when a user views an Advanced Search form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/advanced"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                  | value                                                      |
+			| type                                 | PageLoad                                                   |
+			| event                                | ClinicalTrialsSearchApp:Load:AdvancedSearch                |
+			| page.name                            | www.cancer.gov/advanced                                    |
+			| page.title                           | Find NCI-Supported Clinical Trials - Advanced Search       |
+			| page.metaTitle                       | Find NCI-Supported Clinical Trials - Advanced Search - NCI |
+			| page.language                        | english                                                    |
+			| page.type                            | nciAppModulePage                                           |
+			| page.channel                         | About Cancer                                               |
+			| page.contentGroup                    | Clinical Trials                                            |
+			| page.publishedDate                   | 02/02/2011                                                 |
+			| page.additionalDetails.analyticsName | Clinical Trials                                            |
+			| page.additionalDetails.formType      | advanced                                                   |
 
-  Scenario: Click event fires when user starts typing in Primary Cancer Type/Condition field
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/advanced"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user clicks on "All" button
-    And user types "c" in "CancerTypeCondition" field
-    Then there should be an analytics event with the following details
-        | key                | value                                              |
-        | type               | Other                                              |
-        | event              | ClinicalTrialsSearchApp:Other:FormInteractionStart |
-        | linkName           | formAnalysis\|clinicaltrials_advanced\|start       |
-        | data.analyticsName | Clinical Trials                                    |
-        | data.formType      | advanced                                           |
-        | data.field         | ct-searchTerm                                      |
-
-
-
-  Scenario: Click event fires when user clicks on search result item from Advanced Search results page
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?loc=0&rl=2"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    When user clicks on 1 trial result
-    Then there should be an analytics event with the following details
-      | key                  | value                                         |
-      | type                 | Other                                         |
-      | event                | ClinicalTrialsSearchApp:Other:ResultsListItem |
-      | linkName             | UnknownLinkName                               |
-      | data.analyticsName   | Clinical Trials                               |
-      | data.formType        | advanced                                      |
-      | data.pageNum         | (int)1                                        |
-      | data.resultsPosition | (int)1                                        |
-
-  Scenario: Page Load event fires when user fills out Cancer Type Condition fields on Advanced Form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?loc=0&rl=2&stg=C94774&t=C4872"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | advanced                                                       |
-      | page.additionalDetails.numResults                     | (int)27                                                        |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.stages.0              | (arr)C94774                                                    |
-      | page.additionalDetails.formData.location              | search-location-all                                            |
-      | page.additionalDetails.formData.cancerType            | (arr)C4872                                                     |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | c4872\|all\|c94774\|all\|none\|none                            |
-      | page.additionalDetails.helperFormData.fieldUsage      | t:stg                                                          |
-      | page.additionalDetails.helperFormData.loc             | all                                                            |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                          |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                |
-
-  Scenario: Page Load event fires when user fills out Age, Keyword phrases and location at NIH only
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?a=40&loc=4&q=psa&rl=2"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | advanced                                                       |
-      | page.additionalDetails.numResults                     | (int)17                                                        |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.age                   | (int)40                                                        |
-      | page.additionalDetails.formData.location              | search-location-nih                                            |
-      | page.additionalDetails.formData.keywordPhrases        | psa                                                            |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|40\|psa                                    |
-      | page.additionalDetails.helperFormData.fieldUsage      | a:q:loc                                                        |
-      | page.additionalDetails.helperFormData.loc             | at nih                                                         |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                          |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                |
-
-  Scenario: Page Load event fires when user fills out Location fields with VaOnly toggled and specified state
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?lcnty=United%20States&loc=2&lst=WA&rl=2&va=1"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | advanced                                                       |
-      | page.additionalDetails.numResults                     | (int)5                                                         |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.vaOnly                | (bool)true                                                     |
-      | page.additionalDetails.formData.country               | United States                                                  |
-      | page.additionalDetails.formData.location              | search-location-country                                        |
-      | page.additionalDetails.formData.states                | (arr)WA                                                        |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                 |
-      | page.additionalDetails.helperFormData.fieldUsage      | loc:va:lcnty:lst                                               |
-      | page.additionalDetails.helperFormData.loc             | csc\|united states\|wa\|none\|va-only                          |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                          |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                |
-
-  Scenario: Page Load event fires when user fills out Location hospital field and searches
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?hos=UM%20Baltimore%20Washington%20Medical%20Center%2FTate%20Cancer%20Center&loc=3&rl=2"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                           |
-      | type                                                  | PageLoad                                                        |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                            |
-      | page.name                                             | www.cancer.gov/r  																							|
-      | page.title                                            | Clinical Trials Search Results                                  |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute      |
-      | page.language                                         | english                                                         |
-      | page.type                                             | nciAppModulePage                                                |
-      | page.channel                                          | About Cancer                                                    |
-      | page.contentGroup                                     | Clinical Trials                                                 |
-      | page.publishedDate                                    | 02/02/2011                                                      |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                 |
-      | page.additionalDetails.formType                       | advanced                                                        |
-      | page.additionalDetails.numResults                     | (int)29                                                         |
-      | page.additionalDetails.status                         | success                                                         |
-      | page.additionalDetails.formData.hospital              | UM Baltimore Washington Medical Center/Tate Cancer Center     |
-      | page.additionalDetails.formData.location              | search-location-hospital                                        |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                  |
-      | page.additionalDetails.helperFormData.fieldUsage      | loc:hos                                                         |
-      | page.additionalDetails.helperFormData.loc             | hi\|UM Baltimore Washington Medical Center/Tate Cancer Center |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                           |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                 |
-
-  Scenario: Page Load event fires when user fills out Trial Type field and searches
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?hv=1&loc=0&rl=2&tt=treatment&tt=prevention&tt=supportive_care&tt=health_services_research&tt=diagnostic&tt=screening&tt=basic_science&tt=other"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                                                                       |
-      | type                                                  | PageLoad                                                                                                    |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                                                                        |
-      | page.name                                             | www.cancer.gov/r                                              																							|
-      | page.title                                            | Clinical Trials Search Results                                                                              |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute                                                  |
-      | page.language                                         | english                                                                                                     |
-      | page.type                                             | nciAppModulePage                                                                                            |
-      | page.channel                                          | About Cancer                                                                                                |
-      | page.contentGroup                                     | Clinical Trials                                                                                             |
-      | page.publishedDate                                    | 02/02/2011                                                                                                  |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                                                             |
-      | page.additionalDetails.formType                       | advanced                                                                                                    |
-      | page.additionalDetails.numResults                     | (int)508                                                                                                    |
-      | page.additionalDetails.status                         | success                                                                                                     |
-      | page.additionalDetails.formData.healthyVolunteers     | (bool)true                                                                                                  |
-      | page.additionalDetails.formData.location              | search-location-all                                                                                         |
-      | page.additionalDetails.formData.trialTypes            | (arr)treatment,prevention,supportive_care,health_services_research,diagnostic,screening,basic_science,other |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                                                              |
-      | page.additionalDetails.helperFormData.fieldUsage      | tt:hv                                                                                                       |
-      | page.additionalDetails.helperFormData.loc             | all                                                                                                         |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                                                                       |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | tre,sup,dia,bas,pre,hea,scr,oth\|none\|none\|hv                                                             |
-
-  Scenario: Page Load event fires when user fills out Drug Treatment and Trial Phase fields and searches
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?d=C599&i=C18309&loc=0&rl=2&tp=i&tp=ii&tp=iii&tp=iv"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | advanced                                                       |
-      | page.additionalDetails.numResults                     | (int)2                                                         |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.drugs.0               | (arr)C599                                                      |
-      | page.additionalDetails.formData.location              | search-location-all                                            |
-      | page.additionalDetails.formData.trialPhases           | (arr)i,ii,iii,iv                                               |
-      | page.additionalDetails.formData.treatments.0          | (arr)C18309                                                    |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                 |
-      | page.additionalDetails.helperFormData.fieldUsage      | d:i:tp                                                         |
-      | page.additionalDetails.helperFormData.loc             | all                                                            |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | i,ii,iii,iv\|none\|none\|none                                  |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|c599\|c18309                                              |
-
-
-  Scenario: Page Load event fires when user fills out Trial Id, Lead organization and investigator fields and searches
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?in=Jarushka%20Naidoo&lo=ECOG-ACRIN%20Cancer%20Research%20Group&loc=0&rl=2&tid=NCI-2018-02825"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                                          |
-      | type                                                  | PageLoad                                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                                           |
-      | page.name                                             | www.cancer.gov/r                 																							 |
-      | page.title                                            | Clinical Trials Search Results                                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute                     |
-      | page.language                                         | english                                                                        |
-      | page.type                                             | nciAppModulePage                                                               |
-      | page.channel                                          | About Cancer                                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                                |
-      | page.publishedDate                                    | 02/02/2011                                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                                |
-      | page.additionalDetails.formType                       | advanced                                                                       |
-      | page.additionalDetails.numResults                     | (int)1                                                                         |
-      | page.additionalDetails.status                         | success                                                                        |
-      | page.additionalDetails.formData.investigator          | Jarushka Naidoo                                                                |
-      | page.additionalDetails.formData.location              | search-location-all                                                            |
-      | page.additionalDetails.formData.leadOrg               | ECOG-ACRIN Cancer Research Group                                               |
-      | page.additionalDetails.formData.trialId               | NCI-2018-02825                                                                 |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                                 |
-      | page.additionalDetails.helperFormData.fieldUsage      | tid:in:lo                                                                      |
-      | page.additionalDetails.helperFormData.loc             | all                                                                            |
-      | page.additionalDetails.helperFormData.tpTidInvLo      | all\|single:nci-2018-02825\|jarushka naidoo\|ecog-acrin cancer research group |
-      | page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                                |
-
-
- Scenario: Click event fires when user clicks on Modify Search criteria button
-  Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  When the user navigates to "/r?a=40&loc=0&rl=2"
-  Then the page title is "Clinical Trials Search Results"
-  And browser waits
-  When user clicks on "Modify Search Criteria" button
-  Then there should be an analytics event with the following details
-      | key                | value                                                       |
-      | type               | Other                                                       |
-      | event              | ClinicalTrialsSearchApp:Other:ModifySearchCriteriaLinkClick |
-      | linkName           | CTSModifyClick                                              |
-      | data.analyticsName | Clinical Trials                                             |
-      | data.formType      | advanced                                                    |
-      | data.source        | modify_search_criteria_link                                 |
+	Scenario: Click event fires when user starts typing in Primary Cancer Type/Condition field
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/advanced"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user clicks on "All" button
+		And user types "c" in "CancerTypeCondition" field
+		Then there should be an analytics event with the following details
+			| key                | value                                              |
+			| type               | Other                                              |
+			| event              | ClinicalTrialsSearchApp:Other:FormInteractionStart |
+			| linkName           | formAnalysis\|clinicaltrials_advanced\|start       |
+			| data.analyticsName | Clinical Trials                                    |
+			| data.formType      | advanced                                           |
+			| data.field         | ct-searchTerm                                      |
 
 
 
-Scenario: Click event fires when user selects all on page and click print
-  Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  When the user navigates to "/r?loc=0&rl=2"
-  Then the page title is "Clinical Trials Search Results"
-  And browser waits
-  When user checks "Select all on page" checkbox
-  And user clicks on "Print Selected" button
-  Then there should be an analytics event with the following details
-    | key                    | value                                                  |
-    | type                   | Other                                                  |
-    | event                  | ClinicalTrialsSearchApp:Other:PrintSelectedButtonClick |
-    | linkName               | CTSResultsPrintSelectedClick                           |
-    | data.analyticsName     | Clinical Trials                                        |
-    | data.formType          | advanced                                               |
-    | data.buttonPos         | top                                                    |
-    | data.selectAll         | (bool)true                                             |
-    | data.selectedCount     | (int)10                                                |
-    | data.pagesWithSelected | (arrInt)1                                              |
+	Scenario: Click event fires when user clicks on search result item from Advanced Search results page
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user clicks on 1 trial result
+		Then there should be an analytics event with the following details
+			| key                  | value                                         |
+			| type                 | Other                                         |
+			| event                | ClinicalTrialsSearchApp:Other:ResultsListItem |
+			| linkName             | UnknownLinkName                               |
+			| data.analyticsName   | Clinical Trials                               |
+			| data.formType        | advanced                                      |
+			| data.pageNum         | (int)1                                        |
+			| data.resultsPosition | (int)1                                        |
 
-#### Needs scroll to be implemented
+	Scenario: Page Load event fires when user fills out Cancer Type Condition fields on Advanced Form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=2&stg=C94774&t=C4872"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                |
+			| type                                                  | PageLoad                             |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results |
+			| page.name                                             | www.cancer.gov/r                     |
+			| page.title                                            | Clinical Trials Search Results       |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI |
+			| page.language                                         | english                              |
+			| page.type                                             | nciAppModulePage                     |
+			| page.channel                                          | About Cancer                         |
+			| page.contentGroup                                     | Clinical Trials                      |
+			| page.publishedDate                                    | 02/02/2011                           |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                      |
+			| page.additionalDetails.formType                       | advanced                             |
+			| page.additionalDetails.numResults                     | (int)27                              |
+			| page.additionalDetails.status                         | success                              |
+			| page.additionalDetails.formData.stages.0              | (arr)C94774                          |
+			| page.additionalDetails.formData.location              | search-location-all                  |
+			| page.additionalDetails.formData.cancerType            | (arr)C4872                           |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | c4872\|all\|c94774\|all\|none\|none  |
+			| page.additionalDetails.helperFormData.fieldUsage      | t:stg                                |
+			| page.additionalDetails.helperFormData.loc             | all                                  |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                      |
 
-# Scenario: Click event fires when user clicks on Find Trials button from Advanced Search form
-#   Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-#   And "baseHost" is set to "http://localhost:3000"
-#   And "canonicalHost" is set to "https://www.cancer.gov"
-#   And "siteName" is set to "National Cancer Institute"
-#   And "channel" is set to "About Cancer"
-#   And "analyticsPublishedDate" is set to "02/02/2011"
-#   And "analyticsName" is set to "Clinical Trials"
-#   When the user navigates to "/advanced"
-#   Then the page title is "Find NCI-Supported Clinical Trials"
-#   And browser waits
-#   When user scrolls to middle of screen
-#   And user clicks on "Find Trials" button
-#   Then there should be an analytics event with the following details
-#       | key                | value                                                |
-#       | type               | Other                                                |
-#       | event              | ClinicalTrialsSearchApp:Other:FormSubmissionComplete |
-#       | linkName           | fformAnalysis\|clinicaltrials_advanced\|complete     |
-#       | data.analyticsName | Clinical Trials                                      |
-#       | data.formType      | advanced                                             |
-#       | data.completion    | complete_scrolling                                   |
+	Scenario: Page Load event fires when user fills out Age, Keyword phrases and location at NIH only
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?a=40&loc=4&q=psa&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                |
+			| type                                                  | PageLoad                             |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results |
+			| page.name                                             | www.cancer.gov/r                     |
+			| page.title                                            | Clinical Trials Search Results       |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI |
+			| page.language                                         | english                              |
+			| page.type                                             | nciAppModulePage                     |
+			| page.channel                                          | About Cancer                         |
+			| page.contentGroup                                     | Clinical Trials                      |
+			| page.publishedDate                                    | 02/02/2011                           |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                      |
+			| page.additionalDetails.formType                       | advanced                             |
+			| page.additionalDetails.numResults                     | (int)17                              |
+			| page.additionalDetails.status                         | success                              |
+			| page.additionalDetails.formData.age                   | (int)40                              |
+			| page.additionalDetails.formData.location              | search-location-nih                  |
+			| page.additionalDetails.formData.keywordPhrases        | psa                                  |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|40\|psa          |
+			| page.additionalDetails.helperFormData.fieldUsage      | a:q:loc                              |
+			| page.additionalDetails.helperFormData.loc             | at nih                               |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                      |
+
+	Scenario: Page Load event fires when user fills out Location fields with VaOnly toggled and specified state
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?lcnty=United%20States&loc=2&lst=WA&rl=2&va=1"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                 |
+			| type                                                  | PageLoad                              |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results  |
+			| page.name                                             | www.cancer.gov/r                      |
+			| page.title                                            | Clinical Trials Search Results        |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI  |
+			| page.language                                         | english                               |
+			| page.type                                             | nciAppModulePage                      |
+			| page.channel                                          | About Cancer                          |
+			| page.contentGroup                                     | Clinical Trials                       |
+			| page.publishedDate                                    | 02/02/2011                            |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                       |
+			| page.additionalDetails.formType                       | advanced                              |
+			| page.additionalDetails.numResults                     | (int)5                                |
+			| page.additionalDetails.status                         | success                               |
+			| page.additionalDetails.formData.vaOnly                | (bool)true                            |
+			| page.additionalDetails.formData.country               | United States                         |
+			| page.additionalDetails.formData.location              | search-location-country               |
+			| page.additionalDetails.formData.states                | (arr)WA                               |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none        |
+			| page.additionalDetails.helperFormData.fieldUsage      | loc:va:lcnty:lst                      |
+			| page.additionalDetails.helperFormData.loc             | csc\|united states\|wa\|none\|va-only |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                 |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                       |
+
+	Scenario: Page Load event fires when user fills out Location hospital field and searches
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?hos=UM%20Baltimore%20Washington%20Medical%20Center%2FTate%20Cancer%20Center&loc=3&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                                           |
+			| type                                                  | PageLoad                                                        |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results                            |
+			| page.name                                             | www.cancer.gov/r                                                |
+			| page.title                                            | Clinical Trials Search Results                                  |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI                            |
+			| page.language                                         | english                                                         |
+			| page.type                                             | nciAppModulePage                                                |
+			| page.channel                                          | About Cancer                                                    |
+			| page.contentGroup                                     | Clinical Trials                                                 |
+			| page.publishedDate                                    | 02/02/2011                                                      |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                                                 |
+			| page.additionalDetails.formType                       | advanced                                                        |
+			| page.additionalDetails.numResults                     | (int)29                                                         |
+			| page.additionalDetails.status                         | success                                                         |
+			| page.additionalDetails.formData.hospital              | UM Baltimore Washington Medical Center/Tate Cancer Center       |
+			| page.additionalDetails.formData.location              | search-location-hospital                                        |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                  |
+			| page.additionalDetails.helperFormData.fieldUsage      | loc:hos                                                         |
+			| page.additionalDetails.helperFormData.loc             | hi\|UM Baltimore Washington Medical Center/Tate Cancer Center   |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                           |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                 |
+
+	Scenario: Page Load event fires when user fills out Trial Type field and searches
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?hv=1&loc=0&rl=2&tt=treatment&tt=prevention&tt=supportive_care&tt=health_services_research&tt=diagnostic&tt=screening&tt=basic_science&tt=other"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                                                                                       |
+			| type                                                  | PageLoad                                                                                                    |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results                                                                        |
+			| page.name                                             | www.cancer.gov/r                                                                                            |
+			| page.title                                            | Clinical Trials Search Results                                                                              |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI                                                                        |
+			| page.language                                         | english                                                                                                     |
+			| page.type                                             | nciAppModulePage                                                                                            |
+			| page.channel                                          | About Cancer                                                                                                |
+			| page.contentGroup                                     | Clinical Trials                                                                                             |
+			| page.publishedDate                                    | 02/02/2011                                                                                                  |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                                                                                             |
+			| page.additionalDetails.formType                       | advanced                                                                                                    |
+			| page.additionalDetails.numResults                     | (int)508                                                                                                    |
+			| page.additionalDetails.status                         | success                                                                                                     |
+			| page.additionalDetails.formData.healthyVolunteers     | (bool)true                                                                                                  |
+			| page.additionalDetails.formData.location              | search-location-all                                                                                         |
+			| page.additionalDetails.formData.trialTypes            | (arr)treatment,prevention,supportive_care,health_services_research,diagnostic,screening,basic_science,other |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                                                              |
+			| page.additionalDetails.helperFormData.fieldUsage      | tt:hv                                                                                                       |
+			| page.additionalDetails.helperFormData.loc             | all                                                                                                         |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|none\|none\|none                                                                                       |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | tre,sup,dia,bas,pre,hea,scr,oth\|none\|none\|hv                                                             |
+
+	Scenario: Page Load event fires when user fills out Drug Treatment and Trial Phase fields and searches
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?d=C599&i=C18309&loc=0&rl=2&tp=i&tp=ii&tp=iii&tp=iv"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                |
+			| type                                                  | PageLoad                             |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results |
+			| page.name                                             | www.cancer.gov/r                     |
+			| page.title                                            | Clinical Trials Search Results       |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI |
+			| page.language                                         | english                              |
+			| page.type                                             | nciAppModulePage                     |
+			| page.channel                                          | About Cancer                         |
+			| page.contentGroup                                     | Clinical Trials                      |
+			| page.publishedDate                                    | 02/02/2011                           |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                      |
+			| page.additionalDetails.formType                       | advanced                             |
+			| page.additionalDetails.numResults                     | (int)2                               |
+			| page.additionalDetails.status                         | success                              |
+			| page.additionalDetails.formData.drugs.0               | (arr)C599                            |
+			| page.additionalDetails.formData.location              | search-location-all                  |
+			| page.additionalDetails.formData.trialPhases           | (arr)i,ii,iii,iv                     |
+			| page.additionalDetails.formData.treatments.0          | (arr)C18309                          |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none       |
+			| page.additionalDetails.helperFormData.fieldUsage      | d:i:tp                               |
+			| page.additionalDetails.helperFormData.loc             | all                                  |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | i,ii,iii,iv\|none\|none\|none        |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|c599\|c18309                    |
 
 
-Scenario: Click event fires when user clicks on Clear Form button
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  When the user navigates to "/advanced"
-  Then the page title is "Find NCI-Supported Clinical Trials"
-  And browser waits
-  When user clears form
-  Then there should be preserved analytics event with the following details
-      | key                | value                                   |
-      | type               | Other                                   |
-      | event              | ClinicalTrialsSearchApp:Other:ClearForm |
-      | linkName           | clinicaltrials_advanced\|clear          |
-      | data.analyticsName | Clinical Trials                         |
-      | data.formType      | advanced                                |
+	Scenario: Page Load event fires when user fills out Trial Id, Lead organization and investigator fields and searches
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?in=Jarushka%20Naidoo&lo=ECOG-ACRIN%20Cancer%20Research%20Group&loc=0&rl=2&tid=NCI-2018-02825"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                                                         |
+			| type                                                  | PageLoad                                                                      |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results                                          |
+			| page.name                                             | www.cancer.gov/r                                                              |
+			| page.title                                            | Clinical Trials Search Results                                                |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI                                          |
+			| page.language                                         | english                                                                       |
+			| page.type                                             | nciAppModulePage                                                              |
+			| page.channel                                          | About Cancer                                                                  |
+			| page.contentGroup                                     | Clinical Trials                                                               |
+			| page.publishedDate                                    | 02/02/2011                                                                    |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                                                               |
+			| page.additionalDetails.formType                       | advanced                                                                      |
+			| page.additionalDetails.numResults                     | (int)1                                                                        |
+			| page.additionalDetails.status                         | success                                                                       |
+			| page.additionalDetails.formData.investigator          | Jarushka Naidoo                                                               |
+			| page.additionalDetails.formData.location              | search-location-all                                                           |
+			| page.additionalDetails.formData.leadOrg               | ECOG-ACRIN Cancer Research Group                                              |
+			| page.additionalDetails.formData.trialId               | NCI-2018-02825                                                                |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | all\|all\|all\|all\|none\|none                                                |
+			| page.additionalDetails.helperFormData.fieldUsage      | tid:in:lo                                                                     |
+			| page.additionalDetails.helperFormData.loc             | all                                                                           |
+			| page.additionalDetails.helperFormData.tpTidInvLo      | all\|single:nci-2018-02825\|jarushka naidoo\|ecog-acrin cancer research group |
+			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                               |
 
-Scenario: Click event fires when user tries to print without selecting any trial
-  Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  When the user navigates to "/r?loc=0&rl=2"
-  Then the page title is "Clinical Trials Search Results"
-  And browser waits
-  And user clicks on "Print Selected" button
-  And browser waits
-  Then there should be an analytics event with the following details
-      | key                    | value                                                  |
-      | type                   | Other                                                  |
-      | event                  | ClinicalTrialsSearchApp:Other:PrintSelectedError       |
-      | linkName               | CTSResultsSelectedErrorClick                           |
-      | data.analyticsName     | Clinical Trials                                        |
-      | data.formType          | advanced                                               |
-      | data.errorReason       | noneselected                                           |
 
-Scenario: Click event fires when user reaches max number of selected trials
-  Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  When the user navigates to "/r?loc=0&rl=2"
-  Then the page title is "Clinical Trials Search Results"
-  And browser waits
-  When user checks "Select all on page" checkbox on 11 pages
-  And browser waits
-  Then there should be an analytics event with the following details
-      | key                    | value                                                  |
-      | type                   | Other                                                  |
-      | event                  | ClinicalTrialsSearchApp:Other:PrintSelectedError       |
-      | linkName               | CTSResultsSelectedErrorClick                           |
-      | data.analyticsName     | Clinical Trials                                        |
-      | data.formType          | advanced                                               |
-      | data.errorReason       | maxselectionreached                                    |
+	Scenario: Click event fires when user clicks on Modify Search criteria button
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?a=40&loc=0&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user clicks on "Modify Search Criteria" button
+		Then there should be an analytics event with the following details
+			| key                | value                                                       |
+			| type               | Other                                                       |
+			| event              | ClinicalTrialsSearchApp:Other:ModifySearchCriteriaLinkClick |
+			| linkName           | CTSModifyClick                                              |
+			| data.analyticsName | Clinical Trials                                             |
+			| data.formType      | advanced                                                    |
+			| data.source        | modify_search_criteria_link                                 |
+
+
+
+	Scenario: Click event fires when user selects all on page and click print
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user checks "Select all on page" checkbox
+		And user clicks on "Print Selected" button
+		Then there should be an analytics event with the following details
+			| key                    | value                                                  |
+			| type                   | Other                                                  |
+			| event                  | ClinicalTrialsSearchApp:Other:PrintSelectedButtonClick |
+			| linkName               | CTSResultsPrintSelectedClick                           |
+			| data.analyticsName     | Clinical Trials                                        |
+			| data.formType          | advanced                                               |
+			| data.buttonPos         | top                                                    |
+			| data.selectAll         | (bool)true                                             |
+			| data.selectedCount     | (int)10                                                |
+			| data.pagesWithSelected | (arrInt)1                                              |
+
+	#### Needs scroll to be implemented
+
+	# Scenario: Click event fires when user clicks on Find Trials button from Advanced Search form
+	#   Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+	#   And "baseHost" is set to "http://localhost:3000"
+	#   And "canonicalHost" is set to "https://www.cancer.gov"
+	#   And "siteName" is set to "NCI"
+	#   And "channel" is set to "About Cancer"
+	#   And "analyticsPublishedDate" is set to "02/02/2011"
+	#   And "analyticsName" is set to "Clinical Trials"
+	#   When the user navigates to "/advanced"
+	#   Then the page title is "Find NCI-Supported Clinical Trials"
+	#   And browser waits
+	#   When user scrolls to middle of screen
+	#   And user clicks on "Find Trials" button
+	#   Then there should be an analytics event with the following details
+	#       | key                | value                                                |
+	#       | type               | Other                                                |
+	#       | event              | ClinicalTrialsSearchApp:Other:FormSubmissionComplete |
+	#       | linkName           | fformAnalysis\|clinicaltrials_advanced\|complete     |
+	#       | data.analyticsName | Clinical Trials                                      |
+	#       | data.formType      | advanced                                             |
+	#       | data.completion    | complete_scrolling                                   |
+
+
+	Scenario: Click event fires when user clicks on Clear Form button
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/advanced"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user clears form
+		Then there should be preserved analytics event with the following details
+			| key                | value                                   |
+			| type               | Other                                   |
+			| event              | ClinicalTrialsSearchApp:Other:ClearForm |
+			| linkName           | clinicaltrials_advanced\|clear          |
+			| data.analyticsName | Clinical Trials                         |
+			| data.formType      | advanced                                |
+
+	Scenario: Click event fires when user tries to print without selecting any trial
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		And user clicks on "Print Selected" button
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                | value                                            |
+			| type               | Other                                            |
+			| event              | ClinicalTrialsSearchApp:Other:PrintSelectedError |
+			| linkName           | CTSResultsSelectedErrorClick                     |
+			| data.analyticsName | Clinical Trials                                  |
+			| data.formType      | advanced                                         |
+			| data.errorReason   | noneselected                                     |
+
+	Scenario: Click event fires when user reaches max number of selected trials
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=2"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user checks "Select all on page" checkbox on 11 pages
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                | value                                            |
+			| type               | Other                                            |
+			| event              | ClinicalTrialsSearchApp:Other:PrintSelectedError |
+			| linkName           | CTSResultsSelectedErrorClick                     |
+			| data.analyticsName | Clinical Trials                                  |
+			| data.formType      | advanced                                         |
+			| data.errorReason   | maxselectionreached                              |

--- a/cypress/integration/Analytics/BasicTrialSearchPage.feature
+++ b/cypress/integration/Analytics/BasicTrialSearchPage.feature
@@ -1,283 +1,283 @@
 Feature: Clinical Trials Search Page - Basic
 
-  ############Analytics################
+	############Analytics################
 
-  Scenario: Page Load Analytics fires when a user views a Basic Search form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                  | value                                                          |
-      | type                                 | PageLoad                                                       |
-      | event                                | ClinicalTrialsSearchApp:Load:BasicSearch                       |
-      | page.name                            | www.cancer.gov/  																						  |
-      | page.title                           | Find NCI-Supported Clinical Trials                             |
-      | page.metaTitle                       | Find NCI-Supported Clinical Trials - National Cancer Institute |
-      | page.language                        | english                                                        |
-      | page.type                            | nciAppModulePage                                               |
-      | page.channel                         | About Cancer                                                   |
-      | page.contentGroup                    | Clinical Trials                                                |
-      | page.publishedDate                   | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName | Clinical Trials                                                |
-      | page.additionalDetails.formType      | basic                                                          |
-
-
-  Scenario: Click event fires when user clicks on Cancer Type/Keyword field
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user clicks on "CancerTypeKeyword" field
-    Then there should be an analytics event with the following details
-      | key                | value                                              |
-      | type               | Other                                              |
-      | event              | ClinicalTrialsSearchApp:Other:FormInteractionStart |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|start          |
-      | data.analyticsName | Clinical Trials                                    |
-      | data.field         | ctk                                                |
-      | data.formType      | basic                                              |
-
-  Scenario: Click event fires when user inputs invalid age and submits form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user types "234" in "Age" field
-    And user clicks on "Find Trials" button
-    Then there should be an analytics event with the following details
-      | key                | value                                             |
-      | type               | Other                                             |
-      | event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|error         |
-      | data.analyticsName | Clinical Trials                                   |
-      | data.formType      | basic                                             |
-      | data.status        | error                                             |
-      | data.fieldError    | a                                                 |
-
-  Scenario: Click event fires when user inputs invalid ZipCode and tries to submit search
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user types "999g9" in "Zipcode" field
-    And user clicks on "Find Trials" button
-    Then there should be an analytics event with the following details
-      | key                | value                                             |
-      | type               | Other                                             |
-      | event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|error         |
-      | data.analyticsName | Clinical Trials                                   |
-      | data.formType      | basic                                             |
-      | data.status        | error                                             |
-      | data.fieldError    | z                                                 |
-
-  Scenario: Click event fires when user inputs invalid age and invalid zipcode ans submits form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user types "234" in "Age" field
-    And user types "999g9" in "Zipcode" field
-    And user clicks on "Find Trials" button
-    Then there should be an analytics event with the following details
-      | key                | value                                             |
-      | type               | Other                                             |
-      | event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|error         |
-      | data.analyticsName | Clinical Trials                                   |
-      | data.formType      | basic                                             |
-      | data.status        | error                                             |
-      | data.fieldError    | a,z                                               |
-
-  Scenario: Click event fires when user clicks on Find Trials button
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user clicks on "Find Trials" button
-    Then there should be an analytics event with the following details
-      | key                | value                                                |
-      | type               | Other                                                |
-      | event              | ClinicalTrialsSearchApp:Other:FormSubmissionComplete |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|complete         |
-      | data.analyticsName | Clinical Trials                                      |
-      | data.formType      | basic                                                |
-      | data.status        | complete                                             |
+	Scenario: Page Load Analytics fires when a user views a Basic Search form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                  | value                                    |
+			| type                                 | PageLoad                                 |
+			| event                                | ClinicalTrialsSearchApp:Load:BasicSearch |
+			| page.name                            | www.cancer.gov/                          |
+			| page.title                           | Find NCI-Supported Clinical Trials       |
+			| page.metaTitle                       | Find NCI-Supported Clinical Trials - NCI |
+			| page.language                        | english                                  |
+			| page.type                            | nciAppModulePage                         |
+			| page.channel                         | About Cancer                             |
+			| page.contentGroup                    | Clinical Trials                          |
+			| page.publishedDate                   | 02/02/2011                               |
+			| page.additionalDetails.analyticsName | Clinical Trials                          |
+			| page.additionalDetails.formType      | basic                                    |
 
 
-  Scenario: Click event fires when user clicks on Start Over link while on Basic Form Results page
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?loc=0&rl=1"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    When user clicks on "Start Over" link
-    Then there should be an analytics event with the following details
-      | key                | value                                            |
-      | type               | Other                                            |
-      | event              | ClinicalTrialsSearchApp:Other:NewSearchLinkClick |
-      | linkName           | CTStartOverClick                                 |
-      | data.analyticsName | Clinical Trials                                  |
-      | data.formType      | basic                                            |
-      | data.source        | start_over_link                                  |
+	Scenario: Click event fires when user clicks on Cancer Type/Keyword field
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user clicks on "CancerTypeKeyword" field
+		Then there should be an analytics event with the following details
+			| key                | value                                              |
+			| type               | Other                                              |
+			| event              | ClinicalTrialsSearchApp:Other:FormInteractionStart |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|start          |
+			| data.analyticsName | Clinical Trials                                    |
+			| data.field         | ctk                                                |
+			| data.formType      | basic                                              |
 
-  Scenario: Page Load event fires when user fills out fields on Basic Form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?a=40&loc=0&rl=1&t=C4872"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | basic                                                          |
-      | page.additionalDetails.numResults                     | (int)894                                                       |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.age                   | (int)40                                                        |
-      | page.additionalDetails.formData.location              | search-location-all                                            |
-      | page.additionalDetails.formData.cancerType            | (arr)C4872                                                     |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | typecondition\|c4872\|40                                       |
-      | page.additionalDetails.helperFormData.fieldUsage      | t:a                                                            |
-      | page.additionalDetails.helperFormData.loc             | all                                                            |
+	Scenario: Click event fires when user inputs invalid age and submits form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user types "234" in "Age" field
+		And user clicks on "Find Trials" button
+		Then there should be an analytics event with the following details
+			| key                | value                                             |
+			| type               | Other                                             |
+			| event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|error         |
+			| data.analyticsName | Clinical Trials                                   |
+			| data.formType      | basic                                             |
+			| data.status        | error                                             |
+			| data.fieldError    | a                                                 |
 
-  Scenario: Click event fires when user clicks on search result item from Basic Search results page
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/r?loc=0&rl=1"
-    Then the page title is "Clinical Trials Search Results"
-    And browser waits
-    When user clicks on 1 trial result
-    Then there should be an analytics event with the following details
-      | key                  | value                                         |
-      | type                 | Other                                         |
-      | event                | ClinicalTrialsSearchApp:Other:ResultsListItem |
-      | linkName             | UnknownLinkName                               |
-      | data.analyticsName   | Clinical Trials                               |
-      | data.formType        | basic                                         |
-      | data.pageNum         | (int)1                                        |
-      | data.resultsPosition | (int)1                                        |
+	Scenario: Click event fires when user inputs invalid ZipCode and tries to submit search
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user types "999g9" in "Zipcode" field
+		And user clicks on "Find Trials" button
+		Then there should be an analytics event with the following details
+			| key                | value                                             |
+			| type               | Other                                             |
+			| event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|error         |
+			| data.analyticsName | Clinical Trials                                   |
+			| data.formType      | basic                                             |
+			| data.status        | error                                             |
+			| data.fieldError    | z                                                 |
 
-  #Below scenario should be just navigating to search results page, but zip code look up times out with 500 status code
-  Scenario: Page Load event fires when user fills out zipcode field on Basic Form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user types "22182" in "Zipcode" field
-    And user clicks on "Find Trials" button
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                                   | value                                                          |
-      | type                                                  | PageLoad                                                       |
-      | event                                                 | ClinicalTrialsSearchApp:Load:Results                           |
-      | page.name                                             | www.cancer.gov/r 																							 |
-      | page.title                                            | Clinical Trials Search Results                                 |
-      | page.metaTitle                                        | Clinical Trials Search Results - National Cancer Institute     |
-      | page.language                                         | english                                                        |
-      | page.type                                             | nciAppModulePage                                               |
-      | page.channel                                          | About Cancer                                                   |
-      | page.contentGroup                                     | Clinical Trials                                                |
-      | page.publishedDate                                    | 02/02/2011                                                     |
-      | page.additionalDetails.analyticsName                  | Clinical Trials                                                |
-      | page.additionalDetails.formType                       | basic                                                          |
-      | page.additionalDetails.numResults                     | (int)1130                                                      |
-      | page.additionalDetails.status                         | success                                                        |
-      | page.additionalDetails.formData.zip                   | 22182                                                          |
-      | page.additionalDetails.formData.zipRadius             | 100                                                            |
-      | page.additionalDetails.formData.location              | search-location-zip                                            |
-      | page.additionalDetails.helperFormData.canTypeKwPhrAge | none\|none                                                     |
-      | page.additionalDetails.helperFormData.fieldUsage      | loc:z                                                          |
-      | page.additionalDetails.helperFormData.loc             | zip\|22182\|none                                               |
+	Scenario: Click event fires when user inputs invalid age and invalid zipcode ans submits form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user types "234" in "Age" field
+		And user types "999g9" in "Zipcode" field
+		And user clicks on "Find Trials" button
+		Then there should be an analytics event with the following details
+			| key                | value                                             |
+			| type               | Other                                             |
+			| event              | ClinicalTrialsSearchApp:Other:FormSubmissionError |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|error         |
+			| data.analyticsName | Clinical Trials                                   |
+			| data.formType      | basic                                             |
+			| data.status        | error                                             |
+			| data.fieldError    | a,z                                               |
+
+	Scenario: Click event fires when user clicks on Find Trials button
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user clicks on "Find Trials" button
+		Then there should be an analytics event with the following details
+			| key                | value                                                |
+			| type               | Other                                                |
+			| event              | ClinicalTrialsSearchApp:Other:FormSubmissionComplete |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|complete         |
+			| data.analyticsName | Clinical Trials                                      |
+			| data.formType      | basic                                                |
+			| data.status        | complete                                             |
 
 
+	Scenario: Click event fires when user clicks on Start Over link while on Basic Form Results page
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=1"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user clicks on "Start Over" link
+		Then there should be an analytics event with the following details
+			| key                | value                                            |
+			| type               | Other                                            |
+			| event              | ClinicalTrialsSearchApp:Other:NewSearchLinkClick |
+			| linkName           | CTStartOverClick                                 |
+			| data.analyticsName | Clinical Trials                                  |
+			| data.formType      | basic                                            |
+			| data.source        | start_over_link                                  |
 
-  Scenario: Click event fires when user abandons the form
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/advanced"
-    When the user navigates to "/"
-    Then the page title is "Find NCI-Supported Clinical Trials"
-    And browser waits
-    When user types "22" in "Age" field
-    And user navigates back to the previous page
-    Then there should be preserved analytics event with the following details
-      | key                | value                                       |
-      | type               | Other                                       |
-      | event              | ClinicalTrialsSearchApp:Other:FormAbandon   |
-      | linkName           | formAnalysis\|clinicaltrials_basic\|abandon |
-      | data.analyticsName | Clinical Trials                             |
-      | data.formType      | basic                                       |
-      | data.field         | age                                         |
+	Scenario: Page Load event fires when user fills out fields on Basic Form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?a=40&loc=0&rl=1&t=C4872"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                |
+			| type                                                  | PageLoad                             |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results |
+			| page.name                                             | www.cancer.gov/r                     |
+			| page.title                                            | Clinical Trials Search Results       |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI |
+			| page.language                                         | english                              |
+			| page.type                                             | nciAppModulePage                     |
+			| page.channel                                          | About Cancer                         |
+			| page.contentGroup                                     | Clinical Trials                      |
+			| page.publishedDate                                    | 02/02/2011                           |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                      |
+			| page.additionalDetails.formType                       | basic                                |
+			| page.additionalDetails.numResults                     | (int)894                             |
+			| page.additionalDetails.status                         | success                              |
+			| page.additionalDetails.formData.age                   | (int)40                              |
+			| page.additionalDetails.formData.location              | search-location-all                  |
+			| page.additionalDetails.formData.cancerType            | (arr)C4872                           |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | typecondition\|c4872\|40             |
+			| page.additionalDetails.helperFormData.fieldUsage      | t:a                                  |
+			| page.additionalDetails.helperFormData.loc             | all                                  |
+
+	Scenario: Click event fires when user clicks on search result item from Basic Search results page
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/r?loc=0&rl=1"
+		Then the page title is "Clinical Trials Search Results"
+		And browser waits
+		When user clicks on 1 trial result
+		Then there should be an analytics event with the following details
+			| key                  | value                                         |
+			| type                 | Other                                         |
+			| event                | ClinicalTrialsSearchApp:Other:ResultsListItem |
+			| linkName             | UnknownLinkName                               |
+			| data.analyticsName   | Clinical Trials                               |
+			| data.formType        | basic                                         |
+			| data.pageNum         | (int)1                                        |
+			| data.resultsPosition | (int)1                                        |
+
+	#Below scenario should be just navigating to search results page, but zip code look up times out with 500 status code
+	Scenario: Page Load event fires when user fills out zipcode field on Basic Form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user types "22182" in "Zipcode" field
+		And user clicks on "Find Trials" button
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                                   | value                                |
+			| type                                                  | PageLoad                             |
+			| event                                                 | ClinicalTrialsSearchApp:Load:Results |
+			| page.name                                             | www.cancer.gov/r                     |
+			| page.title                                            | Clinical Trials Search Results       |
+			| page.metaTitle                                        | Clinical Trials Search Results - NCI |
+			| page.language                                         | english                              |
+			| page.type                                             | nciAppModulePage                     |
+			| page.channel                                          | About Cancer                         |
+			| page.contentGroup                                     | Clinical Trials                      |
+			| page.publishedDate                                    | 02/02/2011                           |
+			| page.additionalDetails.analyticsName                  | Clinical Trials                      |
+			| page.additionalDetails.formType                       | basic                                |
+			| page.additionalDetails.numResults                     | (int)1130                            |
+			| page.additionalDetails.status                         | success                              |
+			| page.additionalDetails.formData.zip                   | 22182                                |
+			| page.additionalDetails.formData.zipRadius             | 100                                  |
+			| page.additionalDetails.formData.location              | search-location-zip                  |
+			| page.additionalDetails.helperFormData.canTypeKwPhrAge | none\|none                           |
+			| page.additionalDetails.helperFormData.fieldUsage      | loc:z                                |
+			| page.additionalDetails.helperFormData.loc             | zip\|22182\|none                     |
+
+
+
+	Scenario: Click event fires when user abandons the form
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/advanced"
+		When the user navigates to "/"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And browser waits
+		When user types "22" in "Age" field
+		And user navigates back to the previous page
+		Then there should be preserved analytics event with the following details
+			| key                | value                                       |
+			| type               | Other                                       |
+			| event              | ClinicalTrialsSearchApp:Other:FormAbandon   |
+			| linkName           | formAnalysis\|clinicaltrials_basic\|abandon |
+			| data.analyticsName | Clinical Trials                             |
+			| data.formType      | basic                                       |
+			| data.field         | age                                         |

--- a/cypress/integration/Analytics/TrialDescriptionPage.feature
+++ b/cypress/integration/Analytics/TrialDescriptionPage.feature
@@ -1,60 +1,60 @@
 Feature: Clinical Trial Description Page
 
-  ############Analytics################
+	############Analytics################
 
-  Scenario: Page Load event fires when user navigates to trial description page
-    Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-    And "baseHost" is set to "http://localhost:3000"
-    And "canonicalHost" is set to "https://www.cancer.gov"
-    And "siteName" is set to "National Cancer Institute"
-    And "channel" is set to "About Cancer"
-    And "analyticsPublishedDate" is set to "02/02/2011"
-    And "analyticsName" is set to "Clinical Trials"
-    When the user navigates to "/v?id=NCI-2015-01918&loc=0&rl=1"
-    And browser waits
-    Then there should be an analytics event with the following details
-      | key                                  | value                                                                                                            |
-      | type                                 | PageLoad                                                                                                         |
-      | event                                | ClinicalTrialsSearchApp:Load:TrialDescription                                                                    |
-      | page.name                            | www.cancer.gov/v                                                   																						  |
-      | page.title                           | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence |
-      | page.metaTitle                       | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence |
-      | page.language                        | english                                                                                                          |
-      | page.type                            | nciAppModulePage                                                                                                 |
-      | page.channel                         | About Cancer                                                                                                     |
-      | page.contentGroup                    | Clinical Trials                                                                                                  |
-      | page.publishedDate                   | 02/02/2011                                                                                                       |
-      | page.additionalDetails.analyticsName | Clinical Trials                                                                                                  |
-      | page.additionalDetails.formType      | basic                                                                                                            |
-      | page.additionalDetails.nctId         | NCT02750826                                                                                                      |
+	Scenario: Page Load event fires when user navigates to trial description page
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		When the user navigates to "/v?id=NCI-2015-01918&loc=0&rl=1"
+		And browser waits
+		Then there should be an analytics event with the following details
+			| key                                  | value                                                                                                            |
+			| type                                 | PageLoad                                                                                                         |
+			| event                                | ClinicalTrialsSearchApp:Load:TrialDescription                                                                    |
+			| page.name                            | www.cancer.gov/v                                                                                                 |
+			| page.title                           | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence |
+			| page.metaTitle                       | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence |
+			| page.language                        | english                                                                                                          |
+			| page.type                            | nciAppModulePage                                                                                                 |
+			| page.channel                         | About Cancer                                                                                                     |
+			| page.contentGroup                    | Clinical Trials                                                                                                  |
+			| page.publishedDate                   | 02/02/2011                                                                                                       |
+			| page.additionalDetails.analyticsName | Clinical Trials                                                                                                  |
+			| page.additionalDetails.formType      | basic                                                                                                            |
+			| page.additionalDetails.nctId         | NCT02750826                                                                                                      |
 
- Scenario: Click event fires when user clicks on Print link on trial description page
-  Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
-  And "baseHost" is set to "http://localhost:3000"
-  And "canonicalHost" is set to "https://www.cancer.gov"
-  And "siteName" is set to "National Cancer Institute"
-  And "channel" is set to "About Cancer"
-  And "analyticsPublishedDate" is set to "02/02/2011"
-  And "analyticsName" is set to "Clinical Trials"
-  Given screen breakpoint is set to "desktop"
-  When the user navigates to "//v?id=NCI-2015-01918&loc=0&rl=1"
-  And browser waits
-  When user clicks on share by "Print" button
-  Then there should be an analytics event with the following details
-      | key                | value                                      |
-      | type               | Other                                      |
-      | event              | ClinicalTrialsSearchApp:Other:ShareButton  |
-      | linkName           | UnknownLinkName                            |
-      | data.analyticsName | Clinical Trials                            |
-      | data.formType      | basic                                      |
-      | data.shareType     | print                                      |
+	Scenario: Click event fires when user clicks on Print link on trial description page
+		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		And "baseHost" is set to "http://localhost:3000"
+		And "canonicalHost" is set to "https://www.cancer.gov"
+		And "siteName" is set to "NCI"
+		And "channel" is set to "About Cancer"
+		And "analyticsPublishedDate" is set to "02/02/2011"
+		And "analyticsName" is set to "Clinical Trials"
+		Given screen breakpoint is set to "desktop"
+		When the user navigates to "//v?id=NCI-2015-01918&loc=0&rl=1"
+		And browser waits
+		When user clicks on share by "Print" button
+		Then there should be an analytics event with the following details
+			| key                | value                                     |
+			| type               | Other                                     |
+			| event              | ClinicalTrialsSearchApp:Other:ShareButton |
+			| linkName           | UnknownLinkName                           |
+			| data.analyticsName | Clinical Trials                           |
+			| data.formType      | basic                                     |
+			| data.shareType     | print                                     |
 
 ## below scenario is timing out due to Cypress waiting on page load
 # Scenario: Click event fires when user clicks on Email link on trial description page
 #   Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
 #   And "baseHost" is set to "http://localhost:3000"
 #   And "canonicalHost" is set to "https://www.cancer.gov"
-#   And "siteName" is set to "National Cancer Institute"
+#   And "siteName" is set to "NCI"
 #   And "channel" is set to "About Cancer"
 #   And "analyticsPublishedDate" is set to "02/02/2011"
 #   And "analyticsName" is set to "Clinical Trials"

--- a/cypress/integration/BasicSearchPage/BasicSearchPage.feature
+++ b/cypress/integration/BasicSearchPage/BasicSearchPage.feature
@@ -9,10 +9,10 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		And Search tip icon is displayed and text "Search Tip: For more search options, use our advanced search." appears
 		And "advanced search" link has a href "/advanced"
 		And the following delighters are displayed
-			| delighter    | href                                                       | title                              																		| text                                                                  |
-			| cts-livehelp | /contact            | Have a question?We're here to help 	| Chat with us: LiveHelpCall us: 1-800-4-CANCER(1-800-422-6237)         |
-			| cts-what     | /about-cancer/treatment/clinical-trials/what-are-trials    | What Are Cancer Clinical Trials?   																		| Learn what they are and what you should know about them.              |
-			| cts-which    | /about-cancer/treatment/clinical-trials/search/trial-guide | Which trials are right for you?    																		| Use the checklist in our guide to gather the information you’ll need. |
+			| delighter    | href                                                       | title                              | text                                                                  |
+			| cts-livehelp | /contact                                                   | Have a question?We're here to help | Chat with us: LiveHelpCall us: 1-800-4-CANCER(1-800-422-6237)         |
+			| cts-what     | /about-cancer/treatment/clinical-trials/what-are-trials    | What Are Cancer Clinical Trials?   | Learn what they are and what you should know about them.              |
+			| cts-which    | /about-cancer/treatment/clinical-trials/search/trial-guide | Which trials are right for you?    | Use the checklist in our guide to gather the information you’ll need. |
 
 		Examples:
 			| breakpoint |
@@ -326,7 +326,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: As a search engine I want to have access to the meta data on a basic search page
 		Given the user navigates to "/"
 		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the title tag should be "Find NCI-Supported Clinical Trials - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                       |
 			| description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -347,7 +347,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		Then trial info displays "Results 1-10  of 17 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -360,7 +360,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "40" in "Age" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -374,7 +374,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		And browser waits
 		Then the search is executed and results page is displayed
 		And trial info displays "Results 1-10  of 18 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -398,12 +398,12 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182 |
 			| og:description | Find an NCI-supported clinical trial - Search results                                                 |
 		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182"
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "40" in "Age" field
 		And browser waits
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -426,4 +426,4 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 			| og:description | Find an NCI-supported clinical trial - Search results                                                        |
 		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100"
 		And browser waits
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"

--- a/cypress/integration/SearchResultsPage/GeneralPageComponents.feature
+++ b/cypress/integration/SearchResultsPage/GeneralPageComponents.feature
@@ -250,7 +250,7 @@ Feature: Clinical Trials Search Results Page Components
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displayes "Results 1-10  of 6306 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -263,7 +263,7 @@ Feature: Clinical Trials Search Results Page Components
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "39" in "Age" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -276,7 +276,7 @@ Feature: Clinical Trials Search Results Page Components
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displayes "Results 1-10  of 6731 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -291,7 +291,7 @@ Feature: Clinical Trials Search Results Page Components
 	Scenario: As a user, I expect meta data to update accordingly when I navigate to search results directly and modify my search
 		Given the user navigates to "/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lcnty=United%20States&lcty=Atlanta&lo=M%20D%20Anderson%20Cancer%20Center&loc=2&lst=GA&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment"
 		And trial info displayes "Results 1-1  of 1 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -304,7 +304,7 @@ Feature: Clinical Trials Search Results Page Components
 		When user clicks on Modify Search Criteria button
 		And user selects "Zip" radio button
 		And user types "30309" in "Zipcode" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -317,7 +317,7 @@ Feature: Clinical Trials Search Results Page Components
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displayes "Results 1-1  of 1 for your search "
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |

--- a/cypress/integration/SearchResultsPage/PrintFunctionality.feature
+++ b/cypress/integration/SearchResultsPage/PrintFunctionality.feature
@@ -82,7 +82,7 @@ Feature: As a user I want to be able to print trial search results
         Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
         And "baseHost" is set to "http://localhost:3000"
         And "canonicalHost" is set to "https://www.cancer.gov"
-        And "siteName" is set to "National Cancer Institute"
+        And "siteName" is set to "NCI"
         And "channel" is set to "About Cancer"
         And "analyticsPublishedDate" is set to "02/02/2011"
         And "analyticsName" is set to "Clinical Trials"

--- a/cypress/integration/TrialDescriptionPage/GeneralPageComponents.feature
+++ b/cypress/integration/TrialDescriptionPage/GeneralPageComponents.feature
@@ -141,7 +141,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		Given screen breakpoint is set to "desktop"
 		Given the user navigates to "/r?loc=0&rl=2"
 		Then the page title is "Clinical Trials Search Results"
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -166,7 +166,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 			| parameter | value |
 			| loc       | 0     |
 			| rl        | 2     |
-		And the title tag should be "Clinical Trials Search Results - National Cancer Institute"
+		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
 			| description | Find an NCI-supported clinical trial - Search results |
@@ -188,7 +188,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		When user clicks on "Start Over" link
 		Then the page title is "Find NCI-Supported Clinical Trials"
 		And the url is "/advanced"
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
 			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
@@ -210,7 +210,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		When user clicks on "Start Over" link
 		Then the page title is "Find NCI-Supported Clinical Trials"
 		And the url is "/"
-		And the title tag should be "Find NCI-Supported Clinical Trials - National Cancer Institute"
+		And the title tag should be "Find NCI-Supported Clinical Trials - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                       |
 			| description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -17,7 +17,7 @@ beforeEach(() => {
 			ctsTitle: 'Find NCI-Supported Clinical Trials',
 			language: 'en',
 			rootId: 'NCI-CTS-root',
-			siteName: 'National Cancer Institute',
+			siteName: 'NCI',
 			title: 'NCI Drug Dictionary',
 			contentGroup: 'Clinical Trials',
 			zipConversionEndpoint: '/mock-api/zip_code_lookup',

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
     <link rel="stylesheet" href="%PUBLIC_URL%/__nci-dev__common.css" />
     <title>
-      Find NCI-Supported Clinical Trials - National Cancer Institute
+      Find NCI-Supported Clinical Trials - NCI
     </title>
     <script type="text/javascript">
       // Only setup the handler if this is not running under cypress.
@@ -74,7 +74,7 @@
           printCacheEndpoint: '/CTS.Print/GenCache',
           rootId: 'NCI-CTS-root',
           services: {},
-          siteName: 'National Cancer Institute',
+          siteName: 'NCI',
           useSessionStorage: true,
           zipConversionEndpoint: '/cts_api/zip_code_lookup'
         },

--- a/src/index.js
+++ b/src/index.js
@@ -49,7 +49,7 @@ const initialize = ({
 	language = 'en',
 	printCacheEndpoint = '/CTS.Print/GenCache',
 	rootId = 'NCI-CTS-root',
-	siteName = 'National Cancer Institute',
+	siteName = 'NCI',
 	useSessionStorage = true,
 	zipConversionEndpoint = '/cts_api/zip_code_lookup',
 	// These have been added in to support integration testing.

--- a/src/views/ErrorPage/ErrorPage.jsx
+++ b/src/views/ErrorPage/ErrorPage.jsx
@@ -15,7 +15,8 @@ import { useLocation } from 'react-router-dom';
 
 const ErrorPage = ({ initErrorsList }) => {
 	const tracking = useTracking();
-	const [{ dispatch, analyticsName, canonicalHost }] = useAppSettings();
+	const [{ dispatch, analyticsName, canonicalHost, siteName }] =
+		useAppSettings();
 	const { AdvancedSearchPagePath, BasicSearchPagePath } = useAppPaths();
 
 	// Determine the original formType
@@ -128,7 +129,7 @@ const ErrorPage = ({ initErrorsList }) => {
 	return (
 		<>
 			<Helmet>
-				<title>Clinical Trials Search - National Cancer Institute</title>
+				<title>Clinical Trials Search - {siteName}</title>
 				<meta property="og:title" content="Clinical Trials Search" />
 
 				<meta

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -600,9 +600,7 @@ const ResultsPage = () => {
 	return (
 		<>
 			<Helmet>
-				<title>
-					Clinical Trials Search Results - National Cancer Institute
-				</title>
+				<title>Clinical Trials Search Results - {siteName}</title>
 				<meta property="og:title" content="Clinical Trials Search Results" />
 				<link
 					rel="canonical"

--- a/src/views/SearchPage/SearchPage.jsx
+++ b/src/views/SearchPage/SearchPage.jsx
@@ -335,7 +335,7 @@ const SearchPage = ({ formInit = 'basic' }) => {
 				<title>
 					{`Find NCI-Supported Clinical Trials - ${
 						pageType === 'advanced' ? 'Advanced Search - ' : ''
-					}National Cancer Institute`}
+					}${siteName}`}
 				</title>
 				<link
 					rel="canonical"

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -67,6 +67,7 @@ const TrialDescriptionPage = () => {
 		{
 			analyticsName,
 			canonicalHost,
+			siteName,
 			zipConversionEndpoint,
 			apiClients: { clinicalTrialsSearchClientV2 },
 		},
@@ -500,7 +501,9 @@ const TrialDescriptionPage = () => {
 				<>
 					{!isTrialLoading && (
 						<Helmet>
-							<title>{trialDescription.brief_title}</title>
+							<title>
+								{trialDescription.brief_title} - {siteName}
+							</title>{' '}
 							<meta
 								property="og:title"
 								content={trialDescription.brief_title}

--- a/support/mock-data/clinical-trials/C2989-response.json
+++ b/support/mock-data/clinical-trials/C2989-response.json
@@ -1,0 +1,249 @@
+{
+	"data": [
+			{
+					"name": "22q11.2 Deletion Syndrome",
+					"codes": [
+							"C2989"
+					],
+					"ancestor_ids": [
+							"C2991"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C2991"
+					],
+					"synonyms": [
+							"22q Deletion Syndrome(s)",
+							"22q11 deletion",
+							"CATCH-22",
+							"DGS1",
+							"DiGeorge Anomaly",
+							"DiGeorge Sequence",
+							"DiGeorge Syndrome",
+							"DiGeorge Syndrome Type 1",
+							"DiGeorge's Syndrome",
+							"FACES",
+							"Shprintzen Syndrome"
+					],
+					"count": 2
+			},
+			{
+					"name": "AIDS Related Immunoblastic Lymphoma",
+					"codes": [
+							"C8285"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208",
+							"C3211"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C3211"
+					],
+					"synonyms": [
+							"AIDS Associated Immunoblastic Lymphoma",
+							"AIDS Related Immunoblastic Large Cell Lymphoma",
+							"AIDS-Associated Immunoblastic Large Cell Lymphoma",
+							"AIDS-Related Immunoblastic Lymphoma"
+					],
+					"count": 1
+			},
+			{
+					"name": "AIDS-Related Anal Carcinoma",
+					"codes": [
+							"C9278"
+					],
+					"ancestor_ids": [
+							"C9291"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C9291"
+					],
+					"synonyms": [
+							"AIDS-Related Anal Cancer"
+					],
+					"count": 2
+			},
+			{
+					"name": "AIDS-Related Burkitt Lymphoma",
+					"codes": [
+							"C8286"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208",
+							"C3211"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C3211"
+					],
+					"synonyms": [
+							"AIDS Related Burkitt's Lymphoma",
+							"AIDS Related Small Non Cleaved Cell Lymphoma",
+							"AIDS-Associated Burkitt's Lymphoma",
+							"AIDS-Associated Small Non Cleaved Cell Lymphoma",
+							"AIDS-Related Burkitt's Lymphoma",
+							"AIDS-Related Small Non-Cleaved Cell Lymphoma"
+					],
+					"count": 1
+			},
+			{
+					"name": "AIDS-Related Cervical Cancer",
+					"codes": [
+							"C7432"
+					],
+					"ancestor_ids": [
+							"C9039"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C9039"
+					],
+					"synonyms": [
+							"AIDS Related Carcinoma of Uterine Cervix",
+							"AIDS Related Carcinoma of the Uterine Cervix",
+							"AIDS Related Cervical Cancer",
+							"AIDS-Related Cancer of Uterine Cervix",
+							"AIDS-Related Cancer of the Uterine Cervix",
+							"AIDS-Related Cervical Carcinoma",
+							"AIDS-Related Cervix Carcinoma",
+							"AIDS-Related Uterine Cervix Cancer",
+							"AIDS-Related Uterine Cervix Carcinoma"
+					],
+					"count": 1
+			},
+			{
+					"name": "AIDS-Related Diffuse Large B-cell Lymphoma",
+					"codes": [
+							"C7212"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208",
+							"C3211"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C3211"
+					],
+					"synonyms": [],
+					"count": 2
+			},
+			{
+					"name": "AIDS-Related Hodgkin Lymphoma",
+					"codes": [
+							"C9279"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208",
+							"C9357"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C9357"
+					],
+					"synonyms": [
+							"AIDS-Associated Hodgkin's Disease",
+							"AIDS-Associated Hodgkin's Lymphoma",
+							"AIDS-Related Hodgkin's Disease",
+							"AIDS-Related Hodgkin's Lymphoma",
+							"HIV-Associated Hodgkin's Disease",
+							"HIV-Associated Hodgkin's Lymphoma",
+							"HIV-Related Hodgkin's Disease",
+							"HIV-Related Hodgkin's Lymphoma"
+					],
+					"count": 1
+			},
+			{
+					"name": "AIDS-Related Kaposi Sarcoma",
+					"codes": [
+							"C3992"
+					],
+					"ancestor_ids": [
+							"C9087",
+							"C9118",
+							"C9306"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C9087"
+					],
+					"synonyms": [
+							"AIDS Related Kaposi's Sarcoma",
+							"AIDS, Kaposi's Sarcoma",
+							"AIDS-Related Kaposi's Sarcoma",
+							"Autoimmune Deficiency Syndrome-Related Kaposi Sarcoma",
+							"Epidemic Kaposi's Sarcoma",
+							"Kaposi's Sarcoma AIDS Related",
+							"Kaposi's Sarcoma Epidemic Type"
+					],
+					"count": 1
+			},
+			{
+					"name": "AIDS-Related Lymphoma",
+					"codes": [
+							"C3471"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C3208"
+					],
+					"synonyms": [
+							"AIDS Lymphoma",
+							"AIDS Related Lymphoma",
+							"HIV Associated Lymphoma",
+							"Lymphoma AIDS Related",
+							"Lymphoma, AIDS-Related"
+					],
+					"count": 2
+			},
+			{
+					"name": "AIDS-Related Non-Hodgkin Lymphoma",
+					"codes": [
+							"C5051"
+					],
+					"ancestor_ids": [
+							"C27134",
+							"C3208",
+							"C3211"
+					],
+					"type": [
+							"subtype"
+					],
+					"parent_ids": [
+							"C3211"
+					],
+					"synonyms": [
+							"AIDS-Related Non-Hodgkin's Lymphoma",
+							"AIDS-related NHL"
+					],
+					"count": 3
+			}
+	]
+}


### PR DESCRIPTION
- app now uses siteName Param when constructing browser title, rather than the hardcoded version
- updated integration tests
- updated siteName Param to be NCI

Closes #514 