### PR TITLE
(#534) Back to search results link should not appear when directly navigated to trial

### DIFF
--- a/cypress/integration/TrialDescriptionPage/GeneralPageComponents.feature
+++ b/cypress/integration/TrialDescriptionPage/GeneralPageComponents.feature
@@ -39,7 +39,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		Given screen breakpoint is set to "<breakpoint>"
 		Given the user navigates to "/v?a=40&id=NCI-2014-01507&loc=0&rl=2"
 		Then the page title is "Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial)"
-		And "< Back to search results" button as link is displayed
+		And back to search results link does not exist
 		And "This clinical trial matches:" appears below the title
 		When user clicks on "Show Search Criteria" button
 		Then button "Hide Search Criteria" is displayed

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -313,17 +313,19 @@ const TrialDescriptionPage = () => {
 		) {
 			return (
 				<div className="trial-description-page__header">
-					{searchCriteriaObject && searchCriteriaObject.formType != '' && (
-						<div className="back-to-search btnAsLink">
-							<span
-								onClick={() => navigate(-1)}
-								onKeyDown={() => navigate(-1)}
-								tabIndex="0"
-								role="button">
-								&lt; Back to search results
-							</span>
-						</div>
-					)}
+					{searchCriteriaObject &&
+						searchCriteriaObject.formType != '' &&
+						location.state && (
+							<div className="back-to-search btnAsLink">
+								<span
+									onClick={() => navigate(-1)}
+									onKeyDown={() => navigate(-1)}
+									tabIndex="0"
+									role="button">
+									&lt; Back to search results
+								</span>
+							</div>
+						)}
 					{searchCriteriaObject && !hasSCOBeenUpdated(searchCriteriaObject) ? (
 						<>
 							<strong>This clinical trial matches:</strong>


### PR DESCRIPTION
- added location.state existence validation
in rendering the link
- updated test
Closes #534
Closes #250 