### PR TITLE
(#539) Try a new search retains values

### DIFF
--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -564,6 +564,7 @@ const ResultsPage = () => {
 								? BasicSearchPagePath()
 								: AdvancedSearchPagePath()
 						}`}
+						state={{ criteria: {} }}
 						onClick={() => handleStartOver(TRY_NEW_SEARCH_LINK)}>
 						Try a new search
 					</Link>
@@ -589,6 +590,7 @@ const ResultsPage = () => {
 								? BasicSearchPagePath()
 								: AdvancedSearchPagePath()
 						}`}
+						state={{ criteria: {} }}
 						onClick={() => handleStartOver(TRY_NEW_SEARCH_LINK)}>
 						Try a new search
 					</Link>


### PR DESCRIPTION
- passed an empty search criteria to link
Closes #539 