### PR TITLE
(#385) Name param to handle both http and https protocols in event tracking

### DIFF
--- a/src/views/ErrorPage/ErrorPage.jsx
+++ b/src/views/ErrorPage/ErrorPage.jsx
@@ -44,7 +44,9 @@ const ErrorPage = ({ initErrorsList }) => {
 			analyticsName,
 			// Todo: Name, title, metaTitle confirmation
 			metaTitle: pageTitle,
-			name: canonicalHost.replace('https://', '') + window.location.pathname,
+			name:
+				canonicalHost.replace(/https:\/\/|http:\/\//, '') +
+				window.location.pathname,
 			title: pageTitle,
 			// Any additional properties fall into the "page.additionalDetails" bucket
 			// for the event.

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -220,7 +220,9 @@ const ResultsPage = () => {
 				type: 'PageLoad',
 				event: `ClinicalTrialsSearchApp:Load:Results`,
 				analyticsName,
-				name: canonicalHost.replace('https://', '') + window.location.pathname,
+				name:
+					canonicalHost.replace(/https:\/\/|http:\/\//, '') +
+					window.location.pathname,
 				// Any additional properties fall into the "page.additionalDetails" bucket
 				// for the event.
 				metaTitle: `Clinical Trials Search Results - ${siteName}`,

--- a/src/views/SearchPage/SearchPage.jsx
+++ b/src/views/SearchPage/SearchPage.jsx
@@ -161,7 +161,9 @@ const SearchPage = ({ formInit = 'basic' }) => {
 				}`,
 				analyticsName,
 				formType: pageType,
-				name: canonicalHost.replace('https://', '') + window.location.pathname,
+				name:
+					canonicalHost.replace(/https:\/\/|http:\/\//, '') +
+					window.location.pathname,
 				title: `Find NCI-Supported Clinical Trials${
 					pageType === 'advanced' ? ' - Advanced Search' : ''
 				}`,

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -170,7 +170,9 @@ const TrialDescriptionPage = () => {
 				type: 'PageLoad',
 				event: `ClinicalTrialsSearchApp:Load:TrialDescription`,
 				analyticsName,
-				name: canonicalHost.replace('https://', '') + window.location.pathname,
+				name:
+					canonicalHost.replace(/https:\/\/|http:\/\//, '') +
+					window.location.pathname,
 				title: `${trialDescription.brief_title}`,
 				metaTitle: `${trialDescription.brief_title}`,
 				// Any additional properties fall into the "page.additionalDetails" bucket


### PR DESCRIPTION
- name param in event tracking to use regex
to handle protocols

Closes #385 