### PR TITLE
(#561) Clicking a help (?) link is returning a blank page

### DIFF
--- a/cypress/integration/TrialDescriptionPage/PageNotFound.feature
+++ b/cypress/integration/TrialDescriptionPage/PageNotFound.feature
@@ -31,3 +31,19 @@ Feature: Page Not Found
 		And the page contains meta tags with the following names
 			| name                  | content |
 			| prerender-status-code | 404     |
+
+	Scenario: Page not found displays when user navigates to non-existent path
+		Given screen breakpoint is set to "desktop"
+		Given the user navigates to "/chicken"
+		Then the page title is "Page Not Found"
+		And the title tag should be "Page Not Found"
+		And the text "We can't find the page you're looking for." appears on the page
+		And the following links and texts exist on the page
+			| https://www.cancer.gov         | homepage     |
+			| https://www.cancer.gov/types   | cancer type  |
+			| https://www.cancer.gov/contact | Get in touch |
+		And the search bar appears below
+		Then the title tag should be "Page Not Found"
+		And the page contains meta tags with the following names
+			| name                  | content |
+			| prerender-status-code | 404     |

--- a/src/App.js
+++ b/src/App.js
@@ -11,6 +11,7 @@ import { BasicSearchPage, AdvancedSearchPage } from './views/SearchPage';
 import ResultsPage from './views/ResultsPage';
 import TrialDescriptionPage from './views/TrialDescriptionPage';
 import ErrorPage from './views/ErrorPage';
+import PageNotFound from './views/PageNotFound/PageNotFound';
 import { useAppSettings } from './store/store.js';
 import { PrintContextProvider } from './store/printContext';
 import { useAppInitializer } from './hooks';
@@ -48,6 +49,7 @@ const App = ({ zipConversionEndpoint }) => {
 							element={<AdvancedSearchPage />}
 						/>
 						<Route path={BasicSearchPagePath()} element={<BasicSearchPage />} />
+						<Route path="/*" element={<PageNotFound />} />
 					</Routes>
 				</PrintContextProvider>
 			) : (


### PR DESCRIPTION
Closes #561

* Added route handler and view `PageNotFound` for paths not found in app
* Added scenario to integration test for non-existent path