### PR TITLE
(#579) Fix broken print tests

### DIFF
--- a/cypress/integration/SearchResultsPage/PrintFunctionality.feature
+++ b/cypress/integration/SearchResultsPage/PrintFunctionality.feature
@@ -13,7 +13,7 @@ Feature: As a user I want to be able to print trial search results
 		And the request is sent with the following details
 			| link_template                                                                  | new_search_link                                | search_criteria |
 			| /about-cancer/treatment/clinical-trials/search/v?a=39&loc=0&rl=1&id=<TRIAL_ID> | /about-cancer/treatment/clinical-trials/search | notNull         |
-		And print modal appears
+		And the page title is "CTS.Print/Display"
 		Examples:
 			| breakpoint |
 			| desktop    |
@@ -49,7 +49,7 @@ Feature: As a user I want to be able to print trial search results
 		And the request is sent with the following details
 			| link_template                                                                  | new_search_link                                         | search_criteria |
 			| /about-cancer/treatment/clinical-trials/search/v?loc=0&pn=2&rl=2&id=<TRIAL_ID> | /about-cancer/treatment/clinical-trials/search/advanced | null            |
-		And print modal appears
+		And the page title is "CTS.Print/Display"
 
 	Scenario: as a user, I want to see all of the selected trials retained after I navigate back to a previous page
 		Given the user navigates to "/r?loc=0&rl=1"

--- a/cypress/integration/SearchResultsPage/PrintFunctionality/index.js
+++ b/cypress/integration/SearchResultsPage/PrintFunctionality/index.js
@@ -114,7 +114,7 @@ And('the request is sent with the following trial ids', (dataTable) => {
 });
 
 And('user clicks on {string} button', (buttonLabel) => {
-	cy.intercept('POST', '/CTS.Print/GenCache*').as('print');
+	cy.intercept('POST', '/mock-api/cts-print/GenCache*').as('print');
 	cy.get('button').contains(buttonLabel).click({ force: true });
 });
 

--- a/cypress/integration/common/beforeEach.js
+++ b/cypress/integration/common/beforeEach.js
@@ -15,6 +15,7 @@ beforeEach(() => {
 			ctsApiEndpointV1: '/v1',
 			ctsApiEndpointV2: '/cts/mock-api/v2',
 			ctsTitle: 'Find NCI-Supported Clinical Trials',
+			printApiBase: '/mock-api/cts-print',
 			language: 'en',
 			rootId: 'NCI-CTS-root',
 			siteName: 'NCI',

--- a/support/src/mock-cts-print.js
+++ b/support/src/mock-cts-print.js
@@ -1,0 +1,82 @@
+/**
+ * Timeout function.
+ *
+ * So the tests only work when the modal appears, which means that the search
+ * takes a while.
+ *
+ * @param {number} ms milliseconds
+ * @returns {Promise}
+ */
+function timeout(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * mockGenCache - Middleware for mocking CTS.Print/GenCache API Requests.
+ *
+ * This allows us to mock api requests for integration tests.
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ * @param {Function} next
+ */
+const mockGenCache = async (req, res) => {
+	// This is currently going to accept anything and return a nice shiny print
+	// id. This should be updated to you know, maybe actually test the
+	// mechanism... Like what happens when a 500 is encountered, does the app
+	// actually redirect, etc.
+
+	const resData = {
+		printID: 'd49690d4-3322-ed11-82da-0ed908919b64',
+	};
+
+	try {
+		// Wait 1 seconds - should be fast enough for a computer.
+		await timeout(1 * 1000);
+		res.set('Content-Type', 'application/json; charset=utf-8');
+		res.status(200).send(resData);
+	} catch (err) {
+		// This must be an error from sending the file, or joining
+		// the path.
+		console.error(err);
+		res.status(500).end();
+	}
+};
+
+/**
+ * mockDisplay - Middleware for mocking CTS.Print/Display API Requests.
+ *
+ * This allows us to mock api requests for integration tests.
+ *
+ * @param {Express.Request} req
+ * @param {Express.Response} res
+ * @param {Function} next
+ */
+const mockDisplay = async (req, res) => {
+	// This is currently going to accept anything and return a nice hello world.
+	// This should be updated to you know, maybe actually test the
+	// mechanism... Like what happens when a 500 is encountered, does the app
+	// actually redirect, etc.
+
+	const resData = `
+<html>
+	<head><title>CTS.Print/Display</title></head>
+	<body><h1>CTS.Print/Display</h1></body>
+</html>
+	`;
+
+	try {
+		res.set('Content-Type', 'text/html; charset=utf-8');
+		res.status(200).send(resData);
+	} catch (err) {
+		// This must be an error from sending the file, or joining
+		// the path.
+		console.error(err);
+		res.status(500).end();
+	}
+};
+
+module.exports = {
+	mockGenCache,
+	mockDisplay,
+};

--- a/support/src/setupProxy.js
+++ b/support/src/setupProxy.js
@@ -3,6 +3,7 @@ const express = require('express');
 const { createProxyMiddleware } = require('http-proxy-middleware');
 
 const mockZipCodeLookup = require('./mock-zipcode-lookup');
+const { mockGenCache, mockDisplay } = require('./mock-cts-print');
 const mockClinicalTrial = require('./mock-clinical-trials/clinical-trial');
 const mockClinicalTrials = require('./mock-clinical-trials/clinical-trials');
 const mockInterventions = require('./mock-clinical-trials/interventions');
@@ -29,6 +30,10 @@ module.exports = function (app) {
 
 	// Handle mock requests for the zip code lookup API
 	app.use('/mock-api/zip_code_lookup/:zip', mockZipCodeLookup);
+
+	// Handle mock requests from the CTS.Print API
+	app.use('/mock-api/cts-print/GenCache', mockGenCache);
+	app.use('/mock-api/cts-print/Display', mockDisplay);
 
 	// The Zip Code API does not allow CORS headers, so we must proxy it for
 	// local development.


### PR DESCRIPTION
This is a quick and dirty make work fix. I implemented a proxy for the CTS.Print endpoints. However, they just take in data and have no expectations. I also removed some of the modal checks in the feature as the modal is closed when the response occurs. Another test should be added to make sure the popup appears when the request is made. I did add a check to make sure the user was taken to a CTS.Print/Display endpoint. 

Closes #579