### PR TITLE
(#567) Hospital/Institution invalid params page loads scrolled to the bottom of the page

### DIFF
--- a/src/views/ErrorPage/ErrorPage.jsx
+++ b/src/views/ErrorPage/ErrorPage.jsx
@@ -34,6 +34,7 @@ const ErrorPage = ({ initErrorsList }) => {
 	}
 
 	useEffect(() => {
+		window.scrollTo(0, 0);
 		const pageTitle = 'Errors Occurred';
 
 		// Fire off page load event


### PR DESCRIPTION
- ErrorPage now scrolls to top on load