### PR TITLE
(#583) Publish main.css as a main-legacy.css for Redesign Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -87,6 +87,7 @@
         "jest-resolve": "^27.0.6",
         "jest-watch-typeahead": "^0.4.2",
         "nock": "^11.7.0",
+        "postcss-prefix-selector": "^1.16.0",
         "prop-types": "^15.7.2",
         "redux-devtools-extension": "^2.13.8",
         "redux-mock-store": "^1.5.3",
@@ -24632,6 +24633,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true,
+      "peerDependencies": {
+        "postcss": ">4 <9"
       }
     },
     "node_modules/postcss-preset-env": {
@@ -49249,6 +49259,12 @@
         "postcss": "^7.0.2",
         "postcss-values-parser": "^2.0.0"
       }
+    },
+    "postcss-prefix-selector": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/postcss-prefix-selector/-/postcss-prefix-selector-1.16.0.tgz",
+      "integrity": "sha512-rdVMIi7Q4B0XbXqNUEI+Z4E+pueiu/CS5E6vRCQommzdQ/sgsS4dK42U7GX8oJR+TJOtT+Qv3GkNo6iijUMp3Q==",
+      "dev": true
     },
     "postcss-preset-env": {
       "version": "6.7.0",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
   "keywords": [],
   "contributors": [],
   "engines": {
-		"node": ">=16.0.0 <17.0.0",
-		"npm": ">=8.0.0 <9.0.0"
-},
+    "node": ">=16.0.0 <17.0.0",
+    "npm": ">=8.0.0 <9.0.0"
+  },
   "dependencies": {
     "@svgr/webpack": "4.3.2",
     "axios": "^0.21.4",
@@ -76,7 +76,9 @@
   "scripts": {
     "start": "node scripts/start.js",
     "start:silent": "BROWSER=none npm start",
-    "build": "node scripts/build.js",
+		"build:cgdp-legacy": "node scripts/generate-cgdp-legacy.js",
+		"build:cra": "node scripts/build.js",
+		"build": "npm run build:cra && npm run build:cgdp-legacy",
     "test": "npm run unit-tests && npm run cy:ci && npm run merge-coverage",
     "test:it": "NODE_ENV=test cypress open",
     "cy:ci": "start-server-and-test start:silent http://localhost:3000 integration-tests",
@@ -179,11 +181,11 @@
       "jest-watch-typeahead/testname"
     ]
   },
-	"cypress-cucumber-preprocessor": {
-		"nonGlobalStepDefinitions": true,
-		"stepDefinitions": "cypress/e2e",
-		"commonPath": "cypress/e2e/common"
-	},
+  "cypress-cucumber-preprocessor": {
+    "nonGlobalStepDefinitions": true,
+    "stepDefinitions": "cypress/e2e",
+    "commonPath": "cypress/e2e/common"
+  },
   "nyc": {
     "report-dir": "coverage/cypress",
     "check-coverage": false,
@@ -226,6 +228,7 @@
     "jest-resolve": "^27.0.6",
     "jest-watch-typeahead": "^0.4.2",
     "nock": "^11.7.0",
+    "postcss-prefix-selector": "^1.16.0",
     "prop-types": "^15.7.2",
     "redux-devtools-extension": "^2.13.8",
     "redux-mock-store": "^1.5.3",

--- a/scripts/generate-cgdp-legacy.js
+++ b/scripts/generate-cgdp-legacy.js
@@ -1,0 +1,35 @@
+/* -------------------------------------------------------------------------
+ * So we need to prefix all CTS css selectors with .cgdpl to support the
+ * www redesign using ncids. Since our app manages its css with each
+ * component, we can't just create a new entry point. Well, I guess we could
+ * and just build the app twice and then do something, but that seems icky.
+ * ------------------------------------------------------------------------- */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const appPaths = require('../config/paths');
+const postcss = require('postcss');
+const prefixer = require('postcss-prefix-selector');
+
+const inputFileName = path.join(appPaths.appBuild, '/static/css/main.css');
+const outputFileName = path.join(
+	appPaths.appBuild,
+	'/static/css/main-legacy.css'
+);
+
+try {
+	const inputCss = fs.readFileSync(inputFileName, 'utf8');
+
+	const outputCss = postcss()
+		.use(
+			prefixer({
+				prefix: '.cgdpl',
+			})
+		)
+		.process(inputCss).css;
+
+	fs.writeFileSync(outputFileName, outputCss);
+} catch (err) {
+	console.error(err);
+}


### PR DESCRIPTION
  * npm install --save-dev postcss-prefix-selector

  * Create the script for creating the legacy css. Create this as scripts/generate-cgdp-legacy.js

  * Change the "build": "node scripts/build.js"

  See: https://github.com/NCIOCPL/cgov-react-app-playground/issues/50

  Closes #583