### PR TITLE
(#608) Handle Display for Min/Max Age In Months

### DIFF
--- a/cypress/e2e/AdvancedSearchPage/AgeSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/AgeSection.feature
@@ -75,3 +75,28 @@ Feature: Clinical Trials Advanced Search Page age section
         And trial info displays "Results 1-10  of 6306 for your search "
         When user clicks on Modify Search Criteria button
         Then age field has value "40"
+
+	Scenario: User is able to view trial results which have varying age criteria
+		Given the user navigates to "/advanced"
+		Then the page title is "Find NCI-Supported Clinical Trials"
+		And "Age" form section is displayed
+		When user types "NCI-2019-02289, NCI-2019-06216, NCI-2019-08622, NCI-2019-00399, NCI-2021-06711, NCI-2014-00677, NCI-2016-01734" in "TrialID" field
+		And user clicks on "Find Trials" button
+		Then the search is executed and results page is displayed
+		And the criteria table displays the following
+			| Category | Selection                                    |
+			| Trial ID | NCI-2019-02289, NCI-2019-06216, NCI-2019-08622, NCI-2019-00399, NCI-2021-06711, NCI-2014-00677, NCI-2016-01734|
+		# Maximum Age - Years
+		And the Age for result 1 displays the following "50 years and younger"
+		# Maximum Age - Months
+		And the Age for result 2 displays the following "18 months and younger"
+		# Days to Years
+		And the Age for result 3 displays the following "365 days to 30 years"
+		# Months to Year
+		And the Age for result 4 displays the following "12 months to 21 years"
+		# Years to Years
+		And the Age for result 5 displays the following "1 to 30 years"
+		# Minimum Age
+		And the Age for result 6 displays the following "1 years and over"
+		# Not specified
+		And the Age for result 7 displays the following "Not Specified"

--- a/cypress/e2e/common/index.js
+++ b/cypress/e2e/common/index.js
@@ -193,3 +193,13 @@ And('the following delighters are displayed', (dataTable) => {
 Then('help icon is displayed with href {string}', (helpHref) => {
 	cy.get('a.text-icon-help').should('have.attr', 'href', helpHref);
 });
+
+Then(
+	'the Age for result {int} displays the following {string}',
+	(resultItemNum, ageText) => {
+		cy.get('.results-list__item span')
+			.eq(resultItemNum - 1)
+			.get('.results-list-item__category')
+			.contains(ageText);
+	}
+);

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -115,29 +115,33 @@ const ResultsListItem = ({
 	};
 
 	const getAgeDisplay = () => {
-		if (
-			item.eligibility.structured.min_age_number === 0 &&
-			item.eligibility.structured.max_age_number > 120
-		) {
+		const minAge = item.eligibility.structured.min_age_number;
+		const maxAge = item.eligibility.structured.max_age_number;
+
+		const minAgeUnit = item.eligibility.structured.min_age_unit.toLowerCase();
+		const maxAgeUnit = item.eligibility.structured.max_age_unit.toLowerCase();
+
+		// CASE: Not specified / the incoming age range is out of bounds
+		if (minAge === 0 && maxAge > 120) {
 			return 'Not Specified';
 		}
-		if (
-			item.eligibility.structured.min_age_number === 0 &&
-			item.eligibility.structured.max_age_number < 120
-		) {
-			return `${item.eligibility.structured.min_age_number} years and younger`;
+
+		// CASE: No minimum age for trial
+		if (minAge === 0 && maxAge < 120) {
+			return `${maxAge} ${maxAgeUnit} and younger`;
 		}
-		if (
-			item.eligibility.structured.min_age_number > 0 &&
-			item.eligibility.structured.max_age_number < 120
-		) {
-			return `${item.eligibility.structured.min_age_number} to ${item.eligibility.structured.max_age_number} years`;
+		// CASE: No maximum age for trial
+		if (minAge > 0 && maxAge > 120) {
+			return `${minAge} ${minAgeUnit} and over`;
 		}
-		if (
-			item.eligibility.structured.min_age_number > 0 &&
-			item.eligibility.structured.max_age_number > 120
-		) {
-			return `${item.eligibility.structured.min_age_number} years and over`;
+		// CASE: Bound age range for trial
+		if (minAge > 0 && maxAge < 120) {
+			// If the units are the same we omit the minAgeUnit
+			if (minAgeUnit === maxAgeUnit) {
+				return `${minAge} to ${maxAge} ${maxAgeUnit}`;
+			}
+			// Base Case
+			return `${minAge} ${minAgeUnit} to ${maxAge} ${maxAgeUnit}`;
 		}
 	};
 

--- a/support/mock-data/clinical-trials/age-display-request.json
+++ b/support/mock-data/clinical-trials/age-display-request.json
@@ -1,0 +1,37 @@
+{
+	"current_trial_status": [
+		"Active",
+		"Approved",
+		"Enrolling by Invitation",
+		"In Review",
+		"Temporarily Closed to Accrual",
+		"Temporarily Closed to Accrual and Intervention"
+	],
+	"include": [
+		"nci_id",
+		"nct_id",
+		"brief_title",
+		"sites.org_name",
+		"sites.org_postal_code",
+		"eligibility.structured",
+		"current_trial_status",
+		"sites.org_va",
+		"sites.org_country",
+		"sites.org_state_or_province",
+		"sites.org_city",
+		"sites.org_coordinates",
+		"sites.recruitment_status",
+		"diseases"
+	],
+	"trial_ids": [
+		"NCI-2019-02289",
+		"NCI-2019-06216",
+		"NCI-2019-08622",
+		"NCI-2019-00399",
+		"NCI-2021-06711",
+		"NCI-2014-00677",
+		"NCI-2016-01734"
+	],
+	"from": 0,
+	"size": 10
+}

--- a/support/mock-data/clinical-trials/age-display-response.json
+++ b/support/mock-data/clinical-trials/age-display-response.json
@@ -1,0 +1,14788 @@
+{
+	"total": 7,
+	"data": [
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT04994132",
+			"brief_title": "A Study to Compare Early Use of Vinorelbine and Maintenance Therapy for Patients with High Risk Rhabdomyosarcoma",
+			"eligibility": {
+				"structured": {
+					"max_age": "50 Years",
+					"max_age_number": 50.0,
+					"min_age_unit": "Years",
+					"max_age_unit": "Years",
+					"max_age_in_years": 50.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "0 Years",
+					"min_age_number": 0.0,
+					"min_age_in_years": 0.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C121654",
+					"name": "Spindle Cell/Sclerosing Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3359"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C166414",
+					"name": "Metastatic Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3359",
+						"C153069"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C183250",
+					"name": "Metastatic Embryonal Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C8971",
+						"C166414"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C27493",
+					"name": "Solid Alveolar Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3749"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"ARMS",
+						"Monomorphous Round Cell Rhabdomyosarcoma"
+					],
+					"nci_thesaurus_concept_id": "C3749",
+					"name": "Alveolar Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3359",
+						"C9029"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C6519",
+					"name": "Spindle Cell Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C121654"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"ERMS"
+					],
+					"nci_thesaurus_concept_id": "C8971",
+					"name": "Embryonal Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3359",
+						"C9029"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Sarcoma Botryoides",
+						"Botryoid Sarcoma"
+					],
+					"nci_thesaurus_concept_id": "C9150",
+					"name": "Botryoid-Type Embryonal Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C8971"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"G3 Grade 3",
+						"Sarcoma Differentiation Score 3",
+						"Sarcoma FNCLCC Grade 3"
+					],
+					"nci_thesaurus_concept_id": "C9029",
+					"name": "FNCLCC Sarcoma Grade 3",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9023"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Skeletal Muscle",
+						"Tumor of the Skeletal Muscle",
+						"Skeletal Muscle Tumor",
+						"Tumor of Skeletal Muscle",
+						"Neoplasm of the Skeletal Muscle"
+					],
+					"nci_thesaurus_concept_id": "C6514",
+					"name": "Skeletal Muscle Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4063"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Muscle Tumor",
+						"Malignant Tumor of the Muscle",
+						"Myosarcoma",
+						"Malignant Tumor of Muscle",
+						"Malignant Neoplasm of the Muscle",
+						"Malignant Neoplasm of Muscle"
+					],
+					"nci_thesaurus_concept_id": "C4883",
+					"name": "Malignant Muscle Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4063",
+						"C166357"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Musculoskeletal System Disorder",
+						"Disorder of Musculoskeletal System"
+					],
+					"nci_thesaurus_concept_id": "C107377",
+					"name": "Musculoskeletal Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27574"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Infrequent Tumor"
+					],
+					"nci_thesaurus_concept_id": "C7201",
+					"name": "Infrequent Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Sarcoma by FNCLCC Histologic Grade",
+						"FNCLCC Histologic Grading System",
+						"Tumor Differentiation Score in Sarcoma",
+						"Sarcoma by FNCLCC Tumor Differentiation Score",
+						"FNCLCC Tumor Grade in Sarcoma",
+						"FNCLCC Histologic Grade",
+						"Histologic Grade (FNCLCC Grading system) (excludes GISTs)"
+					],
+					"nci_thesaurus_concept_id": "C9023",
+					"name": "Sarcoma by FNCLCC Grade",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9118"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Sarcoma NCI Grade III"
+					],
+					"nci_thesaurus_concept_id": "C9415",
+					"name": "Sarcoma NCI Grade 3",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C9387"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neoplasm of Skeletal Muscle",
+						"Malignant Tumor of Skeletal Muscle",
+						"Malignant Tumor of the Skeletal Muscle",
+						"Malignant Neoplasm of the Skeletal Muscle",
+						"Malignant Skeletal Muscle Tumor"
+					],
+					"nci_thesaurus_concept_id": "C6516",
+					"name": "Malignant Skeletal Muscle Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C6514",
+						"C4883"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Connective and Soft Tissue Diseases",
+						"Connective and Soft Tissue Disease"
+					],
+					"nci_thesaurus_concept_id": "C27574",
+					"name": "Connective and Soft Tissue Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Mesenchymal Neoplasm",
+						"Mesenchymal Tumor",
+						"Mesenchymal Cell Tumor"
+					],
+					"nci_thesaurus_concept_id": "C7059",
+					"name": "Mesenchymal Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3810",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"NCI Tumor Grade in Sarcoma"
+					],
+					"nci_thesaurus_concept_id": "C9387",
+					"name": "Sarcoma by NCI Grade",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9118"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C166357",
+					"name": "Malignant Musculoskeletal Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305",
+						"C166354"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Musculoskeletal System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C166354",
+					"name": "Musculoskeletal Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C107377",
+						"C3810"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Muscle",
+						"Myomatous Tumor",
+						"Tumor of Muscle",
+						"Neoplasm of the Muscle",
+						"Tumor of the Muscle",
+						"Muscle Tumor",
+						"Muscle Neoplasm",
+						"Myomatous Neoplasms"
+					],
+					"nci_thesaurus_concept_id": "C4063",
+					"name": "Myomatous Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C166354",
+						"C7059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"RHABDOMYOSARCOMA, MALIGNANT",
+						"Rhabdomyosarcoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3359",
+					"name": "Rhabdomyosarcoma",
+					"type": [
+						"grade",
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C7201",
+						"C9415",
+						"C6516"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Musculoskeletal and Soft Tissue Neoplasm",
+						"Soft Tissue and Bone Neoplasm",
+						"Tumor of Skeletal and Soft Tissue",
+						"Skeletal and Soft Tissue Neoplasm",
+						"Tumor of Soft Tissue and Skeleton",
+						"Soft Tissue and Bone Tumor",
+						"Connective and Soft Tissue Tumor",
+						"Skeletal and Soft Tissue Tumor",
+						"Musculoskeletal and Soft Tissue Tumor",
+						"Neoplasm of Soft Tissue and Skeleton",
+						"Tumor of Soft Tissue and Bone",
+						"Neoplasm of Skeletal and Soft Tissue",
+						"Neoplasm of Soft Tissue and Bone"
+					],
+					"nci_thesaurus_concept_id": "C3810",
+					"name": "Connective and Soft Tissue Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3263",
+						"C27574"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Sarcoma of Soft Tissue and Bone",
+						"SARCOMA, MALIGNANT",
+						"Sarcoma of the Soft Tissue and Bone",
+						"Sarcoma, Not Otherwise Specified",
+						"Mesenchymal Tumor, Malignant",
+						"SAR",
+						"Sarcoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C9118",
+					"name": "Sarcoma",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C9305",
+						"C3810"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C152076",
+					"name": "Metastatic Sarcoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C36263",
+						"C9118"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Secondary Cancer",
+						"SMN",
+						"Secondary malignant neoplasm of unspecified site",
+						"Secondary Malignancy"
+					],
+					"nci_thesaurus_concept_id": "C4968",
+					"name": "Secondary Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C36255",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Metastatic Tumor",
+						"Tumor, metastatic",
+						"Metastatic",
+						"Neoplasm, metastatic"
+					],
+					"nci_thesaurus_concept_id": "C3261",
+					"name": "Metastatic Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neoplasm, secondary",
+						"Secondary Tumor",
+						"Tumor, secondary"
+					],
+					"nci_thesaurus_concept_id": "C36255",
+					"name": "Secondary Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Sarcoma of the Soft Tissue",
+						"Non-Rhabdo. soft tissue sarcoma",
+						"Sarcoma of Soft Tissue",
+						"Non-Rhabdomyosarcoma soft tissue sarcoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C9306",
+					"name": "Soft Tissue Sarcoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C4867",
+						"C9118"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neoplasm of the Soft Tissue",
+						"Soft Tissue Tumors",
+						"Tumor of Soft Tissue",
+						"Soft tissue neoplasm, NOS",
+						"Neoplasm of Soft Tissue",
+						"Soft Tissue Neoplasm",
+						"Tumor of the Soft Tissue"
+					],
+					"nci_thesaurus_concept_id": "C3377",
+					"name": "Soft Tissue Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3810",
+						"C27042"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Soft Tissue Diseases",
+						"Soft Tissue Disorders",
+						"Soft Tissue Disease"
+					],
+					"nci_thesaurus_concept_id": "C27042",
+					"name": "Soft Tissue Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27574"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Soft Tissue Tumor",
+						"Soft tissue tumor, malignant",
+						"Malignant Tumor of the Soft Tissue",
+						"Malignant Tumor of Soft Tissue",
+						"Malignant Neoplasm of the Soft Tissue",
+						"Malignant Neoplasm of Soft Tissue"
+					],
+					"nci_thesaurus_concept_id": "C4867",
+					"name": "Malignant Soft Tissue Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3377",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C153069",
+					"name": "Metastatic Soft Tissue Sarcoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C152076",
+						"C9306"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Metastatic Cancer"
+					],
+					"nci_thesaurus_concept_id": "C36263",
+					"name": "Metastatic Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4968",
+						"C3261"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "AK",
+					"org_city": "Anchorage",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Alaska Medical Center",
+					"org_postal_code": "99508",
+					"org_coordinates": {
+						"lon": -149.8115,
+						"lat": 61.198
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Oncology Group",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "APPROVED"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Hospital",
+					"org_postal_code": "32827",
+					"org_coordinates": {
+						"lon": -81.3094,
+						"lat": 28.4288
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Jacksonville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Clinic-Jacksonville",
+					"org_postal_code": "32207",
+					"org_coordinates": {
+						"lon": -81.6318,
+						"lat": 30.291
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Lauderdale",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Broward Health Medical Center",
+					"org_postal_code": "33316",
+					"org_coordinates": {
+						"lon": -80.132,
+						"lat": 26.0999
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DE",
+					"org_city": "Wilmington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alfred I duPont Hospital for Children",
+					"org_postal_code": "19803",
+					"org_coordinates": {
+						"lon": -75.5445,
+						"lat": 39.7973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Toronto",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Hospital for Sick Children",
+					"org_postal_code": "M5G 1X8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "M D Anderson Cancer Center",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Buffalo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Roswell Park Cancer Institute",
+					"org_postal_code": "14263",
+					"org_coordinates": {
+						"lon": -78.8765,
+						"lat": 42.8868
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Duarte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "City of Hope Comprehensive Cancer Center",
+					"org_postal_code": "91010",
+					"org_coordinates": {
+						"lon": -117.9655,
+						"lat": 34.1357
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of San Antonio",
+					"org_postal_code": "78207",
+					"org_coordinates": {
+						"lon": -98.5276,
+						"lat": 29.4282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Baylor College of Medicine/Dan L Duncan Comprehensive Cancer Center",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UT Southwestern/Simmons Cancer Center-Dallas",
+					"org_postal_code": "75390",
+					"org_coordinates": {
+						"lon": -96.7016,
+						"lat": 32.8432
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "New Haven",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Yale University",
+					"org_postal_code": "06520",
+					"org_coordinates": {
+						"lon": -72.9291,
+						"lat": 41.31
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "New Haven",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Smilow Cancer Center/Yale-New Haven Hospital",
+					"org_postal_code": "06510",
+					"org_coordinates": {
+						"lon": -72.9252,
+						"lat": 41.3068
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cincinnati",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cincinnati Children's Hospital Medical Center",
+					"org_postal_code": "45229",
+					"org_coordinates": {
+						"lon": -84.4859,
+						"lat": 39.1532
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Gainesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Florida Health Science Center - Gainesville",
+					"org_postal_code": "32610",
+					"org_coordinates": {
+						"lon": -82.344,
+						"lat": 29.6395
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Chicago Comprehensive Cancer Center",
+					"org_postal_code": "60637",
+					"org_coordinates": {
+						"lon": -87.6021,
+						"lat": 41.781
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Worcester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UMass Memorial Medical Center - University Campus",
+					"org_postal_code": "01655",
+					"org_coordinates": {
+						"lon": -71.7598,
+						"lat": 42.2778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Louisville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Norton Children's Hospital",
+					"org_postal_code": "40202",
+					"org_coordinates": {
+						"lon": -85.7498,
+						"lat": 38.2536
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Philadelphia",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Francisco",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Medical Center-Mission Bay",
+					"org_postal_code": "94158",
+					"org_coordinates": {
+						"lon": -122.3951,
+						"lat": 37.7587
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Benioff Children's Hospital Oakland",
+					"org_postal_code": "94609",
+					"org_coordinates": {
+						"lon": -122.2647,
+						"lat": 37.8343
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Norfolk",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of The King's Daughters",
+					"org_postal_code": "23507",
+					"org_coordinates": {
+						"lon": -76.3092,
+						"lat": 36.8688
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Kingston",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Kingston Health Sciences Centre",
+					"org_postal_code": "K7L 2V7",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Palo Alto",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lucile Packard Children's Hospital Stanford University",
+					"org_postal_code": "94304",
+					"org_coordinates": {
+						"lon": -122.1462,
+						"lat": 37.4059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital New Orleans",
+					"org_postal_code": "70118",
+					"org_coordinates": {
+						"lon": -90.1244,
+						"lat": 29.9472
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Newark",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Newark Beth Israel Medical Center",
+					"org_postal_code": "07112",
+					"org_coordinates": {
+						"lon": -74.2114,
+						"lat": 40.7108
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Norton Shores",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cancer and Hematology Centers of Western Michigan - Norton Shores",
+					"org_postal_code": "49444",
+					"org_coordinates": {
+						"lon": -86.1901,
+						"lat": 43.1832
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tufts Medical Center",
+					"org_postal_code": "02111",
+					"org_coordinates": {
+						"lon": -71.0614,
+						"lat": 42.3512
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Fort Worth",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cook Children's Medical Center",
+					"org_postal_code": "76104",
+					"org_coordinates": {
+						"lon": -97.3172,
+						"lat": 32.7282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Reed City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Spectrum Health Reed City Hospital",
+					"org_postal_code": "49677",
+					"org_coordinates": {
+						"lon": -85.5104,
+						"lat": 43.9034
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Traverse City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Munson Medical Center",
+					"org_postal_code": "49684",
+					"org_coordinates": {
+						"lon": -85.6942,
+						"lat": 44.7515
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Helen DeVos Children's Hospital at Spectrum Health",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Trinity Health Grand Rapids Hospital",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Michigan Cancer Center",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Battle Creek",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Bronson Battle Creek",
+					"org_postal_code": "49017",
+					"org_coordinates": {
+						"lon": -85.165,
+						"lat": 42.3329
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Bronson Methodist Hospital",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Borgess Medical Center",
+					"org_postal_code": "49048",
+					"org_coordinates": {
+						"lon": -85.5302,
+						"lat": 42.297
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Saint Joseph",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lakeland Medical Center Saint Joseph",
+					"org_postal_code": "49085",
+					"org_coordinates": {
+						"lon": -86.4577,
+						"lat": 42.0441
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Wyoming",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Metro Health Hospital",
+					"org_postal_code": "49519",
+					"org_coordinates": {
+						"lon": -85.7181,
+						"lat": 42.9041
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Spectrum Health at Butterworth Campus",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Saint Joseph",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Marie Yeager Cancer Center",
+					"org_postal_code": "49085",
+					"org_coordinates": {
+						"lon": -86.4577,
+						"lat": 42.0441
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Muskegon",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Trinity Health Muskegon Hospital",
+					"org_postal_code": "49444",
+					"org_coordinates": {
+						"lon": -86.1901,
+						"lat": 43.1832
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Corpus Christi",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Driscoll Children's Hospital",
+					"org_postal_code": "78411",
+					"org_coordinates": {
+						"lon": -97.3858,
+						"lat": 27.7297
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Richmond",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Virginia Commonwealth University/Massey Cancer Center",
+					"org_postal_code": "23298",
+					"org_coordinates": {
+						"lon": -77.4296,
+						"lat": 37.5427
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Valhalla",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Westchester Medical Center",
+					"org_postal_code": "10595",
+					"org_coordinates": {
+						"lon": -73.7807,
+						"lat": 41.0861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Manitoba",
+					"org_city": "Winnipeg",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "CancerCare Manitoba",
+					"org_postal_code": "R3E 0V9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Springfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint John's Hospital",
+					"org_postal_code": "62702",
+					"org_coordinates": {
+						"lon": -89.6438,
+						"lat": 39.8235
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Pensacola",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sacred Heart Hospital",
+					"org_postal_code": "32504",
+					"org_coordinates": {
+						"lon": -87.1905,
+						"lat": 30.4842
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ochsner Medical Center Jefferson",
+					"org_postal_code": "70121",
+					"org_coordinates": {
+						"lon": -90.1597,
+						"lat": 29.9622
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Bronx",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Montefiore Medical Center - Moses Campus",
+					"org_postal_code": "10467",
+					"org_coordinates": {
+						"lon": -73.8721,
+						"lat": 40.8778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ID",
+					"org_city": "Boise",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Luke's Cancer Institute - Boise",
+					"org_postal_code": "83712",
+					"org_coordinates": {
+						"lon": -116.082,
+						"lat": 43.5932
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East  Carolina University",
+					"org_postal_code": "27834",
+					"org_coordinates": {
+						"lon": -77.3482,
+						"lat": 35.6768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Green Bay",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Vincent Hospital Cancer Center Green Bay",
+					"org_postal_code": "54301",
+					"org_coordinates": {
+						"lon": -88.0196,
+						"lat": 44.4814
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Green Bay",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Vincent Hospital Cancer Center at Saint Mary's",
+					"org_postal_code": "54303",
+					"org_coordinates": {
+						"lon": -88.0507,
+						"lat": 44.539
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Paterson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Regional Medical Center",
+					"org_postal_code": "07503",
+					"org_coordinates": {
+						"lon": -74.1545,
+						"lat": 40.8977
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Covenant Children's Hospital",
+					"org_postal_code": "79410",
+					"org_coordinates": {
+						"lon": -101.8903,
+						"lat": 33.5715
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Park Ridge",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Park Ridge",
+					"org_postal_code": "60068",
+					"org_coordinates": {
+						"lon": -87.8435,
+						"lat": 42.0122
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Western Australia",
+					"org_city": "Perth",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Perth Children's Hospital",
+					"org_postal_code": "6009",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Michigan",
+					"org_postal_code": "48201",
+					"org_coordinates": {
+						"lon": -83.0598,
+						"lat": 42.3465
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Columbia Regional",
+					"org_postal_code": "65201",
+					"org_coordinates": {
+						"lon": -92.2391,
+						"lat": 38.8994
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Danville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Geisinger Medical Center",
+					"org_postal_code": "17822",
+					"org_coordinates": {
+						"lon": -76.6134,
+						"lat": 40.9634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Spokane",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Sacred Heart Medical Center and Children's Hospital",
+					"org_postal_code": "99204",
+					"org_coordinates": {
+						"lon": -117.427,
+						"lat": 47.6476
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Washington University School of Medicine",
+					"org_postal_code": "63110",
+					"org_coordinates": {
+						"lon": -90.267,
+						"lat": 38.6267
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Montreal",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "The Montreal Children's Hospital of the MUHC",
+					"org_postal_code": "H3H 1P3",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Pittsburgh",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Pittsburgh of UPMC",
+					"org_postal_code": "15224",
+					"org_coordinates": {
+						"lon": -79.9446,
+						"lat": 40.464
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Hospital/Children's Hospital-Tampa",
+					"org_postal_code": "33607",
+					"org_coordinates": {
+						"lon": -82.5019,
+						"lat": 27.963
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arnold Palmer Hospital for Children",
+					"org_postal_code": "32806",
+					"org_coordinates": {
+						"lon": -81.3614,
+						"lat": 28.5125
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins University/Sidney Kimmel Cancer Center",
+					"org_postal_code": "21287",
+					"org_coordinates": {
+						"lon": -76.5621,
+						"lat": 39.3021
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Victoria",
+					"org_city": "Parkville",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Royal Children's Hospital",
+					"org_postal_code": "3052",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Aurora",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Colorado",
+					"org_postal_code": "80045",
+					"org_coordinates": {
+						"lon": -104.837,
+						"lat": 39.7462
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Novant Health Presbyterian Medical Center",
+					"org_postal_code": "28204",
+					"org_coordinates": {
+						"lon": -80.8273,
+						"lat": 35.2145
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente-Oakland",
+					"org_postal_code": "94611",
+					"org_coordinates": {
+						"lon": -122.2081,
+						"lat": 37.8286
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Savannah",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Health University Medical Center",
+					"org_postal_code": "31404",
+					"org_coordinates": {
+						"lon": -81.0542,
+						"lat": 32.0515
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Columbus",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nationwide Children's Hospital",
+					"org_postal_code": "43205",
+					"org_coordinates": {
+						"lon": -82.962,
+						"lat": 39.9577
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Madigan Army Medical Center",
+					"org_postal_code": "98431",
+					"org_coordinates": {
+						"lon": -122.5505,
+						"lat": 47.1056
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Yakima",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "North Star Lodge Cancer Center at Yakima Valley Memorial Hospital",
+					"org_postal_code": "98902",
+					"org_coordinates": {
+						"lon": -120.5343,
+						"lat": 46.5979
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Myers",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Golisano Children's Hospital of Southwest Florida",
+					"org_postal_code": "33908",
+					"org_coordinates": {
+						"lon": -81.9071,
+						"lat": 26.4973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Allentown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lehigh Valley Hospital-Cedar Crest",
+					"org_postal_code": "18103",
+					"org_coordinates": {
+						"lon": -75.4824,
+						"lat": 40.5705
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Asheville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mission Hospital",
+					"org_postal_code": "28801",
+					"org_coordinates": {
+						"lon": -82.5572,
+						"lat": 35.5948
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYP/Columbia University Medical Center/Herbert Irving Comprehensive Cancer Center",
+					"org_postal_code": "10032",
+					"org_coordinates": {
+						"lon": -73.9425,
+						"lat": 40.839
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Bellevue",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Overlake Medical Center",
+					"org_postal_code": "98004",
+					"org_coordinates": {
+						"lon": -122.204,
+						"lat": 47.6186
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Hollywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Regional Hospital/Joe DiMaggio Children's Hospital",
+					"org_postal_code": "33021",
+					"org_coordinates": {
+						"lon": -80.1869,
+						"lat": 26.0228
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ND",
+					"org_city": "Fargo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford Broadway Medical Center",
+					"org_postal_code": "58122",
+					"org_coordinates": {
+						"lon": -96.7842,
+						"lat": 46.8846
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Marshfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Marshfield Medical Center-Marshfield",
+					"org_postal_code": "54449",
+					"org_coordinates": {
+						"lon": -90.1945,
+						"lat": 44.6413
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SD",
+					"org_city": "Sioux Falls",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford USD Medical Center - Sioux Falls",
+					"org_postal_code": "57117-5134",
+					"org_coordinates": {
+						"lon": -96.7245,
+						"lat": 43.5513
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Birmingham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Alabama",
+					"org_postal_code": "35233",
+					"org_coordinates": {
+						"lon": -86.8014,
+						"lat": 33.5089
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Orange",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Orange County",
+					"org_postal_code": "92868",
+					"org_coordinates": {
+						"lon": -117.8683,
+						"lat": 33.7886
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OK",
+					"org_city": "Oklahoma City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Oklahoma Health Sciences Center",
+					"org_postal_code": "73104",
+					"org_coordinates": {
+						"lon": -97.5038,
+						"lat": 35.4753
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Toledo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "ProMedica Toledo Hospital/Russell J Ebeid Children's Hospital",
+					"org_postal_code": "43606",
+					"org_coordinates": {
+						"lon": -83.6099,
+						"lat": 41.6724
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Sylvania",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "ProMedica Flower Hospital",
+					"org_postal_code": "43560",
+					"org_coordinates": {
+						"lon": -83.7379,
+						"lat": 41.6992
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Alberta",
+					"org_city": "Edmonton",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "University of Alberta Hospital",
+					"org_postal_code": "T6G 2B7",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Texas Health Science Center at San Antonio",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sinai Hospital of Baltimore",
+					"org_postal_code": "21215",
+					"org_coordinates": {
+						"lon": -76.6832,
+						"lat": 39.3453
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "El Paso",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "El Paso Children's Hospital",
+					"org_postal_code": "79905",
+					"org_coordinates": {
+						"lon": -106.4242,
+						"lat": 31.7666
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Alberta",
+					"org_city": "Calgary",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Alberta Children's Hospital",
+					"org_postal_code": "T3B 6A8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Nova Scotia",
+					"org_city": "Halifax",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "IWK Health Centre",
+					"org_postal_code": "B3K 6R8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mary Bridge Children's Hospital and Health Center",
+					"org_postal_code": "98405",
+					"org_coordinates": {
+						"lon": -122.4718,
+						"lat": 47.2461
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "OptumCare Cancer Care at MountainView",
+					"org_postal_code": "89128",
+					"org_coordinates": {
+						"lon": -115.2587,
+						"lat": 36.1831
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Reno",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Renown Regional Medical Center",
+					"org_postal_code": "89502",
+					"org_coordinates": {
+						"lon": -119.7469,
+						"lat": 39.4944
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Reno",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Mary's Regional Medical Center",
+					"org_postal_code": "89503",
+					"org_coordinates": {
+						"lon": -119.8415,
+						"lat": 39.5376
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada - Central Valley",
+					"org_postal_code": "89169",
+					"org_coordinates": {
+						"lon": -115.5263,
+						"lat": 36.2548
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alliance for Childhood Diseases/Cure 4 the Kids Foundation",
+					"org_postal_code": "89135",
+					"org_coordinates": {
+						"lon": -115.3507,
+						"lat": 36.1211
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada",
+					"org_postal_code": "89148",
+					"org_coordinates": {
+						"lon": -115.3196,
+						"lat": 36.0599
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Reno",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Radiation Oncology Associates",
+					"org_postal_code": "89509",
+					"org_coordinates": {
+						"lon": -119.8976,
+						"lat": 39.4779
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Radiation Oncology Centers of Nevada Central",
+					"org_postal_code": "89106",
+					"org_coordinates": {
+						"lon": -115.1639,
+						"lat": 36.181
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada - Northwest",
+					"org_postal_code": "89128",
+					"org_coordinates": {
+						"lon": -115.2587,
+						"lat": 36.1831
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Henderson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada - Henderson",
+					"org_postal_code": "89052",
+					"org_coordinates": {
+						"lon": -115.1189,
+						"lat": 35.9946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "GenesisCare USA - Las Vegas",
+					"org_postal_code": "89109",
+					"org_coordinates": {
+						"lon": -115.1573,
+						"lat": 36.1362
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Kingman",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kingman Regional Medical Center",
+					"org_postal_code": "86401",
+					"org_coordinates": {
+						"lon": -114.0201,
+						"lat": 35.2036
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Arroyo Grande",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "PCR Oncology",
+					"org_postal_code": "93420",
+					"org_coordinates": {
+						"lon": -120.3846,
+						"lat": 35.1729
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada - Town Center",
+					"org_postal_code": "89144",
+					"org_coordinates": {
+						"lon": -115.3146,
+						"lat": 36.179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Henderson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "OptumCare Cancer Care at Seven Hills",
+					"org_postal_code": "89052",
+					"org_coordinates": {
+						"lon": -115.1189,
+						"lat": 35.9946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "OptumCare Cancer Care at Charleston",
+					"org_postal_code": "89102",
+					"org_coordinates": {
+						"lon": -115.2004,
+						"lat": 36.1433
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Radiation Oncology Centers of Nevada Southeast",
+					"org_postal_code": "89119",
+					"org_coordinates": {
+						"lon": -115.1471,
+						"lat": 36.0849
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "OptumCare Cancer Care at Fort Apache",
+					"org_postal_code": "89148",
+					"org_coordinates": {
+						"lon": -115.3196,
+						"lat": 36.0599
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Comprehensive Cancer Centers of Nevada-Summerlin",
+					"org_postal_code": "89144",
+					"org_coordinates": {
+						"lon": -115.3146,
+						"lat": 36.179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Madera",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Valley Children's Hospital",
+					"org_postal_code": "93636",
+					"org_coordinates": {
+						"lon": -120.0704,
+						"lat": 36.9581
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Renton",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Valley Medical Center",
+					"org_postal_code": "98055",
+					"org_coordinates": {
+						"lon": -122.211,
+						"lat": 47.4624
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VT",
+					"org_city": "Burlington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Vermont and State Agricultural College",
+					"org_postal_code": "05405",
+					"org_coordinates": {
+						"lon": -73.1956,
+						"lat": 44.4776
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Kansas City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Mercy Hospitals and Clinics",
+					"org_postal_code": "64108",
+					"org_coordinates": {
+						"lon": -94.5849,
+						"lat": 39.084
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Des Moines",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Blank Children's Hospital",
+					"org_postal_code": "50309",
+					"org_coordinates": {
+						"lon": -93.6292,
+						"lat": 41.5836
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Falls Church",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Inova Fairfax Hospital",
+					"org_postal_code": "22042",
+					"org_coordinates": {
+						"lon": -77.1936,
+						"lat": 38.8645
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Scarborough",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maine Children's Cancer Program",
+					"org_postal_code": "04074",
+					"org_coordinates": {
+						"lon": -70.3693,
+						"lat": 43.5917
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tampa General Hospital",
+					"org_postal_code": "33606",
+					"org_coordinates": {
+						"lon": -82.474,
+						"lat": 27.9407
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cleveland Clinic Foundation",
+					"org_postal_code": "44195",
+					"org_coordinates": {
+						"lon": -81.6209,
+						"lat": 41.5036
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Oregon Health and Science University",
+					"org_postal_code": "97239",
+					"org_coordinates": {
+						"lon": -122.6915,
+						"lat": 45.4923
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Austin",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dell Children's Medical Center of Central Texas",
+					"org_postal_code": "78723",
+					"org_coordinates": {
+						"lon": -97.6862,
+						"lat": 30.3039
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Tucson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Banner University Medical Center - Tucson",
+					"org_postal_code": "85719",
+					"org_coordinates": {
+						"lon": -110.9484,
+						"lat": 32.2456
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Nebraska Medical Center",
+					"org_postal_code": "68198",
+					"org_coordinates": {
+						"lon": -95.9773,
+						"lat": 41.2551
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Charlottesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Virginia Cancer Center",
+					"org_postal_code": "22908",
+					"org_coordinates": {
+						"lon": -78.5162,
+						"lat": 38.0346
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Methodist Children's Hospital of South Texas",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Macon",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical Center of Central Georgia",
+					"org_postal_code": "31201",
+					"org_coordinates": {
+						"lon": -83.6184,
+						"lat": 32.8199
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Roanoke",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carilion Children's",
+					"org_postal_code": "24014",
+					"org_coordinates": {
+						"lon": -79.9199,
+						"lat": 37.224
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Montreal",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Centre Hospitalier Universitaire Sainte-Justine",
+					"org_postal_code": "H3T 1C5",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "New South Wales",
+					"org_city": "Hunter Regional Mail Centre",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "John Hunter Children's Hospital",
+					"org_postal_code": "2310",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Hackensack",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Hackensack University Medical Center",
+					"org_postal_code": "07601",
+					"org_coordinates": {
+						"lon": -74.0466,
+						"lat": 40.8892
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "MedStar Georgetown University Hospital",
+					"org_postal_code": "20007",
+					"org_coordinates": {
+						"lon": -77.0771,
+						"lat": 38.9147
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's National Medical Center",
+					"org_postal_code": "20010",
+					"org_coordinates": {
+						"lon": -77.028,
+						"lat": 38.9322
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Bangor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Eastern Maine Medical Center",
+					"org_postal_code": "04401",
+					"org_coordinates": {
+						"lon": -68.8311,
+						"lat": 44.8521
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Sloan Kettering Cancer Center",
+					"org_postal_code": "10065",
+					"org_coordinates": {
+						"lon": -73.9624,
+						"lat": 40.7656
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYP/Weill Cornell Medical Center",
+					"org_postal_code": "10065",
+					"org_coordinates": {
+						"lon": -73.9624,
+						"lat": 40.7656
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Christopher's Hospital for Children",
+					"org_postal_code": "19134",
+					"org_coordinates": {
+						"lon": -75.1049,
+						"lat": 39.9903
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rainbow Babies and Childrens Hospital",
+					"org_postal_code": "44106",
+					"org_coordinates": {
+						"lon": -81.6065,
+						"lat": 41.5063
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Springfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Southern Illinois University School of Medicine",
+					"org_postal_code": "62702",
+					"org_coordinates": {
+						"lon": -89.6438,
+						"lat": 39.8235
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Royal Oak",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Beaumont Children's Hospital-Royal Oak",
+					"org_postal_code": "48073",
+					"org_coordinates": {
+						"lon": -83.1647,
+						"lat": 42.5191
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Temple",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Scott and White Memorial Hospital",
+					"org_postal_code": "76508",
+					"org_coordinates": {
+						"lon": -97.3641,
+						"lat": 31.0937
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Bethesda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Walter Reed National Military Medical Center",
+					"org_postal_code": "20889-5600",
+					"org_coordinates": {
+						"lon": -77.098,
+						"lat": 39.0095
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Denver",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rocky Mountain Hospital for Children-Presbyterian Saint Luke's Medical Center",
+					"org_postal_code": "80218",
+					"org_coordinates": {
+						"lon": -104.9709,
+						"lat": 39.7312
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WV",
+					"org_city": "Charleston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Virginia University Charleston Division",
+					"org_postal_code": "25304",
+					"org_coordinates": {
+						"lon": -81.5932,
+						"lat": 38.301
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Miami Miller School of Medicine-Sylvester Cancer Center",
+					"org_postal_code": "33136",
+					"org_coordinates": {
+						"lon": -80.2039,
+						"lat": 25.7869
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Saskatchewan",
+					"org_city": "Saskatoon",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Saskatoon Cancer Centre",
+					"org_postal_code": "S7N 4H4",
+					"org_coordinates": null,
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Saskatchewan",
+					"org_city": "Saskatoon",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Jim Pattison Children's Hospital",
+					"org_postal_code": "S7N 0W8",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cedars Sinai Medical Center",
+					"org_postal_code": "90048",
+					"org_coordinates": {
+						"lon": -118.3727,
+						"lat": 34.0726
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mattel Children's Hospital UCLA",
+					"org_postal_code": "90095",
+					"org_coordinates": {
+						"lon": -118.4432,
+						"lat": 34.071
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Illinois",
+					"org_postal_code": "60612",
+					"org_coordinates": {
+						"lon": -87.6877,
+						"lat": 41.8804
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mercy Hospital Saint Louis",
+					"org_postal_code": "63141",
+					"org_coordinates": {
+						"lon": -90.4582,
+						"lat": 38.6572
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Syracuse",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "State University of New York Upstate Medical University",
+					"org_postal_code": "13210",
+					"org_coordinates": {
+						"lon": -76.1267,
+						"lat": 43.0355
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Los Angeles",
+					"org_postal_code": "90027",
+					"org_coordinates": {
+						"lon": -118.292,
+						"lat": 34.1252
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Winston-Salem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wake Forest University Health Sciences",
+					"org_postal_code": "27157",
+					"org_coordinates": {
+						"lon": -80.2096,
+						"lat": 36.0964
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "RI",
+					"org_city": "Providence",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rhode Island Hospital",
+					"org_postal_code": "02903",
+					"org_coordinates": {
+						"lon": -71.4128,
+						"lat": 41.8204
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital and Medical Center of Omaha",
+					"org_postal_code": "68114",
+					"org_coordinates": {
+						"lon": -96.0508,
+						"lat": 41.2627
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Quebec",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Centre Hospitalier Universitaire de Quebec",
+					"org_postal_code": "G1V 4G2",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Chattanooga",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "T C Thompson Children's Hospital",
+					"org_postal_code": "37403",
+					"org_coordinates": {
+						"lon": -85.2959,
+						"lat": 35.0463
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Mesa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Banner Children's at Desert",
+					"org_postal_code": "85202",
+					"org_coordinates": {
+						"lon": -111.8737,
+						"lat": 33.3827
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AR",
+					"org_city": "Little Rock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arkansas Children's Hospital",
+					"org_postal_code": "72202-3591",
+					"org_coordinates": {
+						"lon": -92.2557,
+						"lat": 34.7344
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Legacy Emanuel Children's Hospital",
+					"org_postal_code": "97227",
+					"org_coordinates": {
+						"lon": -122.6742,
+						"lat": 45.5435
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "East Lansing",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Michigan State University Clinical Center",
+					"org_postal_code": "48824-7016",
+					"org_coordinates": {
+						"lon": -84.4779,
+						"lat": 42.7234
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Albany",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Albany Medical Center",
+					"org_postal_code": "12208",
+					"org_coordinates": {
+						"lon": -73.8071,
+						"lat": 42.6512
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "London",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital",
+					"org_postal_code": "N6A 5W9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "West Palm Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Mary's Hospital",
+					"org_postal_code": "33407",
+					"org_coordinates": {
+						"lon": -80.0917,
+						"lat": 26.7596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Long Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Miller Children's and Women's Hospital Long Beach",
+					"org_postal_code": "90806",
+					"org_coordinates": {
+						"lon": -118.1736,
+						"lat": 33.8078
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MS",
+					"org_city": "Jackson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Mississippi Medical Center",
+					"org_postal_code": "39216",
+					"org_coordinates": {
+						"lon": -90.1625,
+						"lat": 32.3333
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Phoenix",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Phoenix Childrens Hospital",
+					"org_postal_code": "85016",
+					"org_coordinates": {
+						"lon": -112.0225,
+						"lat": 33.527
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Minnesota/Masonic Cancer Center",
+					"org_postal_code": "55455",
+					"org_coordinates": {
+						"lon": -93.2319,
+						"lat": 44.974
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+					"org_postal_code": "55404",
+					"org_coordinates": {
+						"lon": -93.2613,
+						"lat": 44.9618
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "New South Wales",
+					"org_city": "Westmead",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "The Children's Hospital at Westmead",
+					"org_postal_code": "2145",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Ottawa",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital of Eastern Ontario",
+					"org_postal_code": "K1H 8L1",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "The Children's Hospital at TriStar Centennial",
+					"org_postal_code": "37203",
+					"org_coordinates": {
+						"lon": -86.79,
+						"lat": 36.1494
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Niles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lakeland Hospital Niles",
+					"org_postal_code": "49120",
+					"org_coordinates": {
+						"lon": -86.2139,
+						"lat": 41.8406
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tufts Children's Hospital",
+					"org_postal_code": "02111",
+					"org_coordinates": {
+						"lon": -71.0614,
+						"lat": 42.3512
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Reno",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cancer Care Specialists - Reno",
+					"org_postal_code": "89511",
+					"org_coordinates": {
+						"lon": -119.8071,
+						"lat": 39.3905
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Maywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loyola University Medical Center",
+					"org_postal_code": "60153",
+					"org_coordinates": {
+						"lon": -87.8451,
+						"lat": 41.8685
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Hershey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Penn State Children's Hospital",
+					"org_postal_code": "17033",
+					"org_coordinates": {
+						"lon": -76.626,
+						"lat": 40.2634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New Hyde Park",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "The Steven and Alexandra Cohen Children's Medical Center of New York",
+					"org_postal_code": "11040",
+					"org_coordinates": {
+						"lon": -73.6798,
+						"lat": 40.7459
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Brooklyn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maimonides Medical Center",
+					"org_postal_code": "11219",
+					"org_coordinates": {
+						"lon": -73.9967,
+						"lat": 40.6327
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "New Brunswick",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rutgers Cancer Institute of New Jersey-Robert Wood Johnson University Hospital",
+					"org_postal_code": "08903",
+					"org_coordinates": {
+						"lon": -74.447,
+						"lat": 40.5102
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lurie Children's Hospital-Chicago",
+					"org_postal_code": "60611",
+					"org_coordinates": {
+						"lon": -87.6187,
+						"lat": 41.8946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PR",
+					"org_city": "Caguas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "HIMA San Pablo Oncologic Hospital",
+					"org_postal_code": "00726",
+					"org_coordinates": {
+						"lon": -66.0489,
+						"lat": 18.2364
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Dayton",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dayton Children's Hospital",
+					"org_postal_code": "45404",
+					"org_coordinates": {
+						"lon": -84.1582,
+						"lat": 39.7907
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Iowa City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Iowa/Holden Comprehensive Cancer Center",
+					"org_postal_code": "52242",
+					"org_coordinates": {
+						"lon": -91.5469,
+						"lat": 41.6596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Riley Hospital for Children",
+					"org_postal_code": "46202",
+					"org_coordinates": {
+						"lon": -86.163,
+						"lat": 39.7837
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Mobile",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "USA Health Strada Patient Care Center",
+					"org_postal_code": "36604",
+					"org_coordinates": {
+						"lon": -88.0679,
+						"lat": 30.6824
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Madison",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Wisconsin Carbone Cancer Center",
+					"org_postal_code": "53792",
+					"org_coordinates": {
+						"lon": -89.4329,
+						"lat": 43.0769
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carolinas Medical Center/Levine Cancer Institute",
+					"org_postal_code": "28203",
+					"org_coordinates": {
+						"lon": -80.8578,
+						"lat": 35.2083
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Vanderbilt University/Ingram Cancer Center",
+					"org_postal_code": "37232",
+					"org_coordinates": {
+						"lon": -86.8096,
+						"lat": 36.1437
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Stony Brook",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Stony Brook University Medical Center",
+					"org_postal_code": "11794",
+					"org_coordinates": {
+						"lon": -73.1225,
+						"lat": 40.9145
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Ann Arbor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "C S Mott Children's Hospital",
+					"org_postal_code": "48109",
+					"org_coordinates": {
+						"lon": -83.7144,
+						"lat": 42.2909
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "UT",
+					"org_city": "Salt Lake City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Primary Children's Hospital",
+					"org_postal_code": "84113",
+					"org_coordinates": {
+						"lon": -111.833,
+						"lat": 40.7638
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Amarillo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Texas Tech University Health Sciences Center-Amarillo",
+					"org_postal_code": "79106",
+					"org_coordinates": {
+						"lon": -101.956,
+						"lat": 35.2012
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UMC Cancer Center / UMC Health System",
+					"org_postal_code": "79415",
+					"org_coordinates": {
+						"lon": -101.8817,
+						"lat": 33.6248
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "HI",
+					"org_city": "Honolulu",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kapiolani Medical Center for Women and Children",
+					"org_postal_code": "96826",
+					"org_coordinates": {
+						"lon": -157.8291,
+						"lat": 21.2952
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Oak Lawn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Oak Lawn",
+					"org_postal_code": "60453",
+					"org_coordinates": {
+						"lon": -87.7521,
+						"lat": 41.7129
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mayo Clinic in Rochester",
+					"org_postal_code": "55905",
+					"org_coordinates": {
+						"lon": -92.4912,
+						"lat": 44.0368
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Diego",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rady Children's Hospital - San Diego",
+					"org_postal_code": "92123",
+					"org_coordinates": {
+						"lon": -117.1356,
+						"lat": 32.8053
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Lexington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Kentucky/Markey Cancer Center",
+					"org_postal_code": "40536",
+					"org_coordinates": {
+						"lon": -84.5089,
+						"lat": 38.0316
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "Hartford",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Connecticut Children's Medical Center",
+					"org_postal_code": "06106",
+					"org_coordinates": {
+						"lon": -72.6959,
+						"lat": 41.7484
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "BI-LO Charities Children's Cancer Center",
+					"org_postal_code": "29605",
+					"org_coordinates": {
+						"lon": -82.3803,
+						"lat": 34.7768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Seneca",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Cancer Institute - Seneca",
+					"org_postal_code": "29672",
+					"org_coordinates": {
+						"lon": -82.9753,
+						"lat": 34.7097
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Cancer Institute - Faris",
+					"org_postal_code": "29605",
+					"org_coordinates": {
+						"lon": -82.3803,
+						"lat": 34.7768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Cancer Institute - Eastside",
+					"org_postal_code": "29615",
+					"org_coordinates": {
+						"lon": -82.2952,
+						"lat": 34.8562
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Richland Hospital",
+					"org_postal_code": "29203",
+					"org_coordinates": {
+						"lon": -81.0612,
+						"lat": 34.1179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greer",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Cancer Institute - Greer",
+					"org_postal_code": "29650",
+					"org_coordinates": {
+						"lon": -82.2584,
+						"lat": 34.8978
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Knoxville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East Tennessee Childrens Hospital",
+					"org_postal_code": "37916",
+					"org_coordinates": {
+						"lon": -83.932,
+						"lat": 35.9553
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Seattle",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Seattle Children's Hospital",
+					"org_postal_code": "98105",
+					"org_coordinates": {
+						"lon": -122.2964,
+						"lat": 47.6619
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dana-Farber Cancer Institute",
+					"org_postal_code": "02215",
+					"org_coordinates": {
+						"lon": -71.1025,
+						"lat": 42.3469
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Massachusetts General Hospital Cancer Center",
+					"org_postal_code": "02114",
+					"org_coordinates": {
+						"lon": -71.068,
+						"lat": 42.3621
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Peoria",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Midwest Affiliate",
+					"org_postal_code": "61637",
+					"org_coordinates": {
+						"lon": -89.5906,
+						"lat": 40.7018
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nicklaus Children's Hospital",
+					"org_postal_code": "33155",
+					"org_coordinates": {
+						"lon": -80.3112,
+						"lat": 25.7365
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Hamilton",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "McMaster Children's Hospital at Hamilton Health Sciences",
+					"org_postal_code": "L8N 3Z5",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Loma Linda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loma Linda University Medical Center",
+					"org_postal_code": "92354",
+					"org_coordinates": {
+						"lon": -117.2527,
+						"lat": 34.044
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Valhalla",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "New York Medical College",
+					"org_postal_code": "10595",
+					"org_coordinates": {
+						"lon": -73.7807,
+						"lat": 41.0861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Sacramento",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of California Davis Comprehensive Cancer Center",
+					"org_postal_code": "95817",
+					"org_coordinates": {
+						"lon": -121.4572,
+						"lat": 38.5503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical City Dallas Hospital",
+					"org_postal_code": "75230",
+					"org_coordinates": {
+						"lon": -96.7921,
+						"lat": 32.9028
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Morristown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Morristown Medical Center",
+					"org_postal_code": "07960",
+					"org_coordinates": {
+						"lon": -74.4992,
+						"lat": 40.7857
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2021-06711"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT02176967",
+			"brief_title": "Response and Biology-Based Risk Factor-Guided Therapy in Treating Younger Patients with Non-high Risk Neuroblastoma",
+			"eligibility": {
+				"structured": {
+					"max_age": "18 Months",
+					"max_age_number": 18.0,
+					"min_age_unit": "Months",
+					"max_age_unit": "Months",
+					"max_age_in_years": 1.5,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "0 Months",
+					"min_age_number": 0.0,
+					"min_age_in_years": 0.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neuroblastoma (NBL)",
+						"Neuroblastoma, NOS",
+						"Neuroblastoma (Schwannian Stroma-Poor)",
+						"Neural Crest Tumor, Malignant",
+						"NEUROBLASTOMA, MALIGNANT"
+					],
+					"nci_thesaurus_concept_id": "C3270",
+					"name": "Neuroblastoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6963"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"GANGLIONEUROBLASTOMA, MALIGNANT"
+					],
+					"nci_thesaurus_concept_id": "C3790",
+					"name": "Ganglioneuroblastoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6963"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7835",
+					"name": "Localized Resectable Neuroblastoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C150620",
+						"C27294"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C8277",
+					"name": "Localized Unresectable Neuroblastoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27294",
+						"C150622"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"embryonal tumor"
+					],
+					"nci_thesaurus_concept_id": "C3264",
+					"name": "Embryonal Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C6963",
+					"name": "Neuroblastic Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3716"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Primitive Neuroectodermal Neoplasm",
+						"PNET",
+						"Neuroepithelioma",
+						"PNET, NOS",
+						"Neuroectodermal Tumor",
+						"Primitive neuroectodermal tumor, NOS",
+						"Primitive Neuroectodermal Tumor",
+						"Neuroectodermal Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3716",
+					"name": "Primitive Neuroectodermal Tumor (PNET)",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3264",
+						"C3787",
+						"C4788"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Local Cancer",
+						"Localized Cancer",
+						"Localized Malignancy"
+					],
+					"nci_thesaurus_concept_id": "C8576",
+					"name": "Localized Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C36037",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Non-Metastatic Neoplasm",
+						"tumor_confined_to_organ_of_origin",
+						"tumor confined to organ of origin",
+						"Non-metastatic Disease"
+					],
+					"nci_thesaurus_concept_id": "C36037",
+					"name": "Localized Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C27294",
+					"name": "Localized Primitive Neuroectodermal Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3716",
+						"C8576"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C150602",
+					"name": "Resectable Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C150622",
+					"name": "Unresectable Neuroblastoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3270",
+						"C27359"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C150620",
+					"name": "Resectable Neuroblastoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C150602",
+						"C3270"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Unresectable Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C27359",
+					"name": "Unresectable Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "AK",
+					"org_city": "Anchorage",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Alaska Medical Center",
+					"org_postal_code": "99508",
+					"org_coordinates": {
+						"lon": -149.8115,
+						"lat": 61.198
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DE",
+					"org_city": "Wilmington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alfred I duPont Hospital for Children",
+					"org_postal_code": "19803",
+					"org_coordinates": {
+						"lon": -75.5445,
+						"lat": 39.7973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Hospital",
+					"org_postal_code": "32827",
+					"org_coordinates": {
+						"lon": -81.3094,
+						"lat": 28.4288
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Lauderdale",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Broward Health Medical Center",
+					"org_postal_code": "33316",
+					"org_coordinates": {
+						"lon": -80.132,
+						"lat": 26.0999
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Jacksonville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Clinic-Jacksonville",
+					"org_postal_code": "32207",
+					"org_coordinates": {
+						"lon": -81.6318,
+						"lat": 30.291
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Saint Petersburg",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins All Children's Hospital",
+					"org_postal_code": "33701",
+					"org_coordinates": {
+						"lon": -82.6368,
+						"lat": 27.771
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Toronto",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Hospital for Sick Children",
+					"org_postal_code": "M5G 1X8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Buffalo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Roswell Park Cancer Institute",
+					"org_postal_code": "14263",
+					"org_coordinates": {
+						"lon": -78.8765,
+						"lat": 42.8868
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Carmel",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "IU Health North Hospital",
+					"org_postal_code": "46032",
+					"org_coordinates": {
+						"lon": -86.1603,
+						"lat": 39.9701
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Duarte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "City of Hope Comprehensive Cancer Center",
+					"org_postal_code": "91010",
+					"org_coordinates": {
+						"lon": -117.9655,
+						"lat": 34.1357
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of San Antonio",
+					"org_postal_code": "78207",
+					"org_coordinates": {
+						"lon": -98.5276,
+						"lat": 29.4282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Baylor College of Medicine/Dan L Duncan Comprehensive Cancer Center",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UT Southwestern/Simmons Cancer Center-Dallas",
+					"org_postal_code": "75390",
+					"org_coordinates": {
+						"lon": -96.7016,
+						"lat": 32.8432
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "New Haven",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Yale University",
+					"org_postal_code": "06520",
+					"org_coordinates": {
+						"lon": -72.9291,
+						"lat": 41.31
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cincinnati",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cincinnati Children's Hospital Medical Center",
+					"org_postal_code": "45229",
+					"org_coordinates": {
+						"lon": -84.4859,
+						"lat": 39.1532
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Gainesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Florida Health Science Center - Gainesville",
+					"org_postal_code": "32610",
+					"org_coordinates": {
+						"lon": -82.344,
+						"lat": 29.6395
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Chicago Comprehensive Cancer Center",
+					"org_postal_code": "60637",
+					"org_coordinates": {
+						"lon": -87.6021,
+						"lat": 41.781
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Chapel Hill",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UNC Lineberger Comprehensive Cancer Center",
+					"org_postal_code": "27599",
+					"org_coordinates": {
+						"lon": -79.0561,
+						"lat": 35.9134
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NH",
+					"org_city": "Lebanon",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dartmouth Hitchcock Medical Center/Dartmouth Cancer Center",
+					"org_postal_code": "03756",
+					"org_coordinates": {
+						"lon": -72.2895,
+						"lat": 43.7029
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Worcester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UMass Memorial Medical Center - University Campus",
+					"org_postal_code": "01655",
+					"org_coordinates": {
+						"lon": -71.7598,
+						"lat": 42.2778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Louisville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Norton Children's Hospital",
+					"org_postal_code": "40202",
+					"org_coordinates": {
+						"lon": -85.7498,
+						"lat": 38.2536
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Philadelphia",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WV",
+					"org_city": "Morgantown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Virginia University Healthcare",
+					"org_postal_code": "26506",
+					"org_coordinates": {
+						"lon": -79.9572,
+						"lat": 39.6496
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Mineola",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYU Winthrop Hospital",
+					"org_postal_code": "11501",
+					"org_coordinates": {
+						"lon": -73.6388,
+						"lat": 40.7469
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Laura and Isaac Perlmutter Cancer Center at NYU Langone",
+					"org_postal_code": "10016",
+					"org_coordinates": {
+						"lon": -73.9782,
+						"lat": 40.7445
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Francisco",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Medical Center-Mission Bay",
+					"org_postal_code": "94158",
+					"org_coordinates": {
+						"lon": -122.3951,
+						"lat": 37.7587
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Benioff Children's Hospital Oakland",
+					"org_postal_code": "94609",
+					"org_coordinates": {
+						"lon": -122.2647,
+						"lat": 37.8343
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Western Australia",
+					"org_city": "Perth",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Princess Margaret Hospital for Children",
+					"org_postal_code": "6008",
+					"org_coordinates": null,
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Norfolk",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of The King's Daughters",
+					"org_postal_code": "23507",
+					"org_coordinates": {
+						"lon": -76.3092,
+						"lat": 36.8688
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Kingston",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Kingston Health Sciences Centre",
+					"org_postal_code": "K7L 2V7",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mount Sinai Hospital",
+					"org_postal_code": "10029",
+					"org_coordinates": {
+						"lon": -73.9439,
+						"lat": 40.7917
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Palo Alto",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lucile Packard Children's Hospital Stanford University",
+					"org_postal_code": "94304",
+					"org_coordinates": {
+						"lon": -122.1462,
+						"lat": 37.4059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital New Orleans",
+					"org_postal_code": "70118",
+					"org_coordinates": {
+						"lon": -90.1244,
+						"lat": 29.9472
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WV",
+					"org_city": "Huntington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Edwards Comprehensive Cancer Center",
+					"org_postal_code": "25701",
+					"org_coordinates": {
+						"lon": -82.4123,
+						"lat": 38.3693
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Newark",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Newark Beth Israel Medical Center",
+					"org_postal_code": "07112",
+					"org_coordinates": {
+						"lon": -74.2114,
+						"lat": 40.7108
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Fort Worth",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cook Children's Medical Center",
+					"org_postal_code": "76104",
+					"org_coordinates": {
+						"lon": -97.3172,
+						"lat": 32.7282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Sherbrooke",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Centre Hospitalier Universitaire de Sherbrooke-Fleurimont",
+					"org_postal_code": "J1H 5N4",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Bronson Methodist Hospital",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Spectrum Health at Butterworth Campus",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Helen DeVos Children's Hospital at Spectrum Health",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Michigan Cancer Center",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Corpus Christi",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Driscoll Children's Hospital",
+					"org_postal_code": "78411",
+					"org_coordinates": {
+						"lon": -97.3858,
+						"lat": 27.7297
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wayne State University/Karmanos Cancer Institute",
+					"org_postal_code": "48201",
+					"org_coordinates": {
+						"lon": -83.0598,
+						"lat": 42.3465
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Richmond",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Virginia Commonwealth University/Massey Cancer Center",
+					"org_postal_code": "23298",
+					"org_coordinates": {
+						"lon": -77.4296,
+						"lat": 37.5427
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Pensacola",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Clinic - Pensacola",
+					"org_postal_code": "32504",
+					"org_coordinates": {
+						"lon": -87.1905,
+						"lat": 30.4842
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Manitoba",
+					"org_city": "Winnipeg",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "CancerCare Manitoba",
+					"org_postal_code": "R3E 0V9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "South Australia",
+					"org_city": "North Adelaide",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Women's and Children's Hospital-Adelaide",
+					"org_postal_code": "5006",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Pensacola",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sacred Heart Hospital",
+					"org_postal_code": "32504",
+					"org_coordinates": {
+						"lon": -87.1905,
+						"lat": 30.4842
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ochsner Medical Center Jefferson",
+					"org_postal_code": "70121",
+					"org_coordinates": {
+						"lon": -90.1597,
+						"lat": 29.9622
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Bronx",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Montefiore Medical Center - Moses Campus",
+					"org_postal_code": "10467",
+					"org_coordinates": {
+						"lon": -73.8721,
+						"lat": 40.8778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ID",
+					"org_city": "Boise",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Luke's Cancer Institute - Boise",
+					"org_postal_code": "83712",
+					"org_coordinates": {
+						"lon": -116.082,
+						"lat": 43.5932
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East  Carolina University",
+					"org_postal_code": "27834",
+					"org_coordinates": {
+						"lon": -77.3482,
+						"lat": 35.6768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "AdventHealth Orlando",
+					"org_postal_code": "32803",
+					"org_coordinates": {
+						"lon": -81.3481,
+						"lat": 28.5545
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Augusta",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Augusta University Medical Center",
+					"org_postal_code": "30912",
+					"org_coordinates": {
+						"lon": -82.2514,
+						"lat": 33.4687
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Paterson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Regional Medical Center",
+					"org_postal_code": "07503",
+					"org_coordinates": {
+						"lon": -74.1545,
+						"lat": 40.8977
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Charleston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical University of South Carolina",
+					"org_postal_code": "29425",
+					"org_coordinates": {
+						"lon": -79.9416,
+						"lat": 32.7799
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Western Australia",
+					"org_city": "Perth",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Perth Children's Hospital",
+					"org_postal_code": "6009",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Covenant Children's Hospital",
+					"org_postal_code": "79410",
+					"org_coordinates": {
+						"lon": -101.8903,
+						"lat": 33.5715
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Park Ridge",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Park Ridge",
+					"org_postal_code": "60068",
+					"org_coordinates": {
+						"lon": -87.8435,
+						"lat": 42.0122
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Michigan",
+					"org_postal_code": "48201",
+					"org_coordinates": {
+						"lon": -83.0598,
+						"lat": 42.3465
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Columbia Regional",
+					"org_postal_code": "65201",
+					"org_coordinates": {
+						"lon": -92.2391,
+						"lat": 38.8994
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Danville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Geisinger Medical Center",
+					"org_postal_code": "17822",
+					"org_coordinates": {
+						"lon": -76.6134,
+						"lat": 40.9634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Spokane",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Sacred Heart Medical Center and Children's Hospital",
+					"org_postal_code": "99204",
+					"org_coordinates": {
+						"lon": -117.427,
+						"lat": 47.6476
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NM",
+					"org_city": "Albuquerque",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of New Mexico Cancer Center",
+					"org_postal_code": "87102",
+					"org_coordinates": {
+						"lon": -106.6469,
+						"lat": 35.0815
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Washington University School of Medicine",
+					"org_postal_code": "63110",
+					"org_coordinates": {
+						"lon": -90.267,
+						"lat": 38.6267
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Montreal",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "The Montreal Children's Hospital of the MUHC",
+					"org_postal_code": "H3H 1P3",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Torrance",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lundquist Institute for Biomedical Innovation at Harbor-UCLA Medical Center",
+					"org_postal_code": "90502",
+					"org_coordinates": {
+						"lon": -118.2928,
+						"lat": 33.8359
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Pittsburgh",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Pittsburgh of UPMC",
+					"org_postal_code": "15224",
+					"org_coordinates": {
+						"lon": -79.9446,
+						"lat": 40.464
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Hospital/Children's Hospital-Tampa",
+					"org_postal_code": "33607",
+					"org_coordinates": {
+						"lon": -82.5019,
+						"lat": 27.963
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arnold Palmer Hospital for Children",
+					"org_postal_code": "32806",
+					"org_coordinates": {
+						"lon": -81.3614,
+						"lat": 28.5125
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins University/Sidney Kimmel Cancer Center",
+					"org_postal_code": "21287",
+					"org_coordinates": {
+						"lon": -76.5621,
+						"lat": 39.3021
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Aurora",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Colorado",
+					"org_postal_code": "80045",
+					"org_coordinates": {
+						"lon": -104.837,
+						"lat": 39.7462
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ascension Saint John Hospital",
+					"org_postal_code": "48236",
+					"org_coordinates": {
+						"lon": -82.8975,
+						"lat": 42.4243
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Novant Health Presbyterian Medical Center",
+					"org_postal_code": "28204",
+					"org_coordinates": {
+						"lon": -80.8273,
+						"lat": 35.2145
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "New Brunswick",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Peter's University Hospital",
+					"org_postal_code": "08901",
+					"org_coordinates": {
+						"lon": -74.4473,
+						"lat": 40.4861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente-Oakland",
+					"org_postal_code": "94611",
+					"org_coordinates": {
+						"lon": -122.2081,
+						"lat": 37.8286
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Atlanta",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Healthcare of Atlanta - Egleston",
+					"org_postal_code": "30322",
+					"org_coordinates": {
+						"lon": -84.3239,
+						"lat": 33.792
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Savannah",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Health University Medical Center",
+					"org_postal_code": "31404",
+					"org_coordinates": {
+						"lon": -81.0542,
+						"lat": 32.0515
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Milwaukee",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Wisconsin",
+					"org_postal_code": "53226",
+					"org_coordinates": {
+						"lon": -88.0423,
+						"lat": 43.0503
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Sacramento",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sutter Medical Center Sacramento",
+					"org_postal_code": "95816",
+					"org_coordinates": {
+						"lon": -121.4671,
+						"lat": 38.5712
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Columbus",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nationwide Children's Hospital",
+					"org_postal_code": "43205",
+					"org_coordinates": {
+						"lon": -82.962,
+						"lat": 39.9577
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Madigan Army Medical Center",
+					"org_postal_code": "98431",
+					"org_coordinates": {
+						"lon": -122.5505,
+						"lat": 47.1056
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Myers",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Golisano Children's Hospital of Southwest Florida",
+					"org_postal_code": "33908",
+					"org_coordinates": {
+						"lon": -81.9071,
+						"lat": 26.4973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Bethlehem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lehigh Valley Hospital - Muhlenberg",
+					"org_postal_code": "18017",
+					"org_coordinates": {
+						"lon": -75.3902,
+						"lat": 40.6607
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Allentown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lehigh Valley Hospital-Cedar Crest",
+					"org_postal_code": "18103",
+					"org_coordinates": {
+						"lon": -75.4824,
+						"lat": 40.5705
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Asheville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mission Hospital",
+					"org_postal_code": "28801",
+					"org_coordinates": {
+						"lon": -82.5572,
+						"lat": 35.5948
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYP/Columbia University Medical Center/Herbert Irving Comprehensive Cancer Center",
+					"org_postal_code": "10032",
+					"org_coordinates": {
+						"lon": -73.9425,
+						"lat": 40.839
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Hollywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Regional Hospital/Joe DiMaggio Children's Hospital",
+					"org_postal_code": "33021",
+					"org_coordinates": {
+						"lon": -80.1869,
+						"lat": 26.0228
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ND",
+					"org_city": "Fargo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford Broadway Medical Center",
+					"org_postal_code": "58122",
+					"org_coordinates": {
+						"lon": -96.7842,
+						"lat": 46.8846
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Marshfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Marshfield Medical Center-Marshfield",
+					"org_postal_code": "54449",
+					"org_coordinates": {
+						"lon": -90.1945,
+						"lat": 44.6413
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SD",
+					"org_city": "Sioux Falls",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford USD Medical Center - Sioux Falls",
+					"org_postal_code": "57117-5134",
+					"org_coordinates": {
+						"lon": -96.7245,
+						"lat": 43.5513
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Birmingham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Alabama",
+					"org_postal_code": "35233",
+					"org_coordinates": {
+						"lon": -86.8014,
+						"lat": 33.5089
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Orange",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Orange County",
+					"org_postal_code": "92868",
+					"org_coordinates": {
+						"lon": -117.8683,
+						"lat": 33.7886
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OK",
+					"org_city": "Oklahoma City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Oklahoma Health Sciences Center",
+					"org_postal_code": "73104",
+					"org_coordinates": {
+						"lon": -97.5038,
+						"lat": 35.4753
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Toledo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "ProMedica Toledo Hospital/Russell J Ebeid Children's Hospital",
+					"org_postal_code": "43606",
+					"org_coordinates": {
+						"lon": -83.6099,
+						"lat": 41.6724
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Alberta",
+					"org_city": "Edmonton",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "University of Alberta Hospital",
+					"org_postal_code": "T6G 2B7",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Texas Health Science Center at San Antonio",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sinai Hospital of Baltimore",
+					"org_postal_code": "21215",
+					"org_coordinates": {
+						"lon": -76.6832,
+						"lat": 39.3453
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "El Paso",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "El Paso Children's Hospital",
+					"org_postal_code": "79905",
+					"org_coordinates": {
+						"lon": -106.4242,
+						"lat": 31.7666
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Alberta",
+					"org_city": "Calgary",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Alberta Children's Hospital",
+					"org_postal_code": "T3B 6A8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Nova Scotia",
+					"org_city": "Halifax",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "IWK Health Centre",
+					"org_postal_code": "B3K 6R8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mary Bridge Children's Hospital and Health Center",
+					"org_postal_code": "98405",
+					"org_coordinates": {
+						"lon": -122.4718,
+						"lat": 47.2461
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sunrise Hospital and Medical Center",
+					"org_postal_code": "89109",
+					"org_coordinates": {
+						"lon": -115.1573,
+						"lat": 36.1362
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alliance for Childhood Diseases/Cure 4 the Kids Foundation",
+					"org_postal_code": "89135",
+					"org_coordinates": {
+						"lon": -115.3507,
+						"lat": 36.1211
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University Medical Center of Southern Nevada",
+					"org_postal_code": "89102",
+					"org_coordinates": {
+						"lon": -115.2004,
+						"lat": 36.1433
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Summerlin Hospital Medical Center",
+					"org_postal_code": "89144",
+					"org_coordinates": {
+						"lon": -115.3146,
+						"lat": 36.179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Reno",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Renown Regional Medical Center",
+					"org_postal_code": "89502",
+					"org_coordinates": {
+						"lon": -119.7469,
+						"lat": 39.4944
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ascension Saint Vincent Indianapolis Hospital",
+					"org_postal_code": "46260",
+					"org_coordinates": {
+						"lon": -86.18,
+						"lat": 39.8971
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Madera",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Valley Children's Hospital",
+					"org_postal_code": "93636",
+					"org_coordinates": {
+						"lon": -120.0704,
+						"lat": 36.9581
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VT",
+					"org_city": "Burlington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Vermont and State Agricultural College",
+					"org_postal_code": "05405",
+					"org_coordinates": {
+						"lon": -73.1956,
+						"lat": 44.4776
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Kansas City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Mercy Hospitals and Clinics",
+					"org_postal_code": "64108",
+					"org_coordinates": {
+						"lon": -94.5849,
+						"lat": 39.084
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Des Moines",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Blank Children's Hospital",
+					"org_postal_code": "50309",
+					"org_coordinates": {
+						"lon": -93.6292,
+						"lat": 41.5836
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Falls Church",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Inova Fairfax Hospital",
+					"org_postal_code": "22042",
+					"org_coordinates": {
+						"lon": -77.1936,
+						"lat": 38.8645
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Scarborough",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maine Children's Cancer Program",
+					"org_postal_code": "04074",
+					"org_coordinates": {
+						"lon": -70.3693,
+						"lat": 43.5917
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tampa General Hospital",
+					"org_postal_code": "33606",
+					"org_coordinates": {
+						"lon": -82.474,
+						"lat": 27.9407
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Springfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Baystate Medical Center",
+					"org_postal_code": "01199",
+					"org_coordinates": {
+						"lon": -72.6055,
+						"lat": 42.1198
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cleveland Clinic Foundation",
+					"org_postal_code": "44195",
+					"org_coordinates": {
+						"lon": -81.6209,
+						"lat": 41.5036
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Oregon Health and Science University",
+					"org_postal_code": "97239",
+					"org_coordinates": {
+						"lon": -122.6915,
+						"lat": 45.4923
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Austin",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dell Children's Medical Center of Central Texas",
+					"org_postal_code": "78723",
+					"org_coordinates": {
+						"lon": -97.6862,
+						"lat": 30.3039
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Tucson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Banner University Medical Center - Tucson",
+					"org_postal_code": "85719",
+					"org_coordinates": {
+						"lon": -110.9484,
+						"lat": 32.2456
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Nebraska Medical Center",
+					"org_postal_code": "68198",
+					"org_coordinates": {
+						"lon": -95.9773,
+						"lat": 41.2551
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Charlottesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Virginia Cancer Center",
+					"org_postal_code": "22908",
+					"org_coordinates": {
+						"lon": -78.5162,
+						"lat": 38.0346
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Methodist Children's Hospital of South Texas",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Roanoke",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carilion Children's",
+					"org_postal_code": "24014",
+					"org_coordinates": {
+						"lon": -79.9199,
+						"lat": 37.224
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Flint",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Hurley Medical Center",
+					"org_postal_code": "48503",
+					"org_coordinates": {
+						"lon": -83.6895,
+						"lat": 43.0112
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Montreal",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Centre Hospitalier Universitaire Sainte-Justine",
+					"org_postal_code": "H3T 1C5",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": null,
+					"org_city": "Riyadh",
+					"org_va": false,
+					"org_country": "Saudi Arabia",
+					"org_name": "King Faisal Specialist Hospital and Research Centre",
+					"org_postal_code": "11211",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "New South Wales",
+					"org_city": "Hunter Regional Mail Centre",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "John Hunter Children's Hospital",
+					"org_postal_code": "2310",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "New South Wales",
+					"org_city": "Randwick",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Sydney Children's Hospital",
+					"org_postal_code": "2031",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": null,
+					"org_city": "Christchurch",
+					"org_va": false,
+					"org_country": "New Zealand",
+					"org_name": "Christchurch Hospital",
+					"org_postal_code": "8011",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Auckland",
+					"org_city": "Grafton",
+					"org_va": false,
+					"org_country": "New Zealand",
+					"org_name": "Starship Children's Hospital",
+					"org_postal_code": "1145",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Hackensack",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Hackensack University Medical Center",
+					"org_postal_code": "07601",
+					"org_coordinates": {
+						"lon": -74.0466,
+						"lat": 40.8892
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "MedStar Georgetown University Hospital",
+					"org_postal_code": "20007",
+					"org_coordinates": {
+						"lon": -77.0771,
+						"lat": 38.9147
+					},
+					"recruitment_status": "ADMINISTRATIVELY_COMPLETE"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's National Medical Center",
+					"org_postal_code": "20010",
+					"org_coordinates": {
+						"lon": -77.028,
+						"lat": 38.9322
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Bangor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Eastern Maine Medical Center",
+					"org_postal_code": "04401",
+					"org_coordinates": {
+						"lon": -68.8311,
+						"lat": 44.8521
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Christopher's Hospital for Children",
+					"org_postal_code": "19134",
+					"org_coordinates": {
+						"lon": -75.1049,
+						"lat": 39.9903
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rainbow Babies and Childrens Hospital",
+					"org_postal_code": "44106",
+					"org_coordinates": {
+						"lon": -81.6065,
+						"lat": 41.5063
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Springfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Southern Illinois University School of Medicine",
+					"org_postal_code": "62702",
+					"org_coordinates": {
+						"lon": -89.6438,
+						"lat": 39.8235
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Royal Oak",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Beaumont Children's Hospital-Royal Oak",
+					"org_postal_code": "48073",
+					"org_coordinates": {
+						"lon": -83.1647,
+						"lat": 42.5191
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Temple",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Scott and White Memorial Hospital",
+					"org_postal_code": "76508",
+					"org_coordinates": {
+						"lon": -97.3641,
+						"lat": 31.0937
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Bethesda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Walter Reed National Military Medical Center",
+					"org_postal_code": "20889-5600",
+					"org_coordinates": {
+						"lon": -77.098,
+						"lat": 39.0095
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Denver",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rocky Mountain Hospital for Children-Presbyterian Saint Luke's Medical Center",
+					"org_postal_code": "80218",
+					"org_coordinates": {
+						"lon": -104.9709,
+						"lat": 39.7312
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WV",
+					"org_city": "Charleston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Virginia University Charleston Division",
+					"org_postal_code": "25304",
+					"org_coordinates": {
+						"lon": -81.5932,
+						"lat": 38.301
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Miami Miller School of Medicine-Sylvester Cancer Center",
+					"org_postal_code": "33136",
+					"org_coordinates": {
+						"lon": -80.2039,
+						"lat": 25.7869
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Saskatchewan",
+					"org_city": "Saskatoon",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Saskatoon Cancer Centre",
+					"org_postal_code": "S7N 4H4",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Saskatchewan",
+					"org_city": "Saskatoon",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Jim Pattison Children's Hospital",
+					"org_postal_code": "S7N 0W8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cedars Sinai Medical Center",
+					"org_postal_code": "90048",
+					"org_coordinates": {
+						"lon": -118.3727,
+						"lat": 34.0726
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Illinois",
+					"org_postal_code": "60612",
+					"org_coordinates": {
+						"lon": -87.6877,
+						"lat": 41.8804
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mercy Hospital Saint Louis",
+					"org_postal_code": "63141",
+					"org_coordinates": {
+						"lon": -90.4582,
+						"lat": 38.6572
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cardinal Glennon Children's Medical Center",
+					"org_postal_code": "63104",
+					"org_coordinates": {
+						"lon": -90.2144,
+						"lat": 38.6123
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Syracuse",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "State University of New York Upstate Medical University",
+					"org_postal_code": "13210",
+					"org_coordinates": {
+						"lon": -76.1267,
+						"lat": 43.0355
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Los Angeles",
+					"org_postal_code": "90027",
+					"org_coordinates": {
+						"lon": -118.292,
+						"lat": 34.1252
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Akron",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Medical Center of Akron",
+					"org_postal_code": "44308",
+					"org_coordinates": {
+						"lon": -81.5177,
+						"lat": 41.0819
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Winston-Salem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wake Forest University Health Sciences",
+					"org_postal_code": "27157",
+					"org_coordinates": {
+						"lon": -80.2096,
+						"lat": 36.0964
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "RI",
+					"org_city": "Providence",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rhode Island Hospital",
+					"org_postal_code": "02903",
+					"org_coordinates": {
+						"lon": -71.4128,
+						"lat": 41.8204
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital and Medical Center of Omaha",
+					"org_postal_code": "68114",
+					"org_coordinates": {
+						"lon": -96.0508,
+						"lat": 41.2627
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Quebec",
+					"org_city": "Quebec",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Centre Hospitalier Universitaire de Quebec",
+					"org_postal_code": "G1V 4G2",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Chattanooga",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "T C Thompson Children's Hospital",
+					"org_postal_code": "37403",
+					"org_coordinates": {
+						"lon": -85.2959,
+						"lat": 35.0463
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Mesa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Banner Children's at Desert",
+					"org_postal_code": "85202",
+					"org_coordinates": {
+						"lon": -111.8737,
+						"lat": 33.3827
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AR",
+					"org_city": "Little Rock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arkansas Children's Hospital",
+					"org_postal_code": "72202-3591",
+					"org_coordinates": {
+						"lon": -92.2557,
+						"lat": 34.7344
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Legacy Emanuel Children's Hospital",
+					"org_postal_code": "97227",
+					"org_coordinates": {
+						"lon": -122.6742,
+						"lat": 45.5435
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "East Lansing",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Michigan State University Clinical Center",
+					"org_postal_code": "48824-7016",
+					"org_coordinates": {
+						"lon": -84.4779,
+						"lat": 42.7234
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Albany",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Albany Medical Center",
+					"org_postal_code": "12208",
+					"org_coordinates": {
+						"lon": -73.8071,
+						"lat": 42.6512
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "London",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital",
+					"org_postal_code": "N6A 5W9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "West Palm Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Mary's Hospital",
+					"org_postal_code": "33407",
+					"org_coordinates": {
+						"lon": -80.0917,
+						"lat": 26.7596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Long Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Miller Children's and Women's Hospital Long Beach",
+					"org_postal_code": "90806",
+					"org_coordinates": {
+						"lon": -118.1736,
+						"lat": 33.8078
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Rochester",
+					"org_postal_code": "14642",
+					"org_coordinates": {
+						"lon": -77.6251,
+						"lat": 43.1218
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MS",
+					"org_city": "Jackson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Mississippi Medical Center",
+					"org_postal_code": "39216",
+					"org_coordinates": {
+						"lon": -90.1625,
+						"lat": 32.3333
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Phoenix",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Phoenix Childrens Hospital",
+					"org_postal_code": "85016",
+					"org_coordinates": {
+						"lon": -112.0225,
+						"lat": 33.527
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "British Columbia",
+					"org_city": "Vancouver",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "British Columbia Children's Hospital",
+					"org_postal_code": "V6H 3V4",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Minnesota/Masonic Cancer Center",
+					"org_postal_code": "55455",
+					"org_coordinates": {
+						"lon": -93.2319,
+						"lat": 44.974
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+					"org_postal_code": "55404",
+					"org_coordinates": {
+						"lon": -93.2613,
+						"lat": 44.9618
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "New South Wales",
+					"org_city": "Westmead",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "The Children's Hospital at Westmead",
+					"org_postal_code": "2145",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Ottawa",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital of Eastern Ontario",
+					"org_postal_code": "K1H 8L1",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "The Children's Hospital at TriStar Centennial",
+					"org_postal_code": "37203",
+					"org_coordinates": {
+						"lon": -86.79,
+						"lat": 36.1494
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Queensland",
+					"org_city": "South Brisbane",
+					"org_va": false,
+					"org_country": "Australia",
+					"org_name": "Queensland Children's Hospital",
+					"org_postal_code": "4101",
+					"org_coordinates": null,
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tufts Children's Hospital",
+					"org_postal_code": "02111",
+					"org_coordinates": {
+						"lon": -71.0614,
+						"lat": 42.3512
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Diego",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Naval Medical Center -San Diego",
+					"org_postal_code": "92134",
+					"org_coordinates": {
+						"lon": -117.147,
+						"lat": 32.7276
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Downey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente Downey Medical Center",
+					"org_postal_code": "90242",
+					"org_coordinates": {
+						"lon": -118.1411,
+						"lat": 33.9223
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Maywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loyola University Medical Center",
+					"org_postal_code": "60153",
+					"org_coordinates": {
+						"lon": -87.8451,
+						"lat": 41.8685
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Hershey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Penn State Children's Hospital",
+					"org_postal_code": "17033",
+					"org_coordinates": {
+						"lon": -76.626,
+						"lat": 40.2634
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New Hyde Park",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "The Steven and Alexandra Cohen Children's Medical Center of New York",
+					"org_postal_code": "11040",
+					"org_coordinates": {
+						"lon": -73.6798,
+						"lat": 40.7459
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Brooklyn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maimonides Medical Center",
+					"org_postal_code": "11219",
+					"org_coordinates": {
+						"lon": -73.9967,
+						"lat": 40.6327
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "New Brunswick",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rutgers Cancer Institute of New Jersey-Robert Wood Johnson University Hospital",
+					"org_postal_code": "08903",
+					"org_coordinates": {
+						"lon": -74.447,
+						"lat": 40.5102
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lurie Children's Hospital-Chicago",
+					"org_postal_code": "60611",
+					"org_coordinates": {
+						"lon": -87.6187,
+						"lat": 41.8946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Miami Cancer Institute",
+					"org_postal_code": "33176",
+					"org_coordinates": {
+						"lon": -80.359,
+						"lat": 25.6574
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PR",
+					"org_city": "San Juan",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University Pediatric Hospital",
+					"org_postal_code": "00926",
+					"org_coordinates": {
+						"lon": -66.0577,
+						"lat": 18.3754
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PR",
+					"org_city": "San Juan",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "San Jorge Children's Hospital",
+					"org_postal_code": "00912",
+					"org_coordinates": {
+						"lon": -66.0594,
+						"lat": 18.4475
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Dayton",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dayton Children's Hospital",
+					"org_postal_code": "45404",
+					"org_coordinates": {
+						"lon": -84.1582,
+						"lat": 39.7907
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Iowa City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Iowa/Holden Comprehensive Cancer Center",
+					"org_postal_code": "52242",
+					"org_coordinates": {
+						"lon": -91.5469,
+						"lat": 41.6596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Riley Hospital for Children",
+					"org_postal_code": "46202",
+					"org_coordinates": {
+						"lon": -86.163,
+						"lat": 39.7837
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Mobile",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "USA Health Strada Patient Care Center",
+					"org_postal_code": "36604",
+					"org_coordinates": {
+						"lon": -88.0679,
+						"lat": 30.6824
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Madison",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Wisconsin Carbone Cancer Center",
+					"org_postal_code": "53792",
+					"org_coordinates": {
+						"lon": -89.4329,
+						"lat": 43.0769
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carolinas Medical Center/Levine Cancer Institute",
+					"org_postal_code": "28203",
+					"org_coordinates": {
+						"lon": -80.8578,
+						"lat": 35.2083
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Vanderbilt University/Ingram Cancer Center",
+					"org_postal_code": "37232",
+					"org_coordinates": {
+						"lon": -86.8096,
+						"lat": 36.1437
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Ann Arbor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "C S Mott Children's Hospital",
+					"org_postal_code": "48109",
+					"org_coordinates": {
+						"lon": -83.7144,
+						"lat": 42.2909
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "UT",
+					"org_city": "Salt Lake City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Primary Children's Hospital",
+					"org_postal_code": "84113",
+					"org_coordinates": {
+						"lon": -111.833,
+						"lat": 40.7638
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UMC Cancer Center / UMC Health System",
+					"org_postal_code": "79415",
+					"org_coordinates": {
+						"lon": -101.8817,
+						"lat": 33.6248
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "HI",
+					"org_city": "Honolulu",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tripler Army Medical Center",
+					"org_postal_code": "96859",
+					"org_coordinates": {
+						"lon": -157.8914,
+						"lat": 21.3638
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "HI",
+					"org_city": "Honolulu",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kapiolani Medical Center for Women and Children",
+					"org_postal_code": "96826",
+					"org_coordinates": {
+						"lon": -157.8291,
+						"lat": 21.2952
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Oak Lawn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Oak Lawn",
+					"org_postal_code": "60453",
+					"org_coordinates": {
+						"lon": -87.7521,
+						"lat": 41.7129
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mayo Clinic in Rochester",
+					"org_postal_code": "55905",
+					"org_coordinates": {
+						"lon": -92.4912,
+						"lat": 44.0368
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Diego",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rady Children's Hospital - San Diego",
+					"org_postal_code": "92123",
+					"org_coordinates": {
+						"lon": -117.1356,
+						"lat": 32.8053
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Lexington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Kentucky/Markey Cancer Center",
+					"org_postal_code": "40536",
+					"org_coordinates": {
+						"lon": -84.5089,
+						"lat": 38.0316
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "Hartford",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Connecticut Children's Medical Center",
+					"org_postal_code": "06106",
+					"org_coordinates": {
+						"lon": -72.6959,
+						"lat": 41.7484
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Richland Hospital",
+					"org_postal_code": "29203",
+					"org_coordinates": {
+						"lon": -81.0612,
+						"lat": 34.1179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "BI-LO Charities Children's Cancer Center",
+					"org_postal_code": "29605",
+					"org_coordinates": {
+						"lon": -82.3803,
+						"lat": 34.7768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Knoxville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East Tennessee Childrens Hospital",
+					"org_postal_code": "37916",
+					"org_coordinates": {
+						"lon": -83.932,
+						"lat": 35.9553
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "Newfoundland and Labrador",
+					"org_city": "Saint John's",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Janeway Child Health Centre",
+					"org_postal_code": "A1B 3V6",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Seattle",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Seattle Children's Hospital",
+					"org_postal_code": "98105",
+					"org_coordinates": {
+						"lon": -122.2964,
+						"lat": 47.6619
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dana-Farber Cancer Institute",
+					"org_postal_code": "02215",
+					"org_coordinates": {
+						"lon": -71.1025,
+						"lat": 42.3469
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Massachusetts General Hospital Cancer Center",
+					"org_postal_code": "02114",
+					"org_coordinates": {
+						"lon": -71.068,
+						"lat": 42.3621
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Peoria",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Midwest Affiliate",
+					"org_postal_code": "61637",
+					"org_coordinates": {
+						"lon": -89.5906,
+						"lat": 40.7018
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Durham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Duke University Medical Center",
+					"org_postal_code": "27710",
+					"org_coordinates": {
+						"lon": -78.94,
+						"lat": 35.9995
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nicklaus Children's Hospital",
+					"org_postal_code": "33155",
+					"org_coordinates": {
+						"lon": -80.3112,
+						"lat": 25.7365
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Hamilton",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "McMaster Children's Hospital at Hamilton Health Sciences",
+					"org_postal_code": "L8N 3Z5",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Loma Linda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loma Linda University Medical Center",
+					"org_postal_code": "92354",
+					"org_coordinates": {
+						"lon": -117.2527,
+						"lat": 34.044
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Valhalla",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "New York Medical College",
+					"org_postal_code": "10595",
+					"org_coordinates": {
+						"lon": -73.7807,
+						"lat": 41.0861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Sacramento",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of California Davis Comprehensive Cancer Center",
+					"org_postal_code": "95817",
+					"org_coordinates": {
+						"lon": -121.4572,
+						"lat": 38.5503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical City Dallas Hospital",
+					"org_postal_code": "75230",
+					"org_coordinates": {
+						"lon": -96.7921,
+						"lat": 32.9028
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Morristown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Morristown Medical Center",
+					"org_postal_code": "07960",
+					"org_coordinates": {
+						"lon": -74.4992,
+						"lat": 40.7857
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2014-00677"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT03126916",
+			"brief_title": "Testing the Addition of 131I-MIBG or Lorlatinib to Intensive Therapy in People with High-Risk Neuroblastoma (NBL)",
+			"eligibility": {
+				"structured": {
+					"max_age": "30 Years",
+					"max_age_number": 30.0,
+					"min_age_unit": "Days",
+					"max_age_unit": "Years",
+					"max_age_in_years": 30.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "365 Days",
+					"min_age_number": 365.0,
+					"min_age_in_years": 1.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neuroblastoma (NBL)",
+						"Neuroblastoma, NOS",
+						"Neuroblastoma (Schwannian Stroma-Poor)",
+						"Neural Crest Tumor, Malignant",
+						"NEUROBLASTOMA, MALIGNANT"
+					],
+					"nci_thesaurus_concept_id": "C3270",
+					"name": "Neuroblastoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6963"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"GANGLIONEUROBLASTOMA, MALIGNANT"
+					],
+					"nci_thesaurus_concept_id": "C3790",
+					"name": "Ganglioneuroblastoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6963"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"embryonal tumor"
+					],
+					"nci_thesaurus_concept_id": "C3264",
+					"name": "Embryonal Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C6963",
+					"name": "Neuroblastic Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3716"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Primitive Neuroectodermal Neoplasm",
+						"PNET",
+						"Neuroepithelioma",
+						"PNET, NOS",
+						"Neuroectodermal Tumor",
+						"Primitive neuroectodermal tumor, NOS",
+						"Primitive Neuroectodermal Tumor",
+						"Neuroectodermal Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3716",
+					"name": "Primitive Neuroectodermal Tumor (PNET)",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3264",
+						"C3787",
+						"C4788"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Jacksonville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Clinic-Jacksonville",
+					"org_postal_code": "32207",
+					"org_coordinates": {
+						"lon": -81.6318,
+						"lat": 30.291
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DE",
+					"org_city": "Wilmington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alfred I duPont Hospital for Children",
+					"org_postal_code": "19803",
+					"org_coordinates": {
+						"lon": -75.5445,
+						"lat": 39.7973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Hospital",
+					"org_postal_code": "32827",
+					"org_coordinates": {
+						"lon": -81.3094,
+						"lat": 28.4288
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Saint Petersburg",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins All Children's Hospital",
+					"org_postal_code": "33701",
+					"org_coordinates": {
+						"lon": -82.6368,
+						"lat": 27.771
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Toronto",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Hospital for Sick Children",
+					"org_postal_code": "M5G 1X8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Buffalo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Roswell Park Cancer Institute",
+					"org_postal_code": "14263",
+					"org_coordinates": {
+						"lon": -78.8765,
+						"lat": 42.8868
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of San Antonio",
+					"org_postal_code": "78207",
+					"org_coordinates": {
+						"lon": -98.5276,
+						"lat": 29.4282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Baylor College of Medicine/Dan L Duncan Comprehensive Cancer Center",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UT Southwestern/Simmons Cancer Center-Dallas",
+					"org_postal_code": "75390",
+					"org_coordinates": {
+						"lon": -96.7016,
+						"lat": 32.8432
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "New Haven",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Yale University",
+					"org_postal_code": "06520",
+					"org_coordinates": {
+						"lon": -72.9291,
+						"lat": 41.31
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cincinnati",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cincinnati Children's Hospital Medical Center",
+					"org_postal_code": "45229",
+					"org_coordinates": {
+						"lon": -84.4859,
+						"lat": 39.1532
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Gainesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Florida Health Science Center - Gainesville",
+					"org_postal_code": "32610",
+					"org_coordinates": {
+						"lon": -82.344,
+						"lat": 29.6395
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Chicago Comprehensive Cancer Center",
+					"org_postal_code": "60637",
+					"org_coordinates": {
+						"lon": -87.6021,
+						"lat": 41.781
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Chapel Hill",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UNC Lineberger Comprehensive Cancer Center",
+					"org_postal_code": "27599",
+					"org_coordinates": {
+						"lon": -79.0561,
+						"lat": 35.9134
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NH",
+					"org_city": "Lebanon",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dartmouth Hitchcock Medical Center/Dartmouth Cancer Center",
+					"org_postal_code": "03756",
+					"org_coordinates": {
+						"lon": -72.2895,
+						"lat": 43.7029
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Philadelphia",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WV",
+					"org_city": "Morgantown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "West Virginia University Healthcare",
+					"org_postal_code": "26506",
+					"org_coordinates": {
+						"lon": -79.9572,
+						"lat": 39.6496
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Mineola",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYU Winthrop Hospital",
+					"org_postal_code": "11501",
+					"org_coordinates": {
+						"lon": -73.6388,
+						"lat": 40.7469
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Laura and Isaac Perlmutter Cancer Center at NYU Langone",
+					"org_postal_code": "10016",
+					"org_coordinates": {
+						"lon": -73.9782,
+						"lat": 40.7445
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Francisco",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Medical Center-Mission Bay",
+					"org_postal_code": "94158",
+					"org_coordinates": {
+						"lon": -122.3951,
+						"lat": 37.7587
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Kingston",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Kingston Health Sciences Centre",
+					"org_postal_code": "K7L 2V7",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Palo Alto",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lucile Packard Children's Hospital Stanford University",
+					"org_postal_code": "94304",
+					"org_coordinates": {
+						"lon": -122.1462,
+						"lat": 37.4059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital New Orleans",
+					"org_postal_code": "70118",
+					"org_coordinates": {
+						"lon": -90.1244,
+						"lat": 29.9472
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Newark",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Newark Beth Israel Medical Center",
+					"org_postal_code": "07112",
+					"org_coordinates": {
+						"lon": -74.2114,
+						"lat": 40.7108
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Fort Worth",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cook Children's Medical Center",
+					"org_postal_code": "76104",
+					"org_coordinates": {
+						"lon": -97.3172,
+						"lat": 32.7282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Bronson Methodist Hospital",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Helen DeVos Children's Hospital at Spectrum Health",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Corpus Christi",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Driscoll Children's Hospital",
+					"org_postal_code": "78411",
+					"org_coordinates": {
+						"lon": -97.3858,
+						"lat": 27.7297
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wayne State University/Karmanos Cancer Institute",
+					"org_postal_code": "48201",
+					"org_coordinates": {
+						"lon": -83.0598,
+						"lat": 42.3465
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Richmond",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Virginia Commonwealth University/Massey Cancer Center",
+					"org_postal_code": "23298",
+					"org_coordinates": {
+						"lon": -77.4296,
+						"lat": 37.5427
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Manitoba",
+					"org_city": "Winnipeg",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "CancerCare Manitoba",
+					"org_postal_code": "R3E 0V9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ochsner Medical Center Jefferson",
+					"org_postal_code": "70121",
+					"org_coordinates": {
+						"lon": -90.1597,
+						"lat": 29.9622
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Bronx",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Montefiore Medical Center - Moses Campus",
+					"org_postal_code": "10467",
+					"org_coordinates": {
+						"lon": -73.8721,
+						"lat": 40.8778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ID",
+					"org_city": "Boise",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Luke's Cancer Institute - Boise",
+					"org_postal_code": "83712",
+					"org_coordinates": {
+						"lon": -116.082,
+						"lat": 43.5932
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East  Carolina University",
+					"org_postal_code": "27834",
+					"org_coordinates": {
+						"lon": -77.3482,
+						"lat": 35.6768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Green Bay",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Vincent Hospital Cancer Center Green Bay",
+					"org_postal_code": "54301",
+					"org_coordinates": {
+						"lon": -88.0196,
+						"lat": 44.4814
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "AdventHealth Orlando",
+					"org_postal_code": "32803",
+					"org_coordinates": {
+						"lon": -81.3481,
+						"lat": 28.5545
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Paterson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Regional Medical Center",
+					"org_postal_code": "07503",
+					"org_coordinates": {
+						"lon": -74.1545,
+						"lat": 40.8977
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Charleston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical University of South Carolina",
+					"org_postal_code": "29425",
+					"org_coordinates": {
+						"lon": -79.9416,
+						"lat": 32.7799
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Columbia Regional",
+					"org_postal_code": "65201",
+					"org_coordinates": {
+						"lon": -92.2391,
+						"lat": 38.8994
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Covenant Children's Hospital",
+					"org_postal_code": "79410",
+					"org_coordinates": {
+						"lon": -101.8903,
+						"lat": 33.5715
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Park Ridge",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Park Ridge",
+					"org_postal_code": "60068",
+					"org_coordinates": {
+						"lon": -87.8435,
+						"lat": 42.0122
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Michigan",
+					"org_postal_code": "48201",
+					"org_coordinates": {
+						"lon": -83.0598,
+						"lat": 42.3465
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Danville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Geisinger Medical Center",
+					"org_postal_code": "17822",
+					"org_coordinates": {
+						"lon": -76.6134,
+						"lat": 40.9634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Spokane",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Sacred Heart Medical Center and Children's Hospital",
+					"org_postal_code": "99204",
+					"org_coordinates": {
+						"lon": -117.427,
+						"lat": 47.6476
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NM",
+					"org_city": "Albuquerque",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of New Mexico Cancer Center",
+					"org_postal_code": "87102",
+					"org_coordinates": {
+						"lon": -106.6469,
+						"lat": 35.0815
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Washington University School of Medicine",
+					"org_postal_code": "63110",
+					"org_coordinates": {
+						"lon": -90.267,
+						"lat": 38.6267
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Pittsburgh",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Pittsburgh of UPMC",
+					"org_postal_code": "15224",
+					"org_coordinates": {
+						"lon": -79.9446,
+						"lat": 40.464
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins University/Sidney Kimmel Cancer Center",
+					"org_postal_code": "21287",
+					"org_coordinates": {
+						"lon": -76.5621,
+						"lat": 39.3021
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Aurora",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Colorado",
+					"org_postal_code": "80045",
+					"org_coordinates": {
+						"lon": -104.837,
+						"lat": 39.7462
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Detroit",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ascension Saint John Hospital",
+					"org_postal_code": "48236",
+					"org_coordinates": {
+						"lon": -82.8975,
+						"lat": 42.4243
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "New Brunswick",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Peter's University Hospital",
+					"org_postal_code": "08901",
+					"org_coordinates": {
+						"lon": -74.4473,
+						"lat": 40.4861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente-Oakland",
+					"org_postal_code": "94611",
+					"org_coordinates": {
+						"lon": -122.2081,
+						"lat": 37.8286
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Atlanta",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Healthcare of Atlanta - Egleston",
+					"org_postal_code": "30322",
+					"org_coordinates": {
+						"lon": -84.3239,
+						"lat": 33.792
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Savannah",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Health University Medical Center",
+					"org_postal_code": "31404",
+					"org_coordinates": {
+						"lon": -81.0542,
+						"lat": 32.0515
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Milwaukee",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Wisconsin",
+					"org_postal_code": "53226",
+					"org_coordinates": {
+						"lon": -88.0423,
+						"lat": 43.0503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Columbus",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nationwide Children's Hospital",
+					"org_postal_code": "43205",
+					"org_coordinates": {
+						"lon": -82.962,
+						"lat": 39.9577
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Madigan Army Medical Center",
+					"org_postal_code": "98431",
+					"org_coordinates": {
+						"lon": -122.5505,
+						"lat": 47.1056
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Myers",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Golisano Children's Hospital of Southwest Florida",
+					"org_postal_code": "33908",
+					"org_coordinates": {
+						"lon": -81.9071,
+						"lat": 26.4973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Allentown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lehigh Valley Hospital-Cedar Crest",
+					"org_postal_code": "18103",
+					"org_coordinates": {
+						"lon": -75.4824,
+						"lat": 40.5705
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Asheville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mission Hospital",
+					"org_postal_code": "28801",
+					"org_coordinates": {
+						"lon": -82.5572,
+						"lat": 35.5948
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYP/Columbia University Medical Center/Herbert Irving Comprehensive Cancer Center",
+					"org_postal_code": "10032",
+					"org_coordinates": {
+						"lon": -73.9425,
+						"lat": 40.839
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Hollywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Regional Hospital/Joe DiMaggio Children's Hospital",
+					"org_postal_code": "33021",
+					"org_coordinates": {
+						"lon": -80.1869,
+						"lat": 26.0228
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ND",
+					"org_city": "Fargo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford Broadway Medical Center",
+					"org_postal_code": "58122",
+					"org_coordinates": {
+						"lon": -96.7842,
+						"lat": 46.8846
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Marshfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Marshfield Medical Center-Marshfield",
+					"org_postal_code": "54449",
+					"org_coordinates": {
+						"lon": -90.1945,
+						"lat": 44.6413
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SD",
+					"org_city": "Sioux Falls",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford USD Medical Center - Sioux Falls",
+					"org_postal_code": "57117-5134",
+					"org_coordinates": {
+						"lon": -96.7245,
+						"lat": 43.5513
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Birmingham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Alabama",
+					"org_postal_code": "35233",
+					"org_coordinates": {
+						"lon": -86.8014,
+						"lat": 33.5089
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Orange",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Orange County",
+					"org_postal_code": "92868",
+					"org_coordinates": {
+						"lon": -117.8683,
+						"lat": 33.7886
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OK",
+					"org_city": "Oklahoma City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Oklahoma Health Sciences Center",
+					"org_postal_code": "73104",
+					"org_coordinates": {
+						"lon": -97.5038,
+						"lat": 35.4753
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Toledo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "ProMedica Toledo Hospital/Russell J Ebeid Children's Hospital",
+					"org_postal_code": "43606",
+					"org_coordinates": {
+						"lon": -83.6099,
+						"lat": 41.6724
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Texas Health Science Center at San Antonio",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sinai Hospital of Baltimore",
+					"org_postal_code": "21215",
+					"org_coordinates": {
+						"lon": -76.6832,
+						"lat": 39.3453
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "El Paso",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "El Paso Children's Hospital",
+					"org_postal_code": "79905",
+					"org_coordinates": {
+						"lon": -106.4242,
+						"lat": 31.7666
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Nova Scotia",
+					"org_city": "Halifax",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "IWK Health Centre",
+					"org_postal_code": "B3K 6R8",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mary Bridge Children's Hospital and Health Center",
+					"org_postal_code": "98405",
+					"org_coordinates": {
+						"lon": -122.4718,
+						"lat": 47.2461
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alliance for Childhood Diseases/Cure 4 the Kids Foundation",
+					"org_postal_code": "89135",
+					"org_coordinates": {
+						"lon": -115.3507,
+						"lat": 36.1211
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Summerlin Hospital Medical Center",
+					"org_postal_code": "89144",
+					"org_coordinates": {
+						"lon": -115.3146,
+						"lat": 36.179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University Medical Center of Southern Nevada",
+					"org_postal_code": "89102",
+					"org_coordinates": {
+						"lon": -115.2004,
+						"lat": 36.1433
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NV",
+					"org_city": "Las Vegas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sunrise Hospital and Medical Center",
+					"org_postal_code": "89109",
+					"org_coordinates": {
+						"lon": -115.1573,
+						"lat": 36.1362
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Madera",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Valley Children's Hospital",
+					"org_postal_code": "93636",
+					"org_coordinates": {
+						"lon": -120.0704,
+						"lat": 36.9581
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VT",
+					"org_city": "Burlington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Vermont and State Agricultural College",
+					"org_postal_code": "05405",
+					"org_coordinates": {
+						"lon": -73.1956,
+						"lat": 44.4776
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Kansas City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Mercy Hospitals and Clinics",
+					"org_postal_code": "64108",
+					"org_coordinates": {
+						"lon": -94.5849,
+						"lat": 39.084
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Des Moines",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Blank Children's Hospital",
+					"org_postal_code": "50309",
+					"org_coordinates": {
+						"lon": -93.6292,
+						"lat": 41.5836
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Scarborough",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maine Children's Cancer Program",
+					"org_postal_code": "04074",
+					"org_coordinates": {
+						"lon": -70.3693,
+						"lat": 43.5917
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cleveland Clinic Foundation",
+					"org_postal_code": "44195",
+					"org_coordinates": {
+						"lon": -81.6209,
+						"lat": 41.5036
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Austin",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dell Children's Medical Center of Central Texas",
+					"org_postal_code": "78723",
+					"org_coordinates": {
+						"lon": -97.6862,
+						"lat": 30.3039
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Nebraska Medical Center",
+					"org_postal_code": "68198",
+					"org_coordinates": {
+						"lon": -95.9773,
+						"lat": 41.2551
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Methodist Children's Hospital of South Texas",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Hackensack",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Hackensack University Medical Center",
+					"org_postal_code": "07601",
+					"org_coordinates": {
+						"lon": -74.0466,
+						"lat": 40.8892
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's National Medical Center",
+					"org_postal_code": "20010",
+					"org_coordinates": {
+						"lon": -77.028,
+						"lat": 38.9322
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Bangor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Eastern Maine Medical Center",
+					"org_postal_code": "04401",
+					"org_coordinates": {
+						"lon": -68.8311,
+						"lat": 44.8521
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rainbow Babies and Childrens Hospital",
+					"org_postal_code": "44106",
+					"org_coordinates": {
+						"lon": -81.6065,
+						"lat": 41.5063
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Springfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Southern Illinois University School of Medicine",
+					"org_postal_code": "62702",
+					"org_coordinates": {
+						"lon": -89.6438,
+						"lat": 39.8235
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Royal Oak",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Beaumont Children's Hospital-Royal Oak",
+					"org_postal_code": "48073",
+					"org_coordinates": {
+						"lon": -83.1647,
+						"lat": 42.5191
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Bethesda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Walter Reed National Military Medical Center",
+					"org_postal_code": "20889-5600",
+					"org_coordinates": {
+						"lon": -77.098,
+						"lat": 39.0095
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Denver",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rocky Mountain Hospital for Children-Presbyterian Saint Luke's Medical Center",
+					"org_postal_code": "80218",
+					"org_coordinates": {
+						"lon": -104.9709,
+						"lat": 39.7312
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Miami Miller School of Medicine-Sylvester Cancer Center",
+					"org_postal_code": "33136",
+					"org_coordinates": {
+						"lon": -80.2039,
+						"lat": 25.7869
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mattel Children's Hospital UCLA",
+					"org_postal_code": "90095",
+					"org_coordinates": {
+						"lon": -118.4432,
+						"lat": 34.071
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Illinois",
+					"org_postal_code": "60612",
+					"org_coordinates": {
+						"lon": -87.6877,
+						"lat": 41.8804
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mercy Hospital Saint Louis",
+					"org_postal_code": "63141",
+					"org_coordinates": {
+						"lon": -90.4582,
+						"lat": 38.6572
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Syracuse",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "State University of New York Upstate Medical University",
+					"org_postal_code": "13210",
+					"org_coordinates": {
+						"lon": -76.1267,
+						"lat": 43.0355
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Los Angeles",
+					"org_postal_code": "90027",
+					"org_coordinates": {
+						"lon": -118.292,
+						"lat": 34.1252
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Winston-Salem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wake Forest University Health Sciences",
+					"org_postal_code": "27157",
+					"org_coordinates": {
+						"lon": -80.2096,
+						"lat": 36.0964
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "RI",
+					"org_city": "Providence",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rhode Island Hospital",
+					"org_postal_code": "02903",
+					"org_coordinates": {
+						"lon": -71.4128,
+						"lat": 41.8204
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital and Medical Center of Omaha",
+					"org_postal_code": "68114",
+					"org_coordinates": {
+						"lon": -96.0508,
+						"lat": 41.2627
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AR",
+					"org_city": "Little Rock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arkansas Children's Hospital",
+					"org_postal_code": "72202-3591",
+					"org_coordinates": {
+						"lon": -92.2557,
+						"lat": 34.7344
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Legacy Emanuel Children's Hospital",
+					"org_postal_code": "97227",
+					"org_coordinates": {
+						"lon": -122.6742,
+						"lat": 45.5435
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "East Lansing",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Michigan State University Clinical Center",
+					"org_postal_code": "48824-7016",
+					"org_coordinates": {
+						"lon": -84.4779,
+						"lat": 42.7234
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Albany",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Albany Medical Center",
+					"org_postal_code": "12208",
+					"org_coordinates": {
+						"lon": -73.8071,
+						"lat": 42.6512
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "London",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital",
+					"org_postal_code": "N6A 5W9",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "West Palm Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Mary's Hospital",
+					"org_postal_code": "33407",
+					"org_coordinates": {
+						"lon": -80.0917,
+						"lat": 26.7596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Rochester",
+					"org_postal_code": "14642",
+					"org_coordinates": {
+						"lon": -77.6251,
+						"lat": 43.1218
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MS",
+					"org_city": "Jackson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Mississippi Medical Center",
+					"org_postal_code": "39216",
+					"org_coordinates": {
+						"lon": -90.1625,
+						"lat": 32.3333
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Phoenix",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Phoenix Childrens Hospital",
+					"org_postal_code": "85016",
+					"org_coordinates": {
+						"lon": -112.0225,
+						"lat": 33.527
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "British Columbia",
+					"org_city": "Vancouver",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "British Columbia Children's Hospital",
+					"org_postal_code": "V6H 3V4",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Minnesota/Masonic Cancer Center",
+					"org_postal_code": "55455",
+					"org_coordinates": {
+						"lon": -93.2319,
+						"lat": 44.974
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+					"org_postal_code": "55404",
+					"org_coordinates": {
+						"lon": -93.2613,
+						"lat": 44.9618
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Ottawa",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Children's Hospital of Eastern Ontario",
+					"org_postal_code": "K1H 8L1",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tufts Children's Hospital",
+					"org_postal_code": "02111",
+					"org_coordinates": {
+						"lon": -71.0614,
+						"lat": 42.3512
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Diego",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Naval Medical Center -San Diego",
+					"org_postal_code": "92134",
+					"org_coordinates": {
+						"lon": -117.147,
+						"lat": 32.7276
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Downey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente Downey Medical Center",
+					"org_postal_code": "90242",
+					"org_coordinates": {
+						"lon": -118.1411,
+						"lat": 33.9223
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Hershey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Penn State Children's Hospital",
+					"org_postal_code": "17033",
+					"org_coordinates": {
+						"lon": -76.626,
+						"lat": 40.2634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New Hyde Park",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "The Steven and Alexandra Cohen Children's Medical Center of New York",
+					"org_postal_code": "11040",
+					"org_coordinates": {
+						"lon": -73.6798,
+						"lat": 40.7459
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Brooklyn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Maimonides Medical Center",
+					"org_postal_code": "11219",
+					"org_coordinates": {
+						"lon": -73.9967,
+						"lat": 40.6327
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "New Brunswick",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rutgers Cancer Institute of New Jersey-Robert Wood Johnson University Hospital",
+					"org_postal_code": "08903",
+					"org_coordinates": {
+						"lon": -74.447,
+						"lat": 40.5102
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lurie Children's Hospital-Chicago",
+					"org_postal_code": "60611",
+					"org_coordinates": {
+						"lon": -87.6187,
+						"lat": 41.8946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PR",
+					"org_city": "Caguas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "HIMA San Pablo Oncologic Hospital",
+					"org_postal_code": "00726",
+					"org_coordinates": {
+						"lon": -66.0489,
+						"lat": 18.2364
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Dayton",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dayton Children's Hospital",
+					"org_postal_code": "45404",
+					"org_coordinates": {
+						"lon": -84.1582,
+						"lat": 39.7907
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Iowa City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Iowa/Holden Comprehensive Cancer Center",
+					"org_postal_code": "52242",
+					"org_coordinates": {
+						"lon": -91.5469,
+						"lat": 41.6596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Riley Hospital for Children",
+					"org_postal_code": "46202",
+					"org_coordinates": {
+						"lon": -86.163,
+						"lat": 39.7837
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Madison",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Wisconsin Carbone Cancer Center",
+					"org_postal_code": "53792",
+					"org_coordinates": {
+						"lon": -89.4329,
+						"lat": 43.0769
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carolinas Medical Center/Levine Cancer Institute",
+					"org_postal_code": "28203",
+					"org_coordinates": {
+						"lon": -80.8578,
+						"lat": 35.2083
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Vanderbilt University/Ingram Cancer Center",
+					"org_postal_code": "37232",
+					"org_coordinates": {
+						"lon": -86.8096,
+						"lat": 36.1437
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Stony Brook",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Stony Brook University Medical Center",
+					"org_postal_code": "11794",
+					"org_coordinates": {
+						"lon": -73.1225,
+						"lat": 40.9145
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Ann Arbor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "C S Mott Children's Hospital",
+					"org_postal_code": "48109",
+					"org_coordinates": {
+						"lon": -83.7144,
+						"lat": 42.2909
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "UT",
+					"org_city": "Salt Lake City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Primary Children's Hospital",
+					"org_postal_code": "84113",
+					"org_coordinates": {
+						"lon": -111.833,
+						"lat": 40.7638
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Lubbock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UMC Cancer Center / UMC Health System",
+					"org_postal_code": "79415",
+					"org_coordinates": {
+						"lon": -101.8817,
+						"lat": 33.6248
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "HI",
+					"org_city": "Honolulu",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kapiolani Medical Center for Women and Children",
+					"org_postal_code": "96826",
+					"org_coordinates": {
+						"lon": -157.8291,
+						"lat": 21.2952
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Oak Lawn",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Advocate Children's Hospital-Oak Lawn",
+					"org_postal_code": "60453",
+					"org_coordinates": {
+						"lon": -87.7521,
+						"lat": 41.7129
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mayo Clinic in Rochester",
+					"org_postal_code": "55905",
+					"org_coordinates": {
+						"lon": -92.4912,
+						"lat": 44.0368
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Diego",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rady Children's Hospital - San Diego",
+					"org_postal_code": "92123",
+					"org_coordinates": {
+						"lon": -117.1356,
+						"lat": 32.8053
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Lexington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Kentucky/Markey Cancer Center",
+					"org_postal_code": "40536",
+					"org_coordinates": {
+						"lon": -84.5089,
+						"lat": 38.0316
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "Hartford",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Connecticut Children's Medical Center",
+					"org_postal_code": "06106",
+					"org_coordinates": {
+						"lon": -72.6959,
+						"lat": 41.7484
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Richland Hospital",
+					"org_postal_code": "29203",
+					"org_coordinates": {
+						"lon": -81.0612,
+						"lat": 34.1179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "BI-LO Charities Children's Cancer Center",
+					"org_postal_code": "29605",
+					"org_coordinates": {
+						"lon": -82.3803,
+						"lat": 34.7768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Knoxville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East Tennessee Childrens Hospital",
+					"org_postal_code": "37916",
+					"org_coordinates": {
+						"lon": -83.932,
+						"lat": 35.9553
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Newfoundland and Labrador",
+					"org_city": "Saint John's",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "Janeway Child Health Centre",
+					"org_postal_code": "A1B 3V6",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Seattle",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Seattle Children's Hospital",
+					"org_postal_code": "98105",
+					"org_coordinates": {
+						"lon": -122.2964,
+						"lat": 47.6619
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dana-Farber Cancer Institute",
+					"org_postal_code": "02215",
+					"org_coordinates": {
+						"lon": -71.1025,
+						"lat": 42.3469
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Massachusetts General Hospital Cancer Center",
+					"org_postal_code": "02114",
+					"org_coordinates": {
+						"lon": -71.068,
+						"lat": 42.3621
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Peoria",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Midwest Affiliate",
+					"org_postal_code": "61637",
+					"org_coordinates": {
+						"lon": -89.5906,
+						"lat": 40.7018
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Durham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Duke University Medical Center",
+					"org_postal_code": "27710",
+					"org_coordinates": {
+						"lon": -78.94,
+						"lat": 35.9995
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nicklaus Children's Hospital",
+					"org_postal_code": "33155",
+					"org_coordinates": {
+						"lon": -80.3112,
+						"lat": 25.7365
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "Ontario",
+					"org_city": "Hamilton",
+					"org_va": false,
+					"org_country": "Canada",
+					"org_name": "McMaster Children's Hospital at Hamilton Health Sciences",
+					"org_postal_code": "L8N 3Z5",
+					"org_coordinates": null,
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Loma Linda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loma Linda University Medical Center",
+					"org_postal_code": "92354",
+					"org_coordinates": {
+						"lon": -117.2527,
+						"lat": 34.044
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Valhalla",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "New York Medical College",
+					"org_postal_code": "10595",
+					"org_coordinates": {
+						"lon": -73.7807,
+						"lat": 41.0861
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Sacramento",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of California Davis Comprehensive Cancer Center",
+					"org_postal_code": "95817",
+					"org_coordinates": {
+						"lon": -121.4572,
+						"lat": 38.5503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical City Dallas Hospital",
+					"org_postal_code": "75230",
+					"org_coordinates": {
+						"lon": -96.7921,
+						"lat": 32.9028
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Morristown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Morristown Medical Center",
+					"org_postal_code": "07960",
+					"org_coordinates": {
+						"lon": -74.4992,
+						"lat": 40.7857
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2016-01734"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT03919071",
+			"brief_title": "Dabrafenib Combined with Trametinib after Radiation Therapy in Treating Patients with Newly-Diagnosed High-Grade Glioma",
+			"eligibility": {
+				"structured": {
+					"max_age": "21 Years",
+					"max_age_number": 21.0,
+					"min_age_unit": "Months",
+					"max_age_unit": "Years",
+					"max_age_in_years": 21.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "12 Months",
+					"min_age_number": 12.0,
+					"min_age_in_years": 1.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Glioma",
+						"Anaplastic Glioma"
+					],
+					"nci_thesaurus_concept_id": "C127816",
+					"name": "WHO Grade III Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Anaplastic Astrocytoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C129292",
+					"name": "Anaplastic Astrocytoma, Not Otherwise Specified",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C9477",
+						"C185185"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Pleomorphic Xanthoastrocytoma",
+						"Anaplastic pleomorphic xanthroastrocytoma",
+						"APX",
+						"WHO Grade III Pleomorphic Xanthoastrocytoma"
+					],
+					"nci_thesaurus_concept_id": "C129327",
+					"name": "Anaplastic Pleomorphic Xanthoastrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C60781",
+						"C127816",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Glioblastoma Multiforme",
+						"CNS, glioblastoma (GBM)",
+						"GBM (Glioblastoma)",
+						"GBM",
+						"Spongioblastoma Multiforme"
+					],
+					"nci_thesaurus_concept_id": "C3058",
+					"name": "Glioblastoma",
+					"type": [
+						"grade",
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C102897",
+						"C36025",
+						"C129325"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Ganglioglioma, anaplastic"
+					],
+					"nci_thesaurus_concept_id": "C4717",
+					"name": "Anaplastic Ganglioglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4627",
+						"C4747",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neuroglial Tumor",
+						"Glioma, malignant",
+						"Malignant Glial Tumor",
+						"Malignant Glial Neoplasm",
+						"High-Grade Glioma",
+						"Malignant Neuroglial Neoplasm",
+						"High Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C4822",
+					"name": "Malignant Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3059",
+						"C4627"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Grade 3 Astrocytic Neoplasm",
+						"Malignant Astrocytoma",
+						"Grade III Astrocytoma",
+						"Astrocytoma, anaplastic",
+						"Grade 3 Astrocytoma",
+						"Grade III Astrocytic Tumor",
+						"High Grade Astrocytoma",
+						"High-grade astrocytoma, NOS",
+						"Grade III Astrocytic Neoplasm",
+						"High-Grade Astrocytoma",
+						"Grade 3 Astrocytic Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9477",
+					"name": "Anaplastic Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C127816",
+						"C129325",
+						"C36025",
+						"C102897",
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS Tumor",
+						"Tumor of CNS",
+						"Central Nervous System Tumor",
+						"Tumor of the Central Nervous System",
+						"Tumor of the CNS",
+						"Neoplasm of CNS",
+						"Central Nervous System Neoplasm",
+						"Neoplasm of Central Nervous System",
+						"Neoplasm of the Central Nervous System",
+						"Tumor of Central Nervous System",
+						"Neoplasm of uncertain behavior of central nervous system, unspecified",
+						"CNS Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C9293",
+					"name": "Brain/Spinal Cord Tumor",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Central Nervous System Disease",
+						"Disorder of Central Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C2934",
+					"name": "Central Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C26835"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Glioma, NOS",
+						"Tumor of the Neuroglia",
+						"Glial Tumor",
+						"Glial Neoplasm",
+						"Neoplasm of the Neuroglia",
+						"Tumor of Neuroglia",
+						"Neuroglial Tumor",
+						"Neoplasm of Neuroglia",
+						"Neuroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3059",
+					"name": "Glioma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3787",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Tumor of the CNS",
+						"Malignant neoplasm of central nervous system, unspecified",
+						"Malignant Central Nervous System Tumor",
+						"Malignant Tumor of Central Nervous System",
+						"Cancer of the CNS",
+						"Cancer of CNS",
+						"Malignant CNS Tumor",
+						"Malignant Neoplasm of Central Nervous System",
+						"Cancer of the Central Nervous System",
+						"Malignant CNS Neoplasms",
+						"Malignant CNS Neoplasm",
+						"Cancer of Central Nervous System",
+						"Central Nervous System Neoplasms, Malignant",
+						"Central Nervous System Cancer",
+						"Malignant Neoplasm of CNS",
+						"Malignant Tumor of CNS",
+						"Malignant Neoplasm of the CNS",
+						"Malignant Tumor of the Central Nervous System",
+						"Malignant Neoplasm of the Central Nervous System",
+						"CNS Malignant Neoplasms",
+						"CNS Cancer",
+						"CNS Neoplasms, Malignant"
+					],
+					"nci_thesaurus_concept_id": "C4627",
+					"name": "Malignant Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4788",
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS primary tumor, NOS"
+					],
+					"nci_thesaurus_concept_id": "C102871",
+					"name": "Primary Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytic Neoplasm",
+						"Astroglioma"
+					],
+					"nci_thesaurus_concept_id": "C6958",
+					"name": "Astrocytic Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C129325",
+					"name": "Diffuse Glioma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C185185",
+					"name": "Astrocytoma, Not Otherwise Specified",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neuronal and Glio-Neuronal Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumors",
+						"Neuronal and Glio-Neuronal Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C4747",
+					"name": "Glioneuronal and Neuronal Tumors",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C102871",
+						"C3787"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"High Grade Astrocytic Neoplasm",
+						"High-Grade Astrocytic Tumor",
+						"High-Grade Astrocytic Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C102897",
+					"name": "High Grade Astrocytic Tumor",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822",
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C60781",
+					"name": "Astrocytoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C36025",
+					"name": "Anaplastic Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "DE",
+					"org_city": "Wilmington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Alfred I duPont Hospital for Children",
+					"org_postal_code": "19803",
+					"org_coordinates": {
+						"lon": -75.5445,
+						"lat": 39.7973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Jacksonville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Clinic-Jacksonville",
+					"org_postal_code": "32207",
+					"org_coordinates": {
+						"lon": -81.6318,
+						"lat": 30.291
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nemours Children's Hospital",
+					"org_postal_code": "32827",
+					"org_coordinates": {
+						"lon": -81.3094,
+						"lat": 28.4288
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Saint Petersburg",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins All Children's Hospital",
+					"org_postal_code": "33701",
+					"org_coordinates": {
+						"lon": -82.6368,
+						"lat": 27.771
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Buffalo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Roswell Park Cancer Institute",
+					"org_postal_code": "14263",
+					"org_coordinates": {
+						"lon": -78.8765,
+						"lat": 42.8868
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of San Antonio",
+					"org_postal_code": "78207",
+					"org_coordinates": {
+						"lon": -98.5276,
+						"lat": 29.4282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Baylor College of Medicine/Dan L Duncan Comprehensive Cancer Center",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UT Southwestern/Simmons Cancer Center-Dallas",
+					"org_postal_code": "75390",
+					"org_coordinates": {
+						"lon": -96.7016,
+						"lat": 32.8432
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "New Haven",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Yale University",
+					"org_postal_code": "06520",
+					"org_coordinates": {
+						"lon": -72.9291,
+						"lat": 41.31
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cincinnati",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cincinnati Children's Hospital Medical Center",
+					"org_postal_code": "45229",
+					"org_coordinates": {
+						"lon": -84.4859,
+						"lat": 39.1532
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Gainesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Florida Health Science Center - Gainesville",
+					"org_postal_code": "32610",
+					"org_coordinates": {
+						"lon": -82.344,
+						"lat": 29.6395
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Chicago Comprehensive Cancer Center",
+					"org_postal_code": "60637",
+					"org_coordinates": {
+						"lon": -87.6021,
+						"lat": 41.781
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Louisville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Norton Children's Hospital",
+					"org_postal_code": "40202",
+					"org_coordinates": {
+						"lon": -85.7498,
+						"lat": 38.2536
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Philadelphia",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "San Francisco",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "UCSF Medical Center-Mission Bay",
+					"org_postal_code": "94158",
+					"org_coordinates": {
+						"lon": -122.3951,
+						"lat": 37.7587
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Norfolk",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of The King's Daughters",
+					"org_postal_code": "23507",
+					"org_coordinates": {
+						"lon": -76.3092,
+						"lat": 36.8688
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Palo Alto",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lucile Packard Children's Hospital Stanford University",
+					"org_postal_code": "94304",
+					"org_coordinates": {
+						"lon": -122.1462,
+						"lat": 37.4059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital New Orleans",
+					"org_postal_code": "70118",
+					"org_coordinates": {
+						"lon": -90.1244,
+						"lat": 29.9472
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Fort Worth",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cook Children's Medical Center",
+					"org_postal_code": "76104",
+					"org_coordinates": {
+						"lon": -97.3172,
+						"lat": 32.7282
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Kalamazoo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Bronson Methodist Hospital",
+					"org_postal_code": "49007",
+					"org_coordinates": {
+						"lon": -85.5882,
+						"lat": 42.3015
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Grand Rapids",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Helen DeVos Children's Hospital at Spectrum Health",
+					"org_postal_code": "49503",
+					"org_coordinates": {
+						"lon": -85.6569,
+						"lat": 42.9643
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "LA",
+					"org_city": "New Orleans",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ochsner Medical Center Jefferson",
+					"org_postal_code": "70121",
+					"org_coordinates": {
+						"lon": -90.1597,
+						"lat": 29.9622
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Bronx",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Montefiore Medical Center - Moses Campus",
+					"org_postal_code": "10467",
+					"org_coordinates": {
+						"lon": -73.8721,
+						"lat": 40.8778
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ID",
+					"org_city": "Boise",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Luke's Cancer Institute - Boise",
+					"org_postal_code": "83712",
+					"org_coordinates": {
+						"lon": -116.082,
+						"lat": 43.5932
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East  Carolina University",
+					"org_postal_code": "27834",
+					"org_coordinates": {
+						"lon": -77.3482,
+						"lat": 35.6768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "AdventHealth Orlando",
+					"org_postal_code": "32803",
+					"org_coordinates": {
+						"lon": -81.3481,
+						"lat": 28.5545
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Paterson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Regional Medical Center",
+					"org_postal_code": "07503",
+					"org_coordinates": {
+						"lon": -74.1545,
+						"lat": 40.8977
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Charleston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical University of South Carolina",
+					"org_postal_code": "29425",
+					"org_coordinates": {
+						"lon": -79.9416,
+						"lat": 32.7799
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Spokane",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Providence Sacred Heart Medical Center and Children's Hospital",
+					"org_postal_code": "99204",
+					"org_coordinates": {
+						"lon": -117.427,
+						"lat": 47.6476
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NM",
+					"org_city": "Albuquerque",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of New Mexico Cancer Center",
+					"org_postal_code": "87102",
+					"org_coordinates": {
+						"lon": -106.6469,
+						"lat": 35.0815
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Washington University School of Medicine",
+					"org_postal_code": "63110",
+					"org_coordinates": {
+						"lon": -90.267,
+						"lat": 38.6267
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Torrance",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lundquist Institute for Biomedical Innovation at Harbor-UCLA Medical Center",
+					"org_postal_code": "90502",
+					"org_coordinates": {
+						"lon": -118.2928,
+						"lat": 33.8359
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Pittsburgh",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Pittsburgh of UPMC",
+					"org_postal_code": "15224",
+					"org_coordinates": {
+						"lon": -79.9446,
+						"lat": 40.464
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Joseph's Hospital/Children's Hospital-Tampa",
+					"org_postal_code": "33607",
+					"org_coordinates": {
+						"lon": -82.5019,
+						"lat": 27.963
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Orlando",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arnold Palmer Hospital for Children",
+					"org_postal_code": "32806",
+					"org_coordinates": {
+						"lon": -81.3614,
+						"lat": 28.5125
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins University/Sidney Kimmel Cancer Center",
+					"org_postal_code": "21287",
+					"org_coordinates": {
+						"lon": -76.5621,
+						"lat": 39.3021
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Aurora",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Colorado",
+					"org_postal_code": "80045",
+					"org_coordinates": {
+						"lon": -104.837,
+						"lat": 39.7462
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Oakland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente-Oakland",
+					"org_postal_code": "94611",
+					"org_coordinates": {
+						"lon": -122.2081,
+						"lat": 37.8286
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Atlanta",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Healthcare of Atlanta - Egleston",
+					"org_postal_code": "30322",
+					"org_coordinates": {
+						"lon": -84.3239,
+						"lat": 33.792
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Savannah",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Health University Medical Center",
+					"org_postal_code": "31404",
+					"org_coordinates": {
+						"lon": -81.0542,
+						"lat": 32.0515
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Milwaukee",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Wisconsin",
+					"org_postal_code": "53226",
+					"org_coordinates": {
+						"lon": -88.0423,
+						"lat": 43.0503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Columbus",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nationwide Children's Hospital",
+					"org_postal_code": "43205",
+					"org_coordinates": {
+						"lon": -82.962,
+						"lat": 39.9577
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Fort Myers",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Golisano Children's Hospital of Southwest Florida",
+					"org_postal_code": "33908",
+					"org_coordinates": {
+						"lon": -81.9071,
+						"lat": 26.4973
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Allentown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lehigh Valley Hospital-Cedar Crest",
+					"org_postal_code": "18103",
+					"org_coordinates": {
+						"lon": -75.4824,
+						"lat": 40.5705
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Asheville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mission Hospital",
+					"org_postal_code": "28801",
+					"org_coordinates": {
+						"lon": -82.5572,
+						"lat": 35.5948
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "NYP/Columbia University Medical Center/Herbert Irving Comprehensive Cancer Center",
+					"org_postal_code": "10032",
+					"org_coordinates": {
+						"lon": -73.9425,
+						"lat": 40.839
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Hollywood",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Regional Hospital/Joe DiMaggio Children's Hospital",
+					"org_postal_code": "33021",
+					"org_coordinates": {
+						"lon": -80.1869,
+						"lat": 26.0228
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ND",
+					"org_city": "Fargo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Sanford Broadway Medical Center",
+					"org_postal_code": "58122",
+					"org_coordinates": {
+						"lon": -96.7842,
+						"lat": 46.8846
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Marshfield",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Marshfield Medical Center-Marshfield",
+					"org_postal_code": "54449",
+					"org_coordinates": {
+						"lon": -90.1945,
+						"lat": 44.6413
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AL",
+					"org_city": "Birmingham",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Alabama",
+					"org_postal_code": "35233",
+					"org_coordinates": {
+						"lon": -86.8014,
+						"lat": 33.5089
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Orange",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Orange County",
+					"org_postal_code": "92868",
+					"org_coordinates": {
+						"lon": -117.8683,
+						"lat": 33.7886
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OK",
+					"org_city": "Oklahoma City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Oklahoma Health Sciences Center",
+					"org_postal_code": "73104",
+					"org_coordinates": {
+						"lon": -97.5038,
+						"lat": 35.4753
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Toledo",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "ProMedica Toledo Hospital/Russell J Ebeid Children's Hospital",
+					"org_postal_code": "43606",
+					"org_coordinates": {
+						"lon": -83.6099,
+						"lat": 41.6724
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "San Antonio",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Texas Health Science Center at San Antonio",
+					"org_postal_code": "78229",
+					"org_coordinates": {
+						"lon": -98.5725,
+						"lat": 29.5052
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Tacoma",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mary Bridge Children's Hospital and Health Center",
+					"org_postal_code": "98405",
+					"org_coordinates": {
+						"lon": -122.4718,
+						"lat": 47.2461
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Ascension Saint Vincent Indianapolis Hospital",
+					"org_postal_code": "46260",
+					"org_coordinates": {
+						"lon": -86.18,
+						"lat": 39.8971
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Kansas City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Mercy Hospitals and Clinics",
+					"org_postal_code": "64108",
+					"org_coordinates": {
+						"lon": -94.5849,
+						"lat": 39.084
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Tampa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Tampa General Hospital",
+					"org_postal_code": "33606",
+					"org_coordinates": {
+						"lon": -82.474,
+						"lat": 27.9407
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cleveland Clinic Foundation",
+					"org_postal_code": "44195",
+					"org_coordinates": {
+						"lon": -81.6209,
+						"lat": 41.5036
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Oregon Health and Science University",
+					"org_postal_code": "97239",
+					"org_coordinates": {
+						"lon": -122.6915,
+						"lat": 45.4923
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Austin",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dell Children's Medical Center of Central Texas",
+					"org_postal_code": "78723",
+					"org_coordinates": {
+						"lon": -97.6862,
+						"lat": 30.3039
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Nebraska Medical Center",
+					"org_postal_code": "68198",
+					"org_coordinates": {
+						"lon": -95.9773,
+						"lat": 41.2551
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "VA",
+					"org_city": "Charlottesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Virginia Cancer Center",
+					"org_postal_code": "22908",
+					"org_coordinates": {
+						"lon": -78.5162,
+						"lat": 38.0346
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Hackensack",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Hackensack University Medical Center",
+					"org_postal_code": "07601",
+					"org_coordinates": {
+						"lon": -74.0466,
+						"lat": 40.8892
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "MedStar Georgetown University Hospital",
+					"org_postal_code": "20007",
+					"org_coordinates": {
+						"lon": -77.0771,
+						"lat": 38.9147
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's National Medical Center",
+					"org_postal_code": "20010",
+					"org_coordinates": {
+						"lon": -77.028,
+						"lat": 38.9322
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "ME",
+					"org_city": "Bangor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Eastern Maine Medical Center",
+					"org_postal_code": "04401",
+					"org_coordinates": {
+						"lon": -68.8311,
+						"lat": 44.8521
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Sloan Kettering Cancer Center",
+					"org_postal_code": "10065",
+					"org_coordinates": {
+						"lon": -73.9624,
+						"lat": 40.7656
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cleveland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rainbow Babies and Childrens Hospital",
+					"org_postal_code": "44106",
+					"org_coordinates": {
+						"lon": -81.6065,
+						"lat": 41.5063
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Royal Oak",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Beaumont Children's Hospital-Royal Oak",
+					"org_postal_code": "48073",
+					"org_coordinates": {
+						"lon": -83.1647,
+						"lat": 42.5191
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Temple",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Scott and White Memorial Hospital",
+					"org_postal_code": "76508",
+					"org_coordinates": {
+						"lon": -97.3641,
+						"lat": 31.0937
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Bethesda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Walter Reed National Military Medical Center",
+					"org_postal_code": "20889-5600",
+					"org_coordinates": {
+						"lon": -77.098,
+						"lat": 39.0095
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Miami Miller School of Medicine-Sylvester Cancer Center",
+					"org_postal_code": "33136",
+					"org_coordinates": {
+						"lon": -80.2039,
+						"lat": 25.7869
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cedars Sinai Medical Center",
+					"org_postal_code": "90048",
+					"org_coordinates": {
+						"lon": -118.3727,
+						"lat": 34.0726
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Illinois",
+					"org_postal_code": "60612",
+					"org_coordinates": {
+						"lon": -87.6877,
+						"lat": 41.8804
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mercy Hospital Saint Louis",
+					"org_postal_code": "63141",
+					"org_coordinates": {
+						"lon": -90.4582,
+						"lat": 38.6572
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cardinal Glennon Children's Medical Center",
+					"org_postal_code": "63104",
+					"org_coordinates": {
+						"lon": -90.2144,
+						"lat": 38.6123
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Syracuse",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "State University of New York Upstate Medical University",
+					"org_postal_code": "13210",
+					"org_coordinates": {
+						"lon": -76.1267,
+						"lat": 43.0355
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Los Angeles",
+					"org_postal_code": "90027",
+					"org_coordinates": {
+						"lon": -118.292,
+						"lat": 34.1252
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Akron",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Medical Center of Akron",
+					"org_postal_code": "44308",
+					"org_coordinates": {
+						"lon": -81.5177,
+						"lat": 41.0819
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Winston-Salem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wake Forest University Health Sciences",
+					"org_postal_code": "27157",
+					"org_coordinates": {
+						"lon": -80.2096,
+						"lat": 36.0964
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "RI",
+					"org_city": "Providence",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Rhode Island Hospital",
+					"org_postal_code": "02903",
+					"org_coordinates": {
+						"lon": -71.4128,
+						"lat": 41.8204
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NE",
+					"org_city": "Omaha",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital and Medical Center of Omaha",
+					"org_postal_code": "68114",
+					"org_coordinates": {
+						"lon": -96.0508,
+						"lat": 41.2627
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Mesa",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Banner Children's at Desert",
+					"org_postal_code": "85202",
+					"org_coordinates": {
+						"lon": -111.8737,
+						"lat": 33.3827
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AR",
+					"org_city": "Little Rock",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Arkansas Children's Hospital",
+					"org_postal_code": "72202-3591",
+					"org_coordinates": {
+						"lon": -92.2557,
+						"lat": 34.7344
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OR",
+					"org_city": "Portland",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Legacy Emanuel Children's Hospital",
+					"org_postal_code": "97227",
+					"org_coordinates": {
+						"lon": -122.6742,
+						"lat": 45.5435
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "Albany",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Albany Medical Center",
+					"org_postal_code": "12208",
+					"org_coordinates": {
+						"lon": -73.8071,
+						"lat": 42.6512
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "West Palm Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Mary's Hospital",
+					"org_postal_code": "33407",
+					"org_coordinates": {
+						"lon": -80.0917,
+						"lat": 26.7596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Long Beach",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Miller Children's and Women's Hospital Long Beach",
+					"org_postal_code": "90806",
+					"org_coordinates": {
+						"lon": -118.1736,
+						"lat": 33.8078
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MS",
+					"org_city": "Jackson",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Mississippi Medical Center",
+					"org_postal_code": "39216",
+					"org_coordinates": {
+						"lon": -90.1625,
+						"lat": 32.3333
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Phoenix",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Phoenix Childrens Hospital",
+					"org_postal_code": "85016",
+					"org_coordinates": {
+						"lon": -112.0225,
+						"lat": 33.527
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospitals and Clinics of Minnesota - Minneapolis",
+					"org_postal_code": "55404",
+					"org_coordinates": {
+						"lon": -93.2613,
+						"lat": 44.9618
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Downey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kaiser Permanente Downey Medical Center",
+					"org_postal_code": "90242",
+					"org_coordinates": {
+						"lon": -118.1411,
+						"lat": 33.9223
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Hershey",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Penn State Children's Hospital",
+					"org_postal_code": "17033",
+					"org_coordinates": {
+						"lon": -76.626,
+						"lat": 40.2634
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lurie Children's Hospital-Chicago",
+					"org_postal_code": "60611",
+					"org_coordinates": {
+						"lon": -87.6187,
+						"lat": 41.8946
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PR",
+					"org_city": "Caguas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "HIMA San Pablo Oncologic Hospital",
+					"org_postal_code": "00726",
+					"org_coordinates": {
+						"lon": -66.0489,
+						"lat": 18.2364
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Dayton",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dayton Children's Hospital",
+					"org_postal_code": "45404",
+					"org_coordinates": {
+						"lon": -84.1582,
+						"lat": 39.7907
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IA",
+					"org_city": "Iowa City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Iowa/Holden Comprehensive Cancer Center",
+					"org_postal_code": "52242",
+					"org_coordinates": {
+						"lon": -91.5469,
+						"lat": 41.6596
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Riley Hospital for Children",
+					"org_postal_code": "46202",
+					"org_coordinates": {
+						"lon": -86.163,
+						"lat": 39.7837
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WI",
+					"org_city": "Madison",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Wisconsin Carbone Cancer Center",
+					"org_postal_code": "53792",
+					"org_coordinates": {
+						"lon": -89.4329,
+						"lat": 43.0769
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Charlotte",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Carolinas Medical Center/Levine Cancer Institute",
+					"org_postal_code": "28203",
+					"org_coordinates": {
+						"lon": -80.8578,
+						"lat": 35.2083
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Nashville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Vanderbilt University/Ingram Cancer Center",
+					"org_postal_code": "37232",
+					"org_coordinates": {
+						"lon": -86.8096,
+						"lat": 36.1437
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MI",
+					"org_city": "Ann Arbor",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "C S Mott Children's Hospital",
+					"org_postal_code": "48109",
+					"org_coordinates": {
+						"lon": -83.7144,
+						"lat": 42.2909
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "UT",
+					"org_city": "Salt Lake City",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Primary Children's Hospital",
+					"org_postal_code": "84113",
+					"org_coordinates": {
+						"lon": -111.833,
+						"lat": 40.7638
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "HI",
+					"org_city": "Honolulu",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Kapiolani Medical Center for Women and Children",
+					"org_postal_code": "96826",
+					"org_coordinates": {
+						"lon": -157.8291,
+						"lat": 21.2952
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Rochester",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Mayo Clinic in Rochester",
+					"org_postal_code": "55905",
+					"org_coordinates": {
+						"lon": -92.4912,
+						"lat": 44.0368
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "KY",
+					"org_city": "Lexington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Kentucky/Markey Cancer Center",
+					"org_postal_code": "40536",
+					"org_coordinates": {
+						"lon": -84.5089,
+						"lat": 38.0316
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CT",
+					"org_city": "Hartford",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Connecticut Children's Medical Center",
+					"org_postal_code": "06106",
+					"org_coordinates": {
+						"lon": -72.6959,
+						"lat": 41.7484
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Columbia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Prisma Health Richland Hospital",
+					"org_postal_code": "29203",
+					"org_coordinates": {
+						"lon": -81.0612,
+						"lat": 34.1179
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "SC",
+					"org_city": "Greenville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "BI-LO Charities Children's Cancer Center",
+					"org_postal_code": "29605",
+					"org_coordinates": {
+						"lon": -82.3803,
+						"lat": 34.7768
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Knoxville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "East Tennessee Childrens Hospital",
+					"org_postal_code": "37916",
+					"org_coordinates": {
+						"lon": -83.932,
+						"lat": 35.9553
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "WA",
+					"org_city": "Seattle",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Seattle Children's Hospital",
+					"org_postal_code": "98105",
+					"org_coordinates": {
+						"lon": -122.2964,
+						"lat": 47.6619
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dana-Farber Cancer Institute",
+					"org_postal_code": "02215",
+					"org_coordinates": {
+						"lon": -71.1025,
+						"lat": 42.3469
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Massachusetts General Hospital Cancer Center",
+					"org_postal_code": "02114",
+					"org_coordinates": {
+						"lon": -71.068,
+						"lat": 42.3621
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Peoria",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Midwest Affiliate",
+					"org_postal_code": "61637",
+					"org_coordinates": {
+						"lon": -89.5906,
+						"lat": 40.7018
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Miami",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nicklaus Children's Hospital",
+					"org_postal_code": "33155",
+					"org_coordinates": {
+						"lon": -80.3112,
+						"lat": 25.7365
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Loma Linda",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Loma Linda University Medical Center",
+					"org_postal_code": "92354",
+					"org_coordinates": {
+						"lon": -117.2527,
+						"lat": 34.044
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Sacramento",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of California Davis Comprehensive Cancer Center",
+					"org_postal_code": "95817",
+					"org_coordinates": {
+						"lon": -121.4572,
+						"lat": 38.5503
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Dallas",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Medical City Dallas Hospital",
+					"org_postal_code": "75230",
+					"org_coordinates": {
+						"lon": -96.7921,
+						"lat": 32.9028
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NJ",
+					"org_city": "Morristown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Morristown Medical Center",
+					"org_postal_code": "07960",
+					"org_coordinates": {
+						"lon": -74.4992,
+						"lat": 40.7857
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2019-02289"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT04201457",
+			"brief_title": "Testing the Safety and Benefit of Adding Hydroxychloroquine to Dabrafenib and/or Trametinib in Children with Recurrent or Progressive Low Grade or High Grade Brain Tumor with Specific Genetic Mutations",
+			"eligibility": {
+				"structured": {
+					"max_age": "30 Years",
+					"max_age_number": 30.0,
+					"min_age_unit": "Years",
+					"max_age_unit": "Years",
+					"max_age_in_years": 30.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "1 Years",
+					"min_age_number": 1.0,
+					"min_age_in_years": 1.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent High-Grade Glioma",
+						"Recurrent High Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C142848",
+					"name": "Recurrent Malignant Glioma",
+					"type": [
+						"stage",
+						"grade"
+					],
+					"parents": [
+						"C153823",
+						"C4822",
+						"C132506",
+						"C131500"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Recurrent WHO Grade II Glioma",
+						"Recurrent Grade 2 Glioma",
+						"Recurrent WHO Grade 2 Glioma"
+					],
+					"nci_thesaurus_concept_id": "C148037",
+					"name": "Recurrent Grade II Glioma",
+					"type": [
+						"stage",
+						"grade"
+					],
+					"parents": [
+						"C177794",
+						"C132505"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"NF1",
+						"Neurofibromatosis 1",
+						"Von Recklinghausen Disease",
+						"Recklinghausen disease",
+						"Peripheral Neurofibromatosis",
+						"Neurofibromatosis",
+						"Neurofibromatosis Type 1 Microdeletion Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C3273",
+					"name": "Neurofibromatosis Type 1",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C179667",
+						"C6727"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS primary tumor, NOS"
+					],
+					"nci_thesaurus_concept_id": "C102871",
+					"name": "Primary Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Central Nervous System Disease",
+						"Disorder of Central Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C2934",
+					"name": "Central Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C26835"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent Primary Malignancy"
+					],
+					"nci_thesaurus_concept_id": "C131500",
+					"name": "Recurrent Primary Malignant Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C4813"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Tumor of the CNS",
+						"Malignant neoplasm of central nervous system, unspecified",
+						"Malignant Central Nervous System Tumor",
+						"Malignant Tumor of Central Nervous System",
+						"Cancer of the CNS",
+						"Cancer of CNS",
+						"Malignant CNS Tumor",
+						"Malignant Neoplasm of Central Nervous System",
+						"Cancer of the Central Nervous System",
+						"Malignant CNS Neoplasms",
+						"Malignant CNS Neoplasm",
+						"Cancer of Central Nervous System",
+						"Central Nervous System Neoplasms, Malignant",
+						"Central Nervous System Cancer",
+						"Malignant Neoplasm of CNS",
+						"Malignant Tumor of CNS",
+						"Malignant Neoplasm of the CNS",
+						"Malignant Tumor of the Central Nervous System",
+						"Malignant Neoplasm of the Central Nervous System",
+						"CNS Malignant Neoplasms",
+						"CNS Cancer",
+						"CNS Neoplasms, Malignant"
+					],
+					"nci_thesaurus_concept_id": "C4627",
+					"name": "Malignant Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4788",
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C132506",
+					"name": "Recurrent Glioma",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C71700",
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS Tumor",
+						"Tumor of CNS",
+						"Central Nervous System Tumor",
+						"Tumor of the Central Nervous System",
+						"Tumor of the CNS",
+						"Neoplasm of CNS",
+						"Central Nervous System Neoplasm",
+						"Neoplasm of Central Nervous System",
+						"Neoplasm of the Central Nervous System",
+						"Tumor of Central Nervous System",
+						"Neoplasm of uncertain behavior of central nervous system, unspecified",
+						"CNS Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C9293",
+					"name": "Brain/Spinal Cord Tumor",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C182030",
+					"name": "Recurrent Nervous System Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C4798",
+						"C3268"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent Primary Malignant Central Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C153823",
+					"name": "Recurrent Malignant Central Nervous System Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C4627",
+						"C4813",
+						"C71700"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent Primary Central Nervous System Tumor"
+					],
+					"nci_thesaurus_concept_id": "C71700",
+					"name": "Recurrent Primary Central Nervous System Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C182030",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Malignant Neuroglial Tumor",
+						"Glioma, malignant",
+						"Malignant Glial Tumor",
+						"Malignant Glial Neoplasm",
+						"High-Grade Glioma",
+						"Malignant Neuroglial Neoplasm",
+						"High Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C4822",
+					"name": "Malignant Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3059",
+						"C4627"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent Tumor",
+						"Recurrence",
+						"Neoplasm Recurrence",
+						"Recurrent"
+					],
+					"nci_thesaurus_concept_id": "C4798",
+					"name": "Recurrent Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Glioma, NOS",
+						"Tumor of the Neuroglia",
+						"Glial Tumor",
+						"Glial Neoplasm",
+						"Neoplasm of the Neuroglia",
+						"Tumor of Neuroglia",
+						"Neuroglial Tumor",
+						"Neoplasm of Neuroglia",
+						"Neuroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3059",
+					"name": "Glioma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3787",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Recurrent Malignant Tumor",
+						"Recurrent Cancer",
+						"Recurrence"
+					],
+					"nci_thesaurus_concept_id": "C4813",
+					"name": "Recurrent Malignant Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C4798",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Hereditary Diseases",
+						"Molecular Disease",
+						"Hereditary Disease",
+						"Genetic Condition",
+						"Genetic Syndrome",
+						"Inherited Disease"
+					],
+					"nci_thesaurus_concept_id": "C3101",
+					"name": "Genetic Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"inherited cancer syndrome",
+						"Germline Neoplastic Syndrome",
+						"Familial Tumor Syndrome",
+						"Hereditary Tumor Syndrome",
+						"Familial Neoplastic Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C3266",
+					"name": "Hereditary Neoplastic Syndrome",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C54705",
+						"C3101"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"CNS, low grade glioma (LGG)",
+						"LGG",
+						"Low-Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C132067",
+					"name": "Low Grade Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C179667",
+					"name": "RASopathy",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3101",
+						"C28193"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neurocutaneous Syndrome",
+						"Phacomatosis"
+					],
+					"nci_thesaurus_concept_id": "C84348",
+					"name": "Phakomatosis",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3266"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C177794",
+					"name": "Recurrent Low Grade Glioma",
+					"type": [
+						"stage",
+						"grade"
+					],
+					"parents": [
+						"C132067",
+						"C132506"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neurofibromatosis, NOS",
+						"Neurofibromatosis Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C6727",
+					"name": "Neurofibromatosis",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C84348"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 2 Glioma",
+						"WHO Grade II Glioma",
+						"Grade 2 Glioma"
+					],
+					"nci_thesaurus_concept_id": "C132505",
+					"name": "Grade II Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C132067"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Tumor Syndrome",
+						"Neoplastic Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C54705",
+					"name": "Cancer-Related Syndrome",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C28193"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C28193",
+					"name": "Syndrome",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Cincinnati",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Cincinnati Children's Hospital Medical Center",
+					"org_postal_code": "45229",
+					"org_coordinates": {
+						"lon": -84.4859,
+						"lat": 39.1532
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "FL",
+					"org_city": "Gainesville",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Florida Health Science Center - Gainesville",
+					"org_postal_code": "32610",
+					"org_coordinates": {
+						"lon": -82.344,
+						"lat": 29.6395
+					},
+					"recruitment_status": "TEMPORARILY_CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Palo Alto",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lucile Packard Children's Hospital Stanford University",
+					"org_postal_code": "94304",
+					"org_coordinates": {
+						"lon": -122.1462,
+						"lat": 37.4059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Texas Children's Hospital",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Pittsburgh",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital of Pittsburgh of UPMC",
+					"org_postal_code": "15224",
+					"org_coordinates": {
+						"lon": -79.9446,
+						"lat": 40.464
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CO",
+					"org_city": "Aurora",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Colorado",
+					"org_postal_code": "80045",
+					"org_coordinates": {
+						"lon": -104.837,
+						"lat": 39.7462
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "GA",
+					"org_city": "Atlanta",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Healthcare of Atlanta - Egleston",
+					"org_postal_code": "30322",
+					"org_coordinates": {
+						"lon": -84.3239,
+						"lat": 33.792
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "OH",
+					"org_city": "Columbus",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Nationwide Children's Hospital",
+					"org_postal_code": "43205",
+					"org_coordinates": {
+						"lon": -82.962,
+						"lat": 39.9577
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "DC",
+					"org_city": "Washington",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's National Medical Center",
+					"org_postal_code": "20010",
+					"org_coordinates": {
+						"lon": -77.028,
+						"lat": 38.9322
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Sloan Kettering Cancer Center",
+					"org_postal_code": "10065",
+					"org_coordinates": {
+						"lon": -73.9624,
+						"lat": 40.7656
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "CA",
+					"org_city": "Los Angeles",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Children's Hospital Los Angeles",
+					"org_postal_code": "90027",
+					"org_coordinates": {
+						"lon": -118.292,
+						"lat": 34.1252
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "AZ",
+					"org_city": "Phoenix",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Phoenix Childrens Hospital",
+					"org_postal_code": "85016",
+					"org_coordinates": {
+						"lon": -112.0225,
+						"lat": 33.527
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "IL",
+					"org_city": "Chicago",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Lurie Children's Hospital-Chicago",
+					"org_postal_code": "60611",
+					"org_coordinates": {
+						"lon": -87.6187,
+						"lat": 41.8946
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2019-06216"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT03975829",
+			"brief_title": "Pediatric Long-Term Follow-up and Rollover Study",
+			"eligibility": {
+				"structured": {
+					"max_age": "999 Years",
+					"max_age_number": 999.0,
+					"min_age_unit": "Years",
+					"max_age_unit": "Years",
+					"max_age_in_years": 999.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "1 Years",
+					"min_age_number": 1.0,
+					"min_age_in_years": 1.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Pleomorphic Xanthoastrocytoma",
+						"Anaplastic pleomorphic xanthroastrocytoma",
+						"APX",
+						"WHO Grade III Pleomorphic Xanthoastrocytoma"
+					],
+					"nci_thesaurus_concept_id": "C129327",
+					"name": "Anaplastic Pleomorphic Xanthoastrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C60781",
+						"C127816",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"RGNT"
+					],
+					"nci_thesaurus_concept_id": "C129431",
+					"name": "Rosette-Forming Glioneuronal Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Glioblastoma Multiforme",
+						"CNS, glioblastoma (GBM)",
+						"GBM (Glioblastoma)",
+						"GBM",
+						"Spongioblastoma Multiforme"
+					],
+					"nci_thesaurus_concept_id": "C3058",
+					"name": "Glioblastoma",
+					"type": [
+						"grade",
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C102897",
+						"C36025",
+						"C129325"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"NF1",
+						"Neurofibromatosis 1",
+						"Von Recklinghausen Disease",
+						"Recklinghausen disease",
+						"Peripheral Neurofibromatosis",
+						"Neurofibromatosis",
+						"Neurofibromatosis Type 1 Microdeletion Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C3273",
+					"name": "Neurofibromatosis Type 1",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C179667",
+						"C6727"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 2 Oligodendroglial Tumor",
+						"WHO Grade II Oligodendroglial Neoplasm",
+						"WHO Grade II Oligodendroglial Tumor",
+						"Oligodendroglioma, NOS",
+						"Well Differentiated Oligodendroglioma",
+						"Well Differentiated Oligodendroglial Tumor",
+						"WHO Grade 2 Oligodendroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3288",
+					"name": "Oligodendroglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C6960",
+						"C132505",
+						"C129325"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Subependymal Giant Cell Astrocytic Neoplasm",
+						"SEGA",
+						"Subependymal Giant Cell Astrocytic Tumor"
+					],
+					"nci_thesaurus_concept_id": "C3696",
+					"name": "Subependymal Giant Cell Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C116342",
+						"C177797"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Ganglioglioma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3788",
+					"name": "Ganglioglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Central Neurocytoma (WHO Grade 2)",
+						"Central Neurocytoma (WHO Grade II)"
+					],
+					"nci_thesaurus_concept_id": "C3791",
+					"name": "Central Neurocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4747",
+						"C2937"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Grade 1 Astrocytic Neoplasm",
+						"Grade 1 Astrocytic Tumor",
+						"Grade I Astrocytic Tumor",
+						"Grade I Astrocytoma",
+						"Grade I Astrocytic Neoplasm",
+						"Grade 1 Astrocytoma"
+					],
+					"nci_thesaurus_concept_id": "C4047",
+					"name": "Pilocytic Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C116342",
+						"C177797"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Pleomorphic Xantho-Astrocytoma",
+						"PXA"
+					],
+					"nci_thesaurus_concept_id": "C4323",
+					"name": "Pleomorphic Xanthoastrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Oligodendroglial Neoplasm",
+						"WHO Grade III Oligodendroglial Tumor",
+						"WHO Grade III Oligodendroglial Neoplasm",
+						"WHO Grade 3 Oligodendroglial Tumor",
+						"Oligodendroglioma, anaplastic",
+						"Undifferentiated Oligodendroglioma",
+						"Oligodendroglioma, Malignant",
+						"Malignant Oligodendroglioma"
+					],
+					"nci_thesaurus_concept_id": "C4326",
+					"name": "Anaplastic Oligodendroglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C6960",
+						"C36025",
+						"C127816",
+						"C129325"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Ganglioglioma, anaplastic"
+					],
+					"nci_thesaurus_concept_id": "C4717",
+					"name": "Anaplastic Ganglioglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4627",
+						"C4747",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"DIG"
+					],
+					"nci_thesaurus_concept_id": "C4738",
+					"name": "Desmoplastic Infantile Ganglioglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C5132",
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Chordoid Glioma of Third Ventricle",
+						"Chordoid Glioma of 3rd Ventricle",
+						"Third Ventricle Chordoid Glioma",
+						"Chordoid Glioma of the Third Ventricle (WHO Grade 2)",
+						"Chordoid Glioma of the Third Ventricle",
+						"Chordoid Glioma of the Third Ventricle (WHO Grade II)",
+						"Chordoid Glioma of the 3rd Ventricle"
+					],
+					"nci_thesaurus_concept_id": "C5592",
+					"name": "Chordoid Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C170814",
+						"C2937",
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Astrocytoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C60781",
+					"name": "Astrocytoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Lipomatous Medulloblastoma",
+						"Cerebellar Liponeurocytoma (WHO Grade 2)",
+						"Cerebellar Liponeurocytoma (WHO Grade II)"
+					],
+					"nci_thesaurus_concept_id": "C6905",
+					"name": "Cerebellar Liponeurocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C7372"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C6934",
+					"name": "Gangliocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytoma, Diffuse",
+						"Grade 2 Astrocytic Neoplasm",
+						"Grade 2 Astrocytic Tumor",
+						"WHO Grade 2 Astrocytoma",
+						"Low-grade astrocytoma, NOS",
+						"Grade II Astrocytoma",
+						"Grade II Astrocytic Tumor",
+						"Grade II Astrocytic Neoplasm",
+						"Grade 2 Astrocytoma",
+						"WHO Grade II Astrocytoma",
+						"ASTROCYTOMA, DIFFUSE, MALIGNANT"
+					],
+					"nci_thesaurus_concept_id": "C7173",
+					"name": "Diffuse Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C129325",
+						"C132505",
+						"C116342"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Dysplastic Gangliocytoma of the Cerebellum",
+						"Dysplastic Gangliocytoma of Cerebellum",
+						"Lhermitte-Duclos Disease",
+						"Dysplastic gangliocytoma of cerebellum (Lhermitte-Duclos)",
+						"Dysplastic Cerebellar Gangliocytoma (Lhermitte-Duclos Disease)"
+					],
+					"nci_thesaurus_concept_id": "C8419",
+					"name": "Dysplastic Cerebellar Gangliocytoma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7372"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Angiocentric Glioma (WHO Grade I)",
+						"Angiocentric Neuroepithelial Tumor",
+						"Monomorphus Angiocentric Glioma",
+						"Angiocentric Glioma (WHO Grade 1)"
+					],
+					"nci_thesaurus_concept_id": "C92552",
+					"name": "Angiocentric Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C177797"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Papillary Glioneuronal Tumor (WHO Grade 1)",
+						"Papillary Glioneuronal Tumor (WHO Grade I)",
+						"PGNT"
+					],
+					"nci_thesaurus_concept_id": "C92554",
+					"name": "Papillary Glioneuronal Tumor",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Extraventricular Neurocytoma (WHO Grade II)",
+						"Extraventricular Neurocytoma (WHO Grade 2)"
+					],
+					"nci_thesaurus_concept_id": "C92555",
+					"name": "Extraventricular Neurocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C170814",
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Desmoplastic Astrocytoma of Infancy",
+						"DIA"
+					],
+					"nci_thesaurus_concept_id": "C9476",
+					"name": "Desmoplastic Infantile Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4747",
+						"C5132"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Grade 3 Astrocytic Neoplasm",
+						"Malignant Astrocytoma",
+						"Grade III Astrocytoma",
+						"Astrocytoma, anaplastic",
+						"Grade 3 Astrocytoma",
+						"Grade III Astrocytic Tumor",
+						"High Grade Astrocytoma",
+						"High-grade astrocytoma, NOS",
+						"Grade III Astrocytic Neoplasm",
+						"High-Grade Astrocytoma",
+						"Grade 3 Astrocytic Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9477",
+					"name": "Anaplastic Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C127816",
+						"C129325",
+						"C36025",
+						"C102897",
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS primary tumor, NOS"
+					],
+					"nci_thesaurus_concept_id": "C102871",
+					"name": "Primary Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS Tumor",
+						"Tumor of CNS",
+						"Central Nervous System Tumor",
+						"Tumor of the Central Nervous System",
+						"Tumor of the CNS",
+						"Neoplasm of CNS",
+						"Central Nervous System Neoplasm",
+						"Neoplasm of Central Nervous System",
+						"Neoplasm of the Central Nervous System",
+						"Tumor of Central Nervous System",
+						"Neoplasm of uncertain behavior of central nervous system, unspecified",
+						"CNS Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C9293",
+					"name": "Brain/Spinal Cord Tumor",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Astrocytic Neoplasm",
+						"Astroglioma"
+					],
+					"nci_thesaurus_concept_id": "C6958",
+					"name": "Astrocytic Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Glioma, NOS",
+						"Tumor of the Neuroglia",
+						"Glial Tumor",
+						"Glial Neoplasm",
+						"Neoplasm of the Neuroglia",
+						"Tumor of Neuroglia",
+						"Neuroglial Tumor",
+						"Neoplasm of Neuroglia",
+						"Neuroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3059",
+					"name": "Glioma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3787",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Central Nervous System Disease",
+						"Disorder of Central Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C2934",
+					"name": "Central Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C26835"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C188950",
+					"name": "Childhood Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C6283"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"inherited cancer syndrome",
+						"Germline Neoplastic Syndrome",
+						"Familial Tumor Syndrome",
+						"Hereditary Tumor Syndrome",
+						"Familial Neoplastic Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C3266",
+					"name": "Hereditary Neoplastic Syndrome",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C54705",
+						"C3101"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Pediatric Disease or Disorder",
+						"Pediatric Disease"
+					],
+					"nci_thesaurus_concept_id": "C89328",
+					"name": "Pediatric Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"High Grade Astrocytic Neoplasm",
+						"High-Grade Astrocytic Tumor",
+						"High-Grade Astrocytic Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C102897",
+					"name": "High Grade Astrocytic Tumor",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822",
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"CNS, low grade glioma (LGG)",
+						"LGG",
+						"Low-Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C132067",
+					"name": "Low Grade Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neurofibromatosis, NOS",
+						"Neurofibromatosis Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C6727",
+					"name": "Neurofibromatosis",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C84348"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C28193",
+					"name": "Syndrome",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C129325",
+					"name": "Diffuse Glioma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 2 Glioma",
+						"WHO Grade II Glioma",
+						"Grade 2 Glioma"
+					],
+					"nci_thesaurus_concept_id": "C132505",
+					"name": "Grade II Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C132067"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade I Glioma"
+					],
+					"nci_thesaurus_concept_id": "C177797",
+					"name": "WHO Grade 1 Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C132067"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neoplasm of unspecified behavior of brain",
+						"Neoplasm of Brain",
+						"Neoplasm of the Brain",
+						"Brain Neoplasms",
+						"Tumor of the Brain",
+						"Tumor of Brain",
+						"Brain Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C2907",
+					"name": "Brain Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C96413",
+						"C4953"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Disorder of brain, unspecified"
+					],
+					"nci_thesaurus_concept_id": "C96413",
+					"name": "Brain Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Childhood Neoplasm",
+						"Childhood Tumor",
+						"Pediatric Tumor",
+						"Pediatric Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C6283",
+					"name": "Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C89328",
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C170814",
+					"name": "Primary Brain Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2907",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Neuroglial Tumor",
+						"Glioma, malignant",
+						"Malignant Glial Tumor",
+						"Malignant Glial Neoplasm",
+						"High-Grade Glioma",
+						"Malignant Neuroglial Neoplasm",
+						"High Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C4822",
+					"name": "Malignant Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3059",
+						"C4627"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Infratentorial Tumors",
+						"Brain Neoplasms, Infratentorial",
+						"Infratentorial Tumor",
+						"Neoplasm of uncertain behavior of brain, infratentorial",
+						"Infratentorial Neoplasms",
+						"Neoplasms, Infratentorial"
+					],
+					"nci_thesaurus_concept_id": "C3139",
+					"name": "Infratentorial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2907"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C36025",
+					"name": "Anaplastic Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neuronal and Mixed Neuronal-Glial Tumor of Cerebellum",
+						"Cerebellar Neuronal and Mixed Neuronal-Glial Tumor"
+					],
+					"nci_thesaurus_concept_id": "C7372",
+					"name": "Cerebellar Glioneuronal and Neuronal Tumors",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2935",
+						"C4747"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neurocutaneous Syndrome",
+						"Phacomatosis"
+					],
+					"nci_thesaurus_concept_id": "C84348",
+					"name": "Phakomatosis",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3266"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Intracranial Central Nervous System Neoplasm",
+						"Intracranial Tumor",
+						"Intracranial Central Nervous System Tumor"
+					],
+					"nci_thesaurus_concept_id": "C4953",
+					"name": "Intracranial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neoplasm of Cerebellum",
+						"Cerebellar Tumor",
+						"Tumor of Cerebellum",
+						"Tumor of the Cerebellum",
+						"Neoplasm of the Cerebellum"
+					],
+					"nci_thesaurus_concept_id": "C2935",
+					"name": "Cerebellar Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3139"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Low-Grade Astrocytic Tumor",
+						"Low-Grade Astrocytic Neoplasm",
+						"Low-Grade Astrocytoma",
+						"Low Grade Astrocytic Tumor",
+						"Low Grade Astrocytic Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C116342",
+					"name": "Low Grade Astrocytoma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C132067",
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neuronal and Glio-Neuronal Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumors",
+						"Neuronal and Glio-Neuronal Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C4747",
+					"name": "Glioneuronal and Neuronal Tumors",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C102871",
+						"C3787"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Hereditary Diseases",
+						"Molecular Disease",
+						"Hereditary Disease",
+						"Genetic Condition",
+						"Genetic Syndrome",
+						"Inherited Disease"
+					],
+					"nci_thesaurus_concept_id": "C3101",
+					"name": "Genetic Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Tumor Syndrome",
+						"Neoplastic Syndrome"
+					],
+					"nci_thesaurus_concept_id": "C54705",
+					"name": "Cancer-Related Syndrome",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C28193"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Intraventricular Neoplasm of the Brain",
+						"Intraventricular Neoplasms",
+						"Intraventricular Brain Neoplasms",
+						"Intraventricular Brain Tumor",
+						"Brain Neoplasms, Intraventricular",
+						"Intraventricular Tumor of Brain",
+						"Intraventricular Tumor of the Brain",
+						"Intraventricular Neoplasm of Brain"
+					],
+					"nci_thesaurus_concept_id": "C2937",
+					"name": "Intraventricular Brain Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2907"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Oligodendroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C6960",
+					"name": "Oligodendroglial Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Childhood Neoplasm of CNS",
+						"Childhood CNS Neoplasm",
+						"Pediatric Central Nervous System Neoplasm",
+						"Childhood Tumor of the CNS",
+						"Pediatric Tumor of CNS",
+						"Childhood CNS Tumor",
+						"Pediatric Neoplasm of CNS",
+						"Childhood Central Nervous System Neoplasm",
+						"Childhood Neoplasm of Central Nervous System",
+						"Pediatric Central Nervous System Tumor",
+						"Childhood Central Nervous System Tumor",
+						"Pediatric Tumor of Central Nervous System",
+						"Childhood Neoplasm of the Central Nervous System",
+						"Childhood Tumor of Central Nervous System",
+						"Pediatric Neoplasm of Central Nervous System",
+						"Childhood Central Nervous System Tumors",
+						"Pediatric Neoplasm of the CNS",
+						"Pediatric Tumor of the CNS",
+						"Childhood CNS Tumors",
+						"Childhood Tumor of the Central Nervous System",
+						"Childhood Central Nervous System Neoplasms",
+						"Pediatric Tumor of the Central Nervous System",
+						"Childhood Neoplasm of the CNS",
+						"Pediatric CNS Neoplasm",
+						"Childhood CNS Neoplasms",
+						"Pediatric Neoplasm of the Central Nervous System",
+						"Childhood Tumor of CNS",
+						"Pediatric CNS Tumor"
+					],
+					"nci_thesaurus_concept_id": "C5132",
+					"name": "Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293",
+						"C188950"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Tumor of the CNS",
+						"Malignant neoplasm of central nervous system, unspecified",
+						"Malignant Central Nervous System Tumor",
+						"Malignant Tumor of Central Nervous System",
+						"Cancer of the CNS",
+						"Cancer of CNS",
+						"Malignant CNS Tumor",
+						"Malignant Neoplasm of Central Nervous System",
+						"Cancer of the Central Nervous System",
+						"Malignant CNS Neoplasms",
+						"Malignant CNS Neoplasm",
+						"Cancer of Central Nervous System",
+						"Central Nervous System Neoplasms, Malignant",
+						"Central Nervous System Cancer",
+						"Malignant Neoplasm of CNS",
+						"Malignant Tumor of CNS",
+						"Malignant Neoplasm of the CNS",
+						"Malignant Tumor of the Central Nervous System",
+						"Malignant Neoplasm of the Central Nervous System",
+						"CNS Malignant Neoplasms",
+						"CNS Cancer",
+						"CNS Neoplasms, Malignant"
+					],
+					"nci_thesaurus_concept_id": "C4627",
+					"name": "Malignant Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4788",
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C179667",
+					"name": "RASopathy",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3101",
+						"C28193"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Glioma",
+						"Anaplastic Glioma"
+					],
+					"nci_thesaurus_concept_id": "C127816",
+					"name": "WHO Grade III Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "NY",
+					"org_city": "New York",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Memorial Sloan Kettering Cancer Center",
+					"org_postal_code": "10065",
+					"org_coordinates": {
+						"lon": -73.9624,
+						"lat": 40.7656
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TN",
+					"org_city": "Memphis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Saint Jude Children's Research Hospital",
+					"org_postal_code": "38105",
+					"org_coordinates": {
+						"lon": -90.0341,
+						"lat": 35.1506
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MN",
+					"org_city": "Minneapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Minnesota/Masonic Cancer Center",
+					"org_postal_code": "55455",
+					"org_coordinates": {
+						"lon": -93.2319,
+						"lat": 44.974
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "IN",
+					"org_city": "Indianapolis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Riley Hospital for Children",
+					"org_postal_code": "46202",
+					"org_coordinates": {
+						"lon": -86.163,
+						"lat": 39.7837
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Boston Children's Hospital",
+					"org_postal_code": "02115",
+					"org_coordinates": {
+						"lon": -71.0948,
+						"lat": 42.341
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Boston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Dana-Farber Cancer Institute",
+					"org_postal_code": "02215",
+					"org_coordinates": {
+						"lon": -71.1025,
+						"lat": 42.3469
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "TX",
+					"org_city": "Houston",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Texas Children's Hospital",
+					"org_postal_code": "77030",
+					"org_coordinates": {
+						"lon": -95.4026,
+						"lat": 29.7059
+					},
+					"recruitment_status": "ACTIVE"
+				}
+			],
+			"nci_id": "NCI-2019-08622"
+		},
+		{
+			"current_trial_status": "Active",
+			"nct_id": "NCT03593993",
+			"brief_title": "Biospecimen Collection in Evaluating Pharmacokinetic, Pharmacodynamic, and Resistance Profile to Dabrafenib, Encorafenib, Binimetinib, and Trametinib in Patients with BRAF-V600 Mutated Recurrent Gliomas Undergoing Surgery",
+			"eligibility": {
+				"structured": {
+					"max_age": "999 Years",
+					"max_age_number": 999.0,
+					"min_age_unit": "Days",
+					"max_age_unit": "Years",
+					"max_age_in_years": 999.0,
+					"gender": "BOTH",
+					"accepts_healthy_volunteers": false,
+					"min_age": "0 Days",
+					"min_age_number": 0.0,
+					"min_age_in_years": 0.0
+				}
+			},
+			"diseases": [
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Pleomorphic Xanthoastrocytoma",
+						"Anaplastic pleomorphic xanthroastrocytoma",
+						"APX",
+						"WHO Grade III Pleomorphic Xanthoastrocytoma"
+					],
+					"nci_thesaurus_concept_id": "C129327",
+					"name": "Anaplastic Pleomorphic Xanthoastrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C60781",
+						"C127816",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C132506",
+					"name": "Recurrent Glioma",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C71700",
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C170814",
+					"name": "Primary Brain Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2907",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Glioblastoma Multiforme",
+						"CNS, glioblastoma (GBM)",
+						"GBM (Glioblastoma)",
+						"GBM",
+						"Spongioblastoma Multiforme"
+					],
+					"nci_thesaurus_concept_id": "C3058",
+					"name": "Glioblastoma",
+					"type": [
+						"grade",
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C102897",
+						"C36025",
+						"C129325"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Ganglioglioma, anaplastic"
+					],
+					"nci_thesaurus_concept_id": "C4717",
+					"name": "Anaplastic Ganglioglioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C4627",
+						"C4747",
+						"C36025"
+					]
+				},
+				{
+					"inclusion_indicator": "TRIAL",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Grade 3 Astrocytic Neoplasm",
+						"Malignant Astrocytoma",
+						"Grade III Astrocytoma",
+						"Astrocytoma, anaplastic",
+						"Grade 3 Astrocytoma",
+						"Grade III Astrocytic Tumor",
+						"High Grade Astrocytoma",
+						"High-grade astrocytoma, NOS",
+						"Grade III Astrocytic Neoplasm",
+						"High-Grade Astrocytoma",
+						"Grade 3 Astrocytic Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9477",
+					"name": "Anaplastic Astrocytoma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C127816",
+						"C129325",
+						"C36025",
+						"C102897",
+						"C60781"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease",
+						"disease_term",
+						"Disease or Disorder, Non-Neoplastic",
+						"Diseases and Disorders",
+						"disease term",
+						"Disease or Disorder",
+						"Disorder",
+						"Diagnosis",
+						"disease_type",
+						"disease type",
+						"Diseases",
+						"Disorders",
+						"condition"
+					],
+					"nci_thesaurus_concept_id": "C2991",
+					"name": "Other Disease",
+					"type": [
+						"maintype"
+					],
+					"parents": []
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of unspecified behavior of brain",
+						"Neoplasm of Brain",
+						"Neoplasm of the Brain",
+						"Brain Neoplasms",
+						"Tumor of the Brain",
+						"Tumor of Brain",
+						"Brain Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C2907",
+					"name": "Brain Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C96413",
+						"C4953"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C3263",
+					"name": "Neoplasm by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disorder of brain, unspecified"
+					],
+					"nci_thesaurus_concept_id": "C96413",
+					"name": "Brain Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplastic Disease",
+						"Neoplasm",
+						"Neoplastic Growth",
+						"Neoplasia",
+						"tumor",
+						"Tumor, NOS",
+						"Neoplasm, NOS",
+						"Neoplasms, NOS"
+					],
+					"nci_thesaurus_concept_id": "C3262",
+					"name": "Other Neoplasm",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Neoplasm of Nervous System",
+						"Tumor of the Nervous System",
+						"Tumor of Nervous System",
+						"Nervous System Tumour",
+						"Nervous System Neoplasms",
+						"Neoplasm of the Nervous System",
+						"Nervous System Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3268",
+					"name": "Nervous System Tumor",
+					"type": [
+						"maintype"
+					],
+					"parents": [
+						"C26835",
+						"C3263"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Unspecified Nervous System Problem",
+						"Neurologic Disorder",
+						"Disorder of Nervous System",
+						"Neurological Disorder"
+					],
+					"nci_thesaurus_concept_id": "C26835",
+					"name": "Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C27551"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS primary tumor, NOS"
+					],
+					"nci_thesaurus_concept_id": "C102871",
+					"name": "Primary Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"CNS Tumor",
+						"Tumor of CNS",
+						"Central Nervous System Tumor",
+						"Tumor of the Central Nervous System",
+						"Tumor of the CNS",
+						"Neoplasm of CNS",
+						"Central Nervous System Neoplasm",
+						"Neoplasm of Central Nervous System",
+						"Neoplasm of the Central Nervous System",
+						"Tumor of Central Nervous System",
+						"Neoplasm of uncertain behavior of central nervous system, unspecified",
+						"CNS Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C9293",
+					"name": "Brain/Spinal Cord Tumor",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C2934"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Intracranial Central Nervous System Neoplasm",
+						"Intracranial Tumor",
+						"Intracranial Central Nervous System Tumor"
+					],
+					"nci_thesaurus_concept_id": "C4953",
+					"name": "Intracranial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Central Nervous System Disease",
+						"Disorder of Central Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C2934",
+					"name": "Central Nervous System Disorder",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C26835"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": true,
+					"synonyms": [
+						"Disease by Site"
+					],
+					"nci_thesaurus_concept_id": "C27551",
+					"name": "Disorder by Site",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C2991"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neoplasm of Neuroepithelium",
+						"Neoplasm of the Neuroepithelium",
+						"Neuroepithelial Tissue Neoplasm",
+						"Tumor of Neuroepithelial Tissue",
+						"Neuroepithelial Tissue Tumor",
+						"Neuroepithelial Tumor",
+						"Neuroepithelial Neoplasms",
+						"Tumor of Neuroepithelium",
+						"Neoplasm of Neuroepithelial Tissue",
+						"Neuroepithelial Tumors",
+						"Neuroepitheliomatous Neoplasms",
+						"Tumor of the Neuroepithelium"
+					],
+					"nci_thesaurus_concept_id": "C3787",
+					"name": "Neuroepithelial Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C35562"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Recurrent Primary Central Nervous System Tumor"
+					],
+					"nci_thesaurus_concept_id": "C71700",
+					"name": "Recurrent Primary Central Nervous System Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C182030",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytic Neoplasm",
+						"Astroglioma"
+					],
+					"nci_thesaurus_concept_id": "C6958",
+					"name": "Astrocytic Tumor",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Neuroglial Tumor",
+						"Glioma, malignant",
+						"Malignant Glial Tumor",
+						"Malignant Glial Neoplasm",
+						"High-Grade Glioma",
+						"Malignant Neuroglial Neoplasm",
+						"High Grade Glioma"
+					],
+					"nci_thesaurus_concept_id": "C4822",
+					"name": "Malignant Glioma",
+					"type": [
+						"grade",
+						"subtype"
+					],
+					"parents": [
+						"C3059",
+						"C4627"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Unclassified tumor, malignant",
+						"Tumor, malignant, NOS",
+						"Neoplasm, malignant",
+						"Malignancy",
+						"Malignant Neoplastic Disease",
+						"CA",
+						"Cancer",
+						"Malignant Growth",
+						"Malignant Tumor"
+					],
+					"nci_thesaurus_concept_id": "C9305",
+					"name": "Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C182030",
+					"name": "Recurrent Nervous System Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C4798",
+						"C3268"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"WHO Grade 3 Glioma",
+						"Anaplastic Glioma"
+					],
+					"nci_thesaurus_concept_id": "C127816",
+					"name": "WHO Grade III Glioma",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Astrocytoma, NOS"
+					],
+					"nci_thesaurus_concept_id": "C60781",
+					"name": "Astrocytoma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Glioma, NOS",
+						"Tumor of the Neuroglia",
+						"Glial Tumor",
+						"Glial Neoplasm",
+						"Neoplasm of the Neuroglia",
+						"Tumor of Neuroglia",
+						"Neuroglial Tumor",
+						"Neoplasm of Neuroglia",
+						"Neuroglial Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C3059",
+					"name": "Glioma",
+					"type": [
+						"maintype",
+						"subtype"
+					],
+					"parents": [
+						"C3787",
+						"C102871"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Recurrent Tumor",
+						"Recurrence",
+						"Neoplasm Recurrence",
+						"Recurrent"
+					],
+					"nci_thesaurus_concept_id": "C4798",
+					"name": "Recurrent Neoplasm",
+					"type": [
+						"stage"
+					],
+					"parents": [
+						"C7062"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Tumor of the CNS",
+						"Malignant neoplasm of central nervous system, unspecified",
+						"Malignant Central Nervous System Tumor",
+						"Malignant Tumor of Central Nervous System",
+						"Cancer of the CNS",
+						"Cancer of CNS",
+						"Malignant CNS Tumor",
+						"Malignant Neoplasm of Central Nervous System",
+						"Cancer of the Central Nervous System",
+						"Malignant CNS Neoplasms",
+						"Malignant CNS Neoplasm",
+						"Cancer of Central Nervous System",
+						"Central Nervous System Neoplasms, Malignant",
+						"Central Nervous System Cancer",
+						"Malignant Neoplasm of CNS",
+						"Malignant Tumor of CNS",
+						"Malignant Neoplasm of the CNS",
+						"Malignant Tumor of the Central Nervous System",
+						"Malignant Neoplasm of the Central Nervous System",
+						"CNS Malignant Neoplasms",
+						"CNS Cancer",
+						"CNS Neoplasms, Malignant"
+					],
+					"nci_thesaurus_concept_id": "C4627",
+					"name": "Malignant Central Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C4788",
+						"C9293"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neural Neoplasm",
+						"Neural Tumor"
+					],
+					"nci_thesaurus_concept_id": "C35562",
+					"name": "Neuroepithelial, Perineurial, and Schwann Cell Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C4741"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C129325",
+					"name": "Diffuse Glioma",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3059"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C7062",
+					"name": "Neoplasm by Special Category",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Neuronal and Glio-Neuronal Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumor",
+						"Neuronal and Mixed Neuronal-Glial Tumors",
+						"Neuronal and Glio-Neuronal Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C4747",
+					"name": "Glioneuronal and Neuronal Tumors",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C102871",
+						"C3787"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"High Grade Astrocytic Neoplasm",
+						"High-Grade Astrocytic Tumor",
+						"High-Grade Astrocytic Neoplasm"
+					],
+					"nci_thesaurus_concept_id": "C102897",
+					"name": "High Grade Astrocytic Tumor",
+					"type": [
+						"grade"
+					],
+					"parents": [
+						"C4822",
+						"C6958"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Tumor_Morphology",
+						"Tumor Morphology"
+					],
+					"nci_thesaurus_concept_id": "C4741",
+					"name": "Neoplasm by Morphology",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3262"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [],
+					"nci_thesaurus_concept_id": "C36025",
+					"name": "Anaplastic Malignant Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C9305"
+					]
+				},
+				{
+					"inclusion_indicator": "TREE",
+					"is_lead_disease": false,
+					"synonyms": [
+						"Malignant Neoplasm of the Nervous System",
+						"Malignant Tumor of Nervous System",
+						"Nervous System Neoplasms, Malignant",
+						"Malignant Tumor of the Nervous System",
+						"Malignant Nervous System Tumor",
+						"Malignant Neoplasm of Nervous System"
+					],
+					"nci_thesaurus_concept_id": "C4788",
+					"name": "Malignant Nervous System Neoplasm",
+					"type": [
+						"subtype"
+					],
+					"parents": [
+						"C3268",
+						"C9305"
+					]
+				}
+			],
+			"sites": [
+				{
+					"org_state_or_province": "MD",
+					"org_city": "Baltimore",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Johns Hopkins University/Sidney Kimmel Cancer Center",
+					"org_postal_code": "21287",
+					"org_coordinates": {
+						"lon": -76.5621,
+						"lat": 39.3021
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "University Park",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Penn State University",
+					"org_postal_code": "16802",
+					"org_coordinates": {
+						"lon": -77.8633,
+						"lat": 40.8092
+					},
+					"recruitment_status": "APPROVED"
+				},
+				{
+					"org_state_or_province": "NC",
+					"org_city": "Winston-Salem",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Wake Forest University Health Sciences",
+					"org_postal_code": "27157",
+					"org_coordinates": {
+						"lon": -80.2096,
+						"lat": 36.0964
+					},
+					"recruitment_status": "CLOSED_TO_ACCRUAL"
+				},
+				{
+					"org_state_or_province": "PA",
+					"org_city": "Philadelphia",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "University of Pennsylvania/Abramson Cancer Center",
+					"org_postal_code": "19104",
+					"org_coordinates": {
+						"lon": -75.1995,
+						"lat": 39.9616
+					},
+					"recruitment_status": "ACTIVE"
+				},
+				{
+					"org_state_or_province": "MA",
+					"org_city": "Charlestown",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Massachusetts General Hospital",
+					"org_postal_code": "02129",
+					"org_coordinates": {
+						"lon": -71.0637,
+						"lat": 42.3791
+					},
+					"recruitment_status": "APPROVED"
+				},
+				{
+					"org_state_or_province": "MO",
+					"org_city": "Saint Louis",
+					"org_va": false,
+					"org_country": "United States",
+					"org_name": "Siteman Cancer Center at Washington University",
+					"org_postal_code": "63110",
+					"org_coordinates": {
+						"lon": -90.267,
+						"lat": 38.6267
+					},
+					"recruitment_status": "APPROVED"
+				}
+			],
+			"nci_id": "NCI-2019-00399"
+		}
+	]
+}


### PR DESCRIPTION
 * Adds mock data:  `age-display-{request|response}.json`
  * Adds supporting cypress test case
  * Updates logic for age display to account for varying units

  Prime Example Route: `/r?loc=0&rl=2&tid=NCI-2019-02289%2C+NCI-2019-06216%2C+NCI-2019-08622%2C+NCI-2019-00399%2C+NCI-2021-06711%2C+NCI-2014-00677%2C+NCI-2016-01734`

  Closes #608
