### PR TITLE
(#613) Update CT.gov URLs

### DIFF
--- a/cypress/e2e/TrialDescriptionPage/Accordion.feature
+++ b/cypress/e2e/TrialDescriptionPage/Accordion.feature
@@ -53,7 +53,7 @@ Feature: As a user, I want to be able to get even more details about the trial v
       | Primary ID            |
       | Secondary IDs         |
       | ClinicalTrials.gov ID |
-    And "NCT02201992" link has a href "http://clinicaltrials.gov/show/NCT02201992"
+    And "NCT02201992" link has a href "http://clinicaltrials.gov/study/NCT02201992"
 
   Scenario: user is able to see trial's location that is near searched zipcode
     Given the user navigates to "/v?id=NCI-2014-01507&loc=1&rl=1&z=22182"
@@ -225,7 +225,7 @@ Feature: As a user, I want to be able to get even more details about the trial v
     And trial description accordion is displayed
     When user clicks on "Locations & Contacts" section of accordion
     Then text "See trial information on ClinicalTrials.gov for a list of participating sites." is displayed
-    And "ClinicalTrials.gov" link has a href "https://www.clinicaltrials.gov/show/NCT00596999"
+    And "ClinicalTrials.gov" link has a href "https://www.clinicaltrials.gov/study/NCT00596999"
 
   Scenario: as a user I will not see locations if I searched for a trial in a country that does not exist/host that trial
     Given the user navigates to "/v?id=NCI-2018-01903&lcnty=zimbabue&loc=2&rl=2"

--- a/src/views/ResultsPage/ResultsListItem.jsx
+++ b/src/views/ResultsPage/ResultsListItem.jsx
@@ -180,7 +180,7 @@ const ResultsListItem = ({
 					<>
 						See{' '}
 						<a
-							href={`https://www.clinicaltrials.gov/show/${item.nct_id}`}
+							href={`https://www.clinicaltrials.gov/study/${item.nct_id}`}
 							target="_blank"
 							rel="noopener noreferrer">
 							ClinicalTrials.gov

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -641,7 +641,7 @@ const TrialDescriptionPage = () => {
 													<p>
 														See trial information on{' '}
 														<a
-															href={`https://www.clinicaltrials.gov/show/${trialDescription.nct_id}`}
+															href={`https://www.clinicaltrials.gov/study/${trialDescription.nct_id}`}
 															target="_blank"
 															rel="noopener noreferrer">
 															ClinicalTrials.gov
@@ -721,7 +721,7 @@ const TrialDescriptionPage = () => {
 															ClinicalTrials.gov ID
 														</strong>
 														<a
-															href={`http://clinicaltrials.gov/show/${trialDescription.nct_id}`}
+															href={`http://clinicaltrials.gov/study/${trialDescription.nct_id}`}
 															target="_blank"
 															rel="noopener noreferrer">
 															{trialDescription.nct_id}


### PR DESCRIPTION
- replaced redirects with /show to /study 
Closes #613