### PR TITLE
(#642, #643, #650) Add configuration variables for page info, Locations link

### DIFF
--- a/cypress/e2e/AdvancedSearchPage/AdvancedSearchForm.feature
+++ b/cypress/e2e/AdvancedSearchPage/AdvancedSearchForm.feature
@@ -3,9 +3,8 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 	Scenario Outline: When user visits Advanced Search page, all page items are present
 		And screen breakpoint is set to "<breakpoint>"
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the text "NCI-supported clinical trials are those sponsored or otherwise financially supported by NCI. See our guide, Steps to Find a Clinical Trial, to learn about options for finding trials not included in NCI's collection." appears below the title
-		And "Steps to Find a Clinical Trial" link has a href "https://www.cancer.gov/research/participate/clinical-trials-search/steps"
+		Then the page title is "Find Cancer Clinical Trials"
+		And the text "Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, Steps to Find a Clinical Trial, to learn about options for finding trials not included in NCI's collection." appears below the title
 		And Search tip icon is displayed and text "Search Tip: All fields are optional. Skip any items that are unknown or not applicable or try our basic search." appears
 		And "basic search" link has a href "/"
 		And the following delighters are displayed
@@ -26,7 +25,7 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 
 	Scenario: User is able to clear a form
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Age" form section is displayed
 		When user types "40" in "Age" field
 		And user types "psa" in "Keywords" field
@@ -37,7 +36,7 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 
 	Scenario: user can navigate to basic search form while on advance page
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And Search tip icon is displayed and text "Search Tip: All fields are optional. Skip any items that are unknown or not applicable or try our basic search." appears
 		And "basic search" link has a href "/"
 		When user clicks on "basic search" with href "/"
@@ -45,7 +44,7 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 
 	Scenario: user can navigate to advanced search form while on basic search form page
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And Search tip icon is displayed and text "Search Tip: For more search options, use our advanced search." appears
 		When user clicks on "advanced search" with href "/advanced"
 		Then user is redirected to "/advanced"
@@ -53,15 +52,14 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 		### meta data
 		Scenario: As a search engine I want to have access to the meta data on a page
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		Then the page title is "Find Cancer Clinical Trials"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
-
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"

--- a/cypress/e2e/AdvancedSearchPage/AgeSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/AgeSection.feature
@@ -1,14 +1,14 @@
 Feature: Clinical Trials Advanced Search Page age section
     Scenario: User has an option to narrow down search criteria by age
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Age" form section is displayed
         And help icon is displayed in "Age" section with href "/research/participate/clinical-trials-search/help#age"
         And helper text "Enter the age of the participant." is displayed
 
     Scenario: User is able to search for a specific age
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Age" form section is displayed
         When user types "40" in "Age" field
         And user clicks on "Find Trials" button
@@ -25,7 +25,7 @@ Feature: Clinical Trials Advanced Search Page age section
 
     Scenario: User is able to search for a specific age from basic search and refine search
         Given the user navigates to "/"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Age" form section is displayed
         When user types "40" in "Age" field
         And user clicks on "Find Trials" button
@@ -58,7 +58,7 @@ Feature: Clinical Trials Advanced Search Page age section
 
     Scenario: Negative: User is not able to search for age out of boundaries
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Age" form section is displayed
         When user types "0" in "Age" field
         Then alert "Please enter a number between 1 and 120." is displayed
@@ -78,7 +78,7 @@ Feature: Clinical Trials Advanced Search Page age section
 
 	Scenario: User is able to view trial results which have varying age criteria
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Age" form section is displayed
 		When user types "NCI-2019-02289, NCI-2019-06216, NCI-2019-08622, NCI-2019-00399, NCI-2021-06711, NCI-2014-00677, NCI-2016-01734" in "TrialID" field
 		And user clicks on "Find Trials" button

--- a/cypress/e2e/AdvancedSearchPage/DrugTreatmentSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/DrugTreatmentSection.feature
@@ -2,7 +2,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User has an option to narrow down search criteria by Drug or treatment
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		And help icon is displayed in "Drug/Treatment" section with href "/research/participate/clinical-trials-search/help#drugtreatment"
 		And info text "Search for a specific drug or intervention." is displayed in the section body
@@ -13,7 +13,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User has an option to search by Drug and treatment using autosuggest and refine search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		When user clicks on "Drug" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -54,7 +54,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User has an option to search for multiple Drug and treatment using autosuggest and then refine search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		When user clicks on "Drug" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -104,7 +104,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User enters keyword that does not return a match for drug and intervention
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		When user clicks on "Drug" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -117,7 +117,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User is searching for a drug by it's preferred name
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		When user clicks on "Drug" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -137,7 +137,7 @@ Feature: Advanced Clinical Trials Search Drug Treatment Section
 
 	Scenario: User searches for drug/intervention via autosuggest on advanced form
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
     Then "Drug" input field has a placeholder "Start typing to select drugs and/or drug families"
     When user clicks on "Drug" field

--- a/cypress/e2e/AdvancedSearchPage/KeywordsSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/KeywordsSection.feature
@@ -3,7 +3,7 @@ Feature: Clinical Trials Advanced Search Page
     Scenario Outline: User has an option to narrow down search criteria by keywords or phrases
         Given screen breakpoint is set to "screenBreakpoint"
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Keywords/Phrases" form section is displayed
         And help icon is displayed in "Keywords" section with href "/research/participate/clinical-trials-search/help#keywords"
         And "KeywordsPhrases" input field has a placeholder "Examples: PSA, 'Paget disease'"
@@ -16,7 +16,7 @@ Feature: Clinical Trials Advanced Search Page
 
     Scenario: User has an option to search by keywords and then modify search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Keywords/Phrases" form section is displayed
         When user types "psa" in "KeywordsPhrases" field
         When user clicks on "Find Trials" button
@@ -48,7 +48,7 @@ Feature: Clinical Trials Advanced Search Page
 
     Scenario: Negative : User searches by keyword that does not exist
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Keywords/Phrases" form section is displayed
         When user types "penguin" in "KeywordsPhrases" field
         When user clicks on "Find Trials" button

--- a/cypress/e2e/AdvancedSearchPage/LeadOrganizationSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/LeadOrganizationSection.feature
@@ -3,7 +3,7 @@ Feature: Advanced Clinical Trials Search Lead Organization Section
 
 	Scenario: User has an option to narrow down search criteria by lead org
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Lead Organization" form section is displayed
 		And help icon is displayed in "Lead Organization" section with href "/research/participate/clinical-trials-search/help#leadorganization"
 		And "Lead organization" input field has a placeholder "Organization name"
@@ -11,7 +11,7 @@ Feature: Advanced Clinical Trials Search Lead Organization Section
 
 	Scenario: User has an option to search by lead org using autosuggest and refine search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Lead Organization" form section is displayed
 		When user clicks on "Lead organization" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -48,7 +48,7 @@ Feature: Advanced Clinical Trials Search Lead Organization Section
 
 	Scenario: User searches for investigators that does not exist
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Lead Organization" form section is displayed
 		When user clicks on "Lead organization" field
 		Then autocomplete dropdown is displayed
@@ -66,7 +66,7 @@ Feature: Advanced Clinical Trials Search Lead Organization Section
 
 	Scenario: User has an option to search for lead organization without using autosuggest
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Lead Organization" form section is displayed
 		When user clicks on "Lead organization" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text

--- a/cypress/e2e/AdvancedSearchPage/LocationSection/LocationAtNIHOnly.feature
+++ b/cypress/e2e/AdvancedSearchPage/LocationSection/LocationAtNIHOnly.feature
@@ -3,7 +3,7 @@ Feature: As a user, I want to be able to narrow down my search by location
 
     Scenario: User has an option to narrow down search criteria by location
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Location" form section is displayed
         And help icon is displayed in "Location" section with href "/research/participate/clinical-trials-search/help#location"
         And info text "Search for trials near a specific zip code; or in a country, state and city; or at a particular institution. The default selection will search for trials in all available locations. You may choose to limit results to Veterans Affairs facilities." is displayed in the section body
@@ -13,7 +13,7 @@ Feature: As a user, I want to be able to narrow down my search by location
 
     Scenario: User has an option to limit results to show trials at NIH only
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "At NIH (only show trials at the NIH Clinical Center in Bethesda, MD)" radio button
         When user clicks on "Find Trials" button

--- a/cypress/e2e/AdvancedSearchPage/LocationSection/LocationByHospitals.feature
+++ b/cypress/e2e/AdvancedSearchPage/LocationSection/LocationByHospitals.feature
@@ -3,7 +3,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying a h
 
       Scenario: User has an option to limit results to Hospitals and refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Hospitals/Institutions" radio button
         And user types "um b" in "Hospitals/Institutions" autosuggest field
@@ -68,7 +68,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying a h
 
     Scenario: User has an option to search for a Hospital without using autosuggest
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Hospitals/Institutions" radio button
         And user types "mayo" in "Hospitals/Institutions" autosuggest field

--- a/cypress/e2e/AdvancedSearchPage/LocationSection/LocationByZipcode.feature
+++ b/cypress/e2e/AdvancedSearchPage/LocationSection/LocationByZipcode.feature
@@ -3,7 +3,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying a z
 
 		Scenario: User has an option to limit results to zipcode and radius and refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "ZIP Code" radio button
         And user types "22182" in "U.S. ZIP Code" field
@@ -43,7 +43,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying a z
 
 		Scenario: Negative: User is not able to search for an incorrect zip code AND is NOT able to search for empty zip
 			Given the user navigates to "/advanced"
-			Then the page title is "Find NCI-Supported Clinical Trials"
+			Then the page title is "Find Cancer Clinical Trials"
 			When user selects "ZIP Code" radio button
 			When user types "999g9" in "U.S. ZIP Code" field
 			Then alert "Please enter a valid 5 digit U.S. ZIP code" is displayed
@@ -61,7 +61,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying a z
 
     Scenario: Negative: User is not able to search for an incorrect zip code
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         When user selects "ZIP Code" radio button
         When user types "2016" in "U.S. ZIP Code" field
          And user clicks on "Find Trials" button

--- a/cypress/e2e/AdvancedSearchPage/LocationSection/LocationCountryStateCity.feature
+++ b/cypress/e2e/AdvancedSearchPage/LocationSection/LocationCountryStateCity.feature
@@ -3,7 +3,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying cou
 
     Scenario: User has an option to limit results to Country, State and City and refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Country, State, City" radio button
         And user selects "United Kingdom" from "Country" dropdown
@@ -47,7 +47,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying cou
 
     Scenario: User has an option to limit results to a foreign Country and city
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Country, State, City" radio button
         And user selects "United Kingdom" from "Country" dropdown
@@ -76,7 +76,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying cou
 
     Scenario: User has an option to limit results to the US and city and refines search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Country, State, City" radio button
         When user types "Miami" in "City" field
@@ -119,7 +119,7 @@ Feature: As a user, I want to be able to narrow down my search by specifying cou
 
     Scenario: User has an option to search for multiple states and refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Limit results to Veterans Affairs facilities" toggle is switched to "No"
         When user selects "Country, State, City" radio button
         And user types "vir" in "State" field

--- a/cypress/e2e/AdvancedSearchPage/LocationSection/LocationLimitedToVA.feature
+++ b/cypress/e2e/AdvancedSearchPage/LocationSection/LocationLimitedToVA.feature
@@ -2,7 +2,7 @@ Feature: As a user, I want to be able to narrow down my search by locations limi
 
 Scenario: User has an option to limit results to VA facilities and all locations and refines search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Location" form section is displayed
         When user selects "At NIH (only show trials at the NIH Clinical Center in Bethesda, MD)" radio button
         When user toggles "Limit results to Veterans Affairs facilities"
@@ -39,7 +39,7 @@ Scenario: User has an option to limit results to VA facilities and all locations
 
     Scenario: User has an option to limit results to VA facilities and Zip code and to refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Location" form section is displayed
         When user toggles "Limit results to Veterans Affairs facilities"
         Then "Limit results to Veterans Affairs facilities" toggle is switched to "Yes"
@@ -99,7 +99,7 @@ Scenario: User has an option to limit results to VA facilities and all locations
 
     Scenario: User has an option to limit results to VA facilities and country, state and city
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Location" form section is displayed
         When user toggles "Limit results to Veterans Affairs facilities"
         Then "Limit results to Veterans Affairs facilities" toggle is switched to "Yes"

--- a/cypress/e2e/AdvancedSearchPage/TrialIdSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/TrialIdSection.feature
@@ -2,14 +2,14 @@ Feature: Advanced Clinical Trials Search Trial ID Section
 
 	Scenario: User has an option to narrow down search criteria by trial id
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial ID" form section is displayed
 		And help icon is displayed in "TrialID" section with href "/research/participate/clinical-trials-search/help#trialid"
 		And helper text "Separate multiple IDs with commas." is displayed
 
 	Scenario: User enters trial id and searches
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial ID" form section is displayed
 		When user types "NCI-2018-02825" in "TrialID" field
 		When user clicks on "Find Trials" button
@@ -26,7 +26,7 @@ Feature: Advanced Clinical Trials Search Trial ID Section
 
 	Scenario: User is able to search for multiple IDs and is able to modify search afterwards
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial ID" form section is displayed
 		When user types "NCI-2018-02825,NCI-2015-00054,NCI-2014-01507" in "TrialID" field
 		When user clicks on "Find Trials" button
@@ -81,7 +81,7 @@ Feature: Advanced Clinical Trials Search Trial ID Section
 
 	Scenario: User is searching for a trial id that does not exist will see no results found and is able to modify search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial ID" form section is displayed
 		When user types "NCI-2018-1234" in "TrialID" field
 		When user clicks on "Find Trials" button
@@ -107,7 +107,7 @@ Feature: Advanced Clinical Trials Search Trial ID Section
 
 	Scenario: User enters partial trial id and searches
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial ID" form section is displayed
 		When user types "ecog" in "TrialID" field
 		When user clicks on "Find Trials" button

--- a/cypress/e2e/AdvancedSearchPage/TrialInvestigatorsSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/TrialInvestigatorsSection.feature
@@ -2,7 +2,7 @@ Feature: Advanced Clinical Trials Search Trial Investigators Section
 
 	Scenario: User has an option to narrow down search criteria by Trial Investigators
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial Investigators" form section is displayed
 		And help icon is displayed in "TrialInvestigators" section with href "/research/participate/clinical-trials-search/help#trialinvestigators"
 		And "TrialInvestigator" input field has a placeholder "Investigator name"
@@ -10,7 +10,7 @@ Feature: Advanced Clinical Trials Search Trial Investigators Section
 
 	Scenario: User has an option to search by Trial Investigators using autosuggest
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial Investigators" form section is displayed
 		When user clicks on "TrialInvestigator" field
 		Then autocomplete dropdown is displayed
@@ -31,7 +31,7 @@ Feature: Advanced Clinical Trials Search Trial Investigators Section
 
 	Scenario: User searches for investigators that does not exist
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial Investigators" form section is displayed
 		When user clicks on "TrialInvestigator" field
 		Then autocomplete dropdown is displayed with "Please enter 3 or more characters" text
@@ -63,7 +63,7 @@ Feature: Advanced Clinical Trials Search Trial Investigators Section
 
 	Scenario: User is able to search for a specific investigators and refine search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Trial Investigators" form section is displayed
 		And user types "grace sm" in "TrialInvestigator" field
 		And user selects "Grace Smith" from dropdown

--- a/cypress/e2e/AdvancedSearchPage/TrialPhaseSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/TrialPhaseSection.feature
@@ -2,7 +2,7 @@ Feature: Advanced Clinical Trials Search Trial Phase Section
 
     Scenario: User has an option to narrow down search criteria by trial phase
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Trial Phase" form section is displayed
         And help icon is displayed in "Trial Phase" section with href "/research/participate/clinical-trials-search/help#trialphase"
         And info text "Select the trial phases for your search. You may check more than one box or select \"All\"." is displayed in the section body
@@ -16,7 +16,7 @@ Feature: Advanced Clinical Trials Search Trial Phase Section
 
     Scenario: User has an option to narrow down search criteria by selecting trial phase
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Trial Phase" form section is displayed
         And user checks "Phase I" checkbox
         Then the checkbox "Phase I" is checked

--- a/cypress/e2e/AdvancedSearchPage/TrialTypeSection.feature
+++ b/cypress/e2e/AdvancedSearchPage/TrialTypeSection.feature
@@ -2,7 +2,7 @@ Feature: Advanced Clinical Trials Search Trial Type Section
 
     Scenario: User has an option to narrow down search criteria by selecting all trial types
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         And "Trial Type" form section is displayed
         And help icon is displayed in "Trial Type" section with href "/research/participate/clinical-trials-search/help#trialtype"
         And info text "Select the type of trial for your search. You may check more than one box or select \"All\". You may choose to limit results to trials accepting healthy volunteers." is displayed in the "Trial Type" section body
@@ -38,7 +38,7 @@ Feature: Advanced Clinical Trials Search Trial Type Section
 
     Scenario: User has an option to narrow down search criteria by healthy volunteers and selected trial types and then refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         When user toggles "Healthy Volunteers"
         And "Healthy Volunteers" toggle is switched to "Yes"
         And user selects "Treatment" checkbox
@@ -78,7 +78,7 @@ Feature: Advanced Clinical Trials Search Trial Type Section
 
     Scenario: User has an option to search by healthy volunteers and all trial types and refine search
         Given the user navigates to "/advanced"
-        Then the page title is "Find NCI-Supported Clinical Trials"
+        Then the page title is "Find Cancer Clinical Trials"
         When user toggles "Healthy Volunteers"
         Then "Healthy Volunteers" toggle is switched to "Yes"
         And "All" checkbox is checked

--- a/cypress/e2e/Analytics/AdvancedTrialSearchPage.feature
+++ b/cypress/e2e/Analytics/AdvancedTrialSearchPage.feature
@@ -1,7 +1,7 @@
 Feature: Clinical Trials Search Page - Advanced
 
 	Scenario: Page Load Analytics fires when a user views an Advanced Search form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -9,15 +9,15 @@ Feature: Clinical Trials Search Page - Advanced
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		Then there should be an analytics event with the following details
 			| key                                  | value                                                      |
 			| type                                 | PageLoad                                                   |
 			| event                                | ClinicalTrialsSearchApp:Load:AdvancedSearch                |
 			| page.name                            | www.cancer.gov/advanced                                    |
-			| page.title                           | Find NCI-Supported Clinical Trials - Advanced Search       |
-			| page.metaTitle                       | Find NCI-Supported Clinical Trials - Advanced Search - NCI |
+			| page.title                           | Find Cancer Clinical Trials - Advanced Search       |
+			| page.metaTitle                       | Find Cancer Clinical Trials - Advanced Search - NCI |
 			| page.language                        | english                                                    |
 			| page.type                            | nciAppModulePage                                           |
 			| page.channel                         | About Cancer                                               |
@@ -27,7 +27,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.formType      | advanced                                                   |
 
 	Scenario: Click event fires when user starts typing in Primary Cancer Type/Condition field
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -35,7 +35,7 @@ Feature: Clinical Trials Search Page - Advanced
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user clicks on "All" button
 		And user types "c" in "CancerTypeCondition" field
@@ -51,7 +51,7 @@ Feature: Clinical Trials Search Page - Advanced
 
 
 	Scenario: Click event fires when user clicks on search result item from Advanced Search results page
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -73,7 +73,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| data.resultsPosition | (int)1                                        |
 
 	Scenario: Page Load event fires when user fills out Cancer Type Condition fields on Advanced Form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -109,7 +109,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                      |
 
 	Scenario: Page Load event fires when user fills out Age, Keyword phrases and location at NIH only
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -145,7 +145,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                      |
 
 	Scenario: Page Load event fires when user fills out Location fields with VaOnly toggled and specified state
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -182,7 +182,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                       |
 
 	Scenario: Page Load event fires when user fills out Location hospital field and searches
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -217,7 +217,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.helperFormData.ttDrugTreat     | all\|none\|none                                                 |
 
 	Scenario: Page Load event fires when user fills out Trial Type field and searches
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -253,7 +253,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| page.additionalDetails.helperFormData.ttDrugTreat     | tre,sup,dia,bas,pre,hea,scr,oth\|none\|none\|hv                                                             |
 
 	Scenario: Page Load event fires when user fills out Drug Treatment and Trial Phase fields and searches
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -291,7 +291,7 @@ Feature: Clinical Trials Search Page - Advanced
 
 
 	Scenario: Page Load event fires when user fills out Trial Id, Lead organization and investigator fields and searches
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -329,7 +329,7 @@ Feature: Clinical Trials Search Page - Advanced
 
 
 	Scenario: Click event fires when user clicks on Modify Search criteria button
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -352,7 +352,7 @@ Feature: Clinical Trials Search Page - Advanced
 
 
 	Scenario: Click event fires when user selects all on page and click print
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -379,7 +379,7 @@ Feature: Clinical Trials Search Page - Advanced
 	#### Needs scroll to be implemented
 
 	# Scenario: Click event fires when user clicks on Find Trials button from Advanced Search form
-	#   Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+	#   Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 	#   And "baseHost" is set to "http://localhost:3000"
 	#   And "canonicalHost" is set to "https://www.cancer.gov"
 	#   And "siteName" is set to "NCI"
@@ -387,7 +387,7 @@ Feature: Clinical Trials Search Page - Advanced
 	#   And "analyticsPublishedDate" is set to "02/02/2011"
 	#   And "analyticsName" is set to "Clinical Trials"
 	#   When the user navigates to "/advanced"
-	#   Then the page title is "Find NCI-Supported Clinical Trials"
+	#   Then the page title is "Find Cancer Clinical Trials"
 	#   And browser waits
 	#   When user scrolls to middle of screen
 	#   And user clicks on "Find Trials" button
@@ -402,7 +402,7 @@ Feature: Clinical Trials Search Page - Advanced
 
 
 	Scenario: Click event fires when user clicks on Clear Form button
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -410,7 +410,7 @@ Feature: Clinical Trials Search Page - Advanced
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user clears form
 		Then there should be preserved analytics event with the following details
@@ -422,7 +422,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| data.formType      | advanced                                |
 
 	Scenario: Click event fires when user tries to print without selecting any trial
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -444,7 +444,7 @@ Feature: Clinical Trials Search Page - Advanced
 			| data.errorReason   | noneselected                                     |
 
 	Scenario: Click event fires when user reaches max number of selected trials
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"

--- a/cypress/e2e/Analytics/BasicTrialSearchPage.feature
+++ b/cypress/e2e/Analytics/BasicTrialSearchPage.feature
@@ -3,7 +3,7 @@ Feature: Clinical Trials Search Page - Basic
 	############Analytics################
 
 	Scenario: Page Load Analytics fires when a user views a Basic Search form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -11,15 +11,15 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		Then there should be an analytics event with the following details
 			| key                                  | value                                    |
 			| type                                 | PageLoad                                 |
 			| event                                | ClinicalTrialsSearchApp:Load:BasicSearch |
 			| page.name                            | www.cancer.gov/                          |
-			| page.title                           | Find NCI-Supported Clinical Trials       |
-			| page.metaTitle                       | Find NCI-Supported Clinical Trials - NCI |
+			| page.title                           | Find Cancer Clinical Trials       |
+			| page.metaTitle                       | Find Cancer Clinical Trials - NCI |
 			| page.language                        | english                                  |
 			| page.type                            | nciAppModulePage                         |
 			| page.channel                         | About Cancer                             |
@@ -30,7 +30,7 @@ Feature: Clinical Trials Search Page - Basic
 
 
 	Scenario: Click event fires when user clicks on Cancer Type/Keyword field
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -38,7 +38,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user clicks on "CancerTypeKeyword" field
 		Then there should be an analytics event with the following details
@@ -51,7 +51,7 @@ Feature: Clinical Trials Search Page - Basic
 			| data.formType      | basic                                              |
 
 	Scenario: Click event fires when user inputs invalid age and submits form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -59,7 +59,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user types "234" in "Age" field
 		And user clicks on "Find Trials" button
@@ -74,7 +74,7 @@ Feature: Clinical Trials Search Page - Basic
 			| data.fieldError    | a                                                 |
 
 	Scenario: Click event fires when user inputs invalid ZipCode and tries to submit search
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -82,7 +82,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user types "999g9" in "Zipcode" field
 		And user clicks on "Find Trials" button
@@ -97,7 +97,7 @@ Feature: Clinical Trials Search Page - Basic
 			| data.fieldError    | z                                                 |
 
 	Scenario: Click event fires when user inputs invalid age and invalid zipcode ans submits form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -105,7 +105,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user types "234" in "Age" field
 		And user types "999g9" in "Zipcode" field
@@ -121,7 +121,7 @@ Feature: Clinical Trials Search Page - Basic
 			| data.fieldError    | a,z                                               |
 
 	Scenario: Click event fires when user clicks on Find Trials button
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -129,7 +129,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user clicks on "Find Trials" button
 		Then there should be an analytics event with the following details
@@ -143,7 +143,7 @@ Feature: Clinical Trials Search Page - Basic
 
 
 	Scenario: Click event fires when user clicks on Start Over link while on Basic Form Results page
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -164,7 +164,7 @@ Feature: Clinical Trials Search Page - Basic
 			| data.source        | start_over_link                                  |
 
 	Scenario: Page Load event fires when user fills out fields on Basic Form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -198,7 +198,7 @@ Feature: Clinical Trials Search Page - Basic
 			| page.additionalDetails.helperFormData.loc             | all                                  |
 
 	Scenario: Click event fires when user clicks on search result item from Basic Search results page
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -221,7 +221,7 @@ Feature: Clinical Trials Search Page - Basic
 
 	#Below scenario should be just navigating to search results page, but zip code look up times out with 500 status code
 	Scenario: Page Load event fires when user fills out zipcode field on Basic Form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -229,7 +229,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsPublishedDate" is set to "02/02/2011"
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user types "22182" in "Zipcode" field
 		And user clicks on "Find Trials" button
@@ -260,7 +260,7 @@ Feature: Clinical Trials Search Page - Basic
 
 
 	Scenario: Click event fires when user abandons the form
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -269,7 +269,7 @@ Feature: Clinical Trials Search Page - Basic
 		And "analyticsName" is set to "Clinical Trials"
 		When the user navigates to "/advanced"
 		When the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And browser waits
 		When user types "22" in "Age" field
 		And user navigates back to the previous page

--- a/cypress/e2e/Analytics/TrialDescriptionPage.feature
+++ b/cypress/e2e/Analytics/TrialDescriptionPage.feature
@@ -3,7 +3,7 @@ Feature: Clinical Trial Description Page
 	############Analytics################
 
 	Scenario: Page Load event fires when user navigates to trial description page
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -29,7 +29,7 @@ Feature: Clinical Trial Description Page
 			| page.additionalDetails.nctId         | NCT02750826                                                                                                      |
 
 	Scenario: Click event fires when user clicks on Print link on trial description page
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"
@@ -51,7 +51,7 @@ Feature: Clinical Trial Description Page
 
 ## below scenario is timing out due to Cypress waiting on page load
 # Scenario: Click event fires when user clicks on Email link on trial description page
-#   Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+#   Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 #   And "baseHost" is set to "http://localhost:3000"
 #   And "canonicalHost" is set to "https://www.cancer.gov"
 #   And "siteName" is set to "NCI"

--- a/cypress/e2e/BasicSearchPage/BasicSearchPage.feature
+++ b/cypress/e2e/BasicSearchPage/BasicSearchPage.feature
@@ -3,9 +3,8 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario Outline: When user visits Basic Search page, all page items are present in different breakpoints
 		Given screen breakpoint is set to "<breakpoint>"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the text "NCI-supported clinical trials are those sponsored or otherwise financially supported by NCI. See our guide, Steps to Find a Clinical Trial, to learn about options for finding trials not included in NCI's collection." appears below the title
-		And "Steps to Find a Clinical Trial" link has a href "https://www.cancer.gov/research/participate/clinical-trials-search/steps"
+		Then the page title is "Find Cancer Clinical Trials"
+		And the text "Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, Steps to Find a Clinical Trial, to learn about options for finding trials not included in NCI's collection." appears below the title
 		And Search tip icon is displayed and text "Search Tip: For more search options, use our advanced search." appears
 		And "advanced search" link has a href "/advanced"
 		And the following delighters are displayed
@@ -23,7 +22,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario Outline: all form fields are displayed with its components
 		Given screen breakpoint is set to "<breakpoint>"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Cancer Type/Keyword" form section is displayed
 		And help icon is displayed in "Cancer Type/Keyword" section with href "/research/participate/clinical-trials-search/help#how-to-find-clinical-trials-using-the-basic-search-form"
 		And "Cancer Type/Keyword" input field has a placeholder "Start typing to select a cancer type or keyword"
@@ -47,7 +46,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: User is able to search for and use autosuggested items for cancer type/keyword
 		Given screen breakpoint is set to "desktop"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Cancer Type/Keyword" input field has a placeholder "Start typing to select a cancer type or keyword"
 		When user clicks on "Cancer Type/Keyword" field
 		Then autocomplete dropdown is displayed
@@ -87,7 +86,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: Negative: user is searching for a keyword that does not exist
 		Given screen breakpoint is set to "tablet"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Cancer Type/Keyword" input field has a placeholder "Start typing to select a cancer type or keyword"
 		When user clicks on "Cancer Type/Keyword" field
 		Then autocomplete dropdown is displayed
@@ -104,7 +103,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: User is able to search for a specific age
 		Given screen breakpoint is set to "mobile"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Age" form section is displayed
 		When user types "40" in "Age" field
 		And user clicks on "Find Trials" button
@@ -137,7 +136,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 
 	Scenario: Negative: User is not able to search for age out of boundaries
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Age" form section is displayed
 		When user types "0" in "Age" field
 		Then alert "Please enter a number between 1 and 120." is displayed in "Age" section
@@ -151,7 +150,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: User is able to search for a specific zip code
 		Given screen breakpoint is set to "tablet"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "U.S. ZIP Code" form section is displayed
 		When user types "22182" in "U.S. ZIP Code" field
 		And user clicks on "Find Trials" button
@@ -184,7 +183,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 
 	Scenario: Negative: User is not able to search for an incorrect zip code
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "U.S. ZIP Code" form section is displayed
 		When user types "999g9" in "U.S. ZIP Code" field
 		Then alert "Please enter a valid 5 digit U.S. ZIP code" is displayed in "U.S. ZIP Code" section
@@ -197,7 +196,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 	Scenario: User is able to search for a trials using age and keyword and then refine search
 		Given screen breakpoint is set to "desktop"
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		When user types "breast cancer" in "Cancer Type/Keyword" field
 		And user selects "Breast Cancer" from dropdown
 		And user types "40" in "Age" field
@@ -235,7 +234,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 
 	Scenario: User is able to search for all trials without specifying any criteria
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And user clicks on "Find Trials" button
 	  And browser waits
 		Then the search is executed and results page is displayed
@@ -281,7 +280,7 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 
 	Scenario: User is able to search for everything and modify search
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		When user types "30" in "Age" field
 		When user types "22182" in "U.S. ZIP Code" field
 		When user types "aids" in "Cancer Type/Keyword" field
@@ -325,22 +324,22 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 
 	Scenario: As a search engine I want to have access to the meta data on a basic search page
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
-		And the title tag should be "Find NCI-Supported Clinical Trials - NCI"
+		Then the page title is "Find Cancer Clinical Trials"
+		And the title tag should be "Find Cancer Clinical Trials - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                       |
-			| description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one. |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                       |
-			| og:title       | Find NCI-Supported Clinical Trials                                                                                            |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/                                                         |
-			| og:description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/"
+			| og:title       | Find Cancer Clinical Trials                                                                                            |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/                                                         |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/"
 
 
 	Scenario: As a user, I expect meta data to update accordingly when I search for criteria and modify my search
 		Given the user navigates to "/"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		When user types "30" in "Age" field
 		When user types "22182" in "U.S. ZIP Code" field
 		When user types "aids" in "Cancer Type/Keyword" field
@@ -350,26 +349,26 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                               |
 			| og:title       | Clinical Trials Search Results                                                                        |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=30&loc=1&q=aids&rl=1&z=22182 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                 |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=30&loc=1&q=aids&rl=1&z=22182"
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "40" in "Age" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.|
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.|
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"
 		And user clicks on "Find Trials" button
 		And browser waits
 		Then the search is executed and results page is displayed
@@ -377,13 +376,13 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                      |
 			| og:title       | Clinical Trials Search Results                                                                               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                        |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                        |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100"
 
 
 	Scenario: As a user, I expect meta data to update accordingly when I navigate to search results directly and modify my search
@@ -391,39 +390,39 @@ Feature: As a user, I want to be able to use Basic Search form fields to find cl
 		Then trial info displays "Results 1-10  of 17 for your search "
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                               |
 			| og:title       | Clinical Trials Search Results                                                                        |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=30&loc=1&q=aids&rl=1&z=22182"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=30&loc=1&q=aids&rl=1&z=22182 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                 |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=30&loc=1&q=aids&rl=1&z=22182"
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "40" in "Age" field
 		And browser waits
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.|
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displays "Results 1-10  of 18 for your search "
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                      |
 			| og:title       | Clinical Trials Search Results                                                                               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                        |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                        |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=1&q=aids&rl=2&z=22182&zp=100"
 		And browser waits
 		And the title tag should be "Clinical Trials Search Results - NCI"

--- a/cypress/e2e/SearchResultsPage/GeneralPageComponents.feature
+++ b/cypress/e2e/SearchResultsPage/GeneralPageComponents.feature
@@ -244,7 +244,7 @@ Feature: Clinical Trials Search Results Page Components
 
 	Scenario: As a user, I expect meta data to update accordingly when I search for criteria and modify my search
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Age" form section is displayed
 		When user types "40" in "Age" field
 		And user clicks on "Find Trials" button
@@ -253,39 +253,39 @@ Feature: Clinical Trials Search Results Page Components
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                |
 			| og:title       | Clinical Trials Search Results                                                         |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=0&rl=2 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                  |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=40&loc=0&rl=2"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=0&rl=2 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                  |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=40&loc=0&rl=2"
 		When user clicks on Modify Search Criteria button
 		When user clears "Age" input field
 		And user types "39" in "Age" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.|
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one. |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displayes "Results 1-10  of 6731 for your search "
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                |
 			| og:title       | Clinical Trials Search Results                                                         |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=39&loc=0&rl=2 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                  |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=39&loc=0&rl=2"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=39&loc=0&rl=2 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                  |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=39&loc=0&rl=2"
 
 
 	Scenario: As a user, I expect meta data to update accordingly when I navigate to search results directly and modify my search
@@ -294,39 +294,39 @@ Feature: Clinical Trials Search Results Page Components
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                                                                                                                                                        |
 			| og:title       | Clinical Trials Search Results                                                                                                                                                                                                                                                                 |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lcnty=United%20States&lcty=Atlanta&lo=M%20D%20Anderson%20Cancer%20Center&loc=2&lst=GA&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                                                                                                                                                                                                          |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lcnty=United%20States&lcty=Atlanta&lo=M%20D%20Anderson%20Cancer%20Center&loc=2&lst=GA&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lcnty=United%20States&lcty=Atlanta&lo=M%20D%20Anderson%20Cancer%20Center&loc=2&lst=GA&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                                                                                                                                                                                                          |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lcnty=United%20States&lcty=Atlanta&lo=M%20D%20Anderson%20Cancer%20Center&loc=2&lst=GA&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment"
 		When user clicks on Modify Search Criteria button
 		And user selects "Zip" radio button
 		And user types "30309" in "Zipcode" field
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
-			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| name        | content                                                                                                                       |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one. |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one. |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"
 		And user clicks on "Find Trials" button
 		Then the search is executed and results page is displayed
 		And trial info displayes "Results 1-1  of 1 for your search "
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                                                                                                                             |
 			| og:title       | Clinical Trials Search Results                                                                                                                                                                                                                                      |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lo=M%20D%20Anderson%20Cancer%20Center&loc=1&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment&z=30309&zp=100 |
-			| og:description | Find an NCI-supported clinical trial - Search results                                                                                                                                                                                                               |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lo=M%20D%20Anderson%20Cancer%20Center&loc=1&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment&z=30309&zp=100"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lo=M%20D%20Anderson%20Cancer%20Center&loc=1&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment&z=30309&zp=100 |
+			| og:description | Find Cancer Clinical Trials - Search Results                                                                                                                                                                                                               |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?a=50&d=C798&i=C15313&in=Benjamin%20David%20Smith&lo=M%20D%20Anderson%20Cancer%20Center&loc=1&q=Breast&rl=2&st=C2924&stg=C94774&t=C4872&tid=NCI-2017-00476&tp=iii&tt=treatment&z=30309&zp=100"
 
 
 	Scenario Outline: As a user, I expect the sex-based eligibility display to function regardless of the API's data structure.

--- a/cypress/e2e/SearchResultsPage/PrintFunctionality.feature
+++ b/cypress/e2e/SearchResultsPage/PrintFunctionality.feature
@@ -79,7 +79,7 @@ Feature: As a user I want to be able to print trial search results
 
 
 	Scenario: as a user, I will see a print modal error if I try to select and print more trials than allowed
-		Given "ctsTitle" is set to "Find NCI-Supported Clinical Trials"
+		Given "ctsTitle" is set to "Find Cancer Clinical Trials"
 		And "baseHost" is set to "http://localhost:3000"
 		And "canonicalHost" is set to "https://www.cancer.gov"
 		And "siteName" is set to "NCI"

--- a/cypress/e2e/TrialDescriptionPage/Accordion.feature
+++ b/cypress/e2e/TrialDescriptionPage/Accordion.feature
@@ -53,7 +53,7 @@ Feature: As a user, I want to be able to get even more details about the trial v
       | Primary ID            |
       | Secondary IDs         |
       | ClinicalTrials.gov ID |
-    And "NCT02201992" link has a href "http://clinicaltrials.gov/study/NCT02201992"
+    And "NCT02201992" link has a href "https://www.clinicaltrials.gov/study/NCT02201992"
 
   Scenario: user is able to see trial's location that is near searched zipcode
     Given the user navigates to "/v?id=NCI-2014-01507&loc=1&rl=1&z=22182"
@@ -233,4 +233,3 @@ Feature: As a user, I want to be able to get even more details about the trial v
     And trial description accordion is displayed
     When user clicks on "Locations & Contacts" section of accordion
     Then the location section is empty
-

--- a/cypress/e2e/TrialDescriptionPage/TrialDescriptionPage.feature
+++ b/cypress/e2e/TrialDescriptionPage/TrialDescriptionPage.feature
@@ -30,9 +30,9 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                        |
 			| og:title       | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2015-01918                                       |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2015-01918                                       |
 			| og:description | Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence - NCT02750826 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2015-01918"
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2015-01918"
 
 
 	Scenario Outline: User is able to see the trial description on mobile and tablet by directly navigating to trial url
@@ -66,9 +66,9 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                                              |
 			| og:title       | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial)               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2014-01507                                                                                             |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2014-01507                                                                                             |
 			| og:description | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial) - NCT02201992 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2014-01507"
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2014-01507"
 		Examples:
 			| breakpoint |
 			| mobile     |
@@ -101,9 +101,9 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                                              |
 			| og:title       | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial)               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2014-01507                                                                                             |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2014-01507                                                                                             |
 			| og:description | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial) - NCT02201992 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI-2014-01507"
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI-2014-01507"
 
 	Scenario: User is able to navigate to trial description page directly without being on a search using NCT id
 		Given screen breakpoint is set to "mobile"
@@ -132,9 +132,9 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                                              |
 			| og:title       | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial)               |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCT02201992                                                                                                |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCT02201992                                                                                                |
 			| og:description | Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial) - NCT02201992 |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCT02201992"
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCT02201992"
 
 
 	Scenario: User is able to navigate back to the search results page
@@ -144,13 +144,13 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                           |
 			| og:title       | Clinical Trials Search Results                                                    |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?loc=0&rl=2 |
-			| og:description | Find an NCI-supported clinical trial - Search results                             |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?loc=0&rl=2"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?loc=0&rl=2 |
+			| og:description | Find Cancer Clinical Trials - Search Results                             |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?loc=0&rl=2"
 		When user clicks on 1 trial result
 		Then the page title is "Weight Loss Interventions in Treating Overweight and Obese Women with a Higher Risk for Breast Cancer Recurrence"
 		And the url query has the following corresponding code
@@ -169,13 +169,13 @@ Feature:  As a user, I want to be able to view trial description page with all i
 		And the title tag should be "Clinical Trials Search Results - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                               |
-			| description | Find an NCI-supported clinical trial - Search results |
+			| description | Find Cancer Clinical Trials - Search Results |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                           |
 			| og:title       | Clinical Trials Search Results                                                    |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?loc=0&rl=2 |
-			| og:description | Find an NCI-supported clinical trial - Search results                             |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?loc=0&rl=2"
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/r?loc=0&rl=2 |
+			| og:description | Find Cancer Clinical Trials - Search Results                             |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/r?loc=0&rl=2"
 
 	Scenario: User is able to start over his/her search on an advanced search form page
 		Given the user navigates to "/v?a=40&id=NCI-2014-01507&loc=0&rl=2"
@@ -186,18 +186,18 @@ Feature:  As a user, I want to be able to view trial description page with all i
 			| Age      | 40        |
 		And "Start Over" link has a href "/advanced"
 		When user clicks on "Start Over" link
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And the url is "/advanced"
-		And the title tag should be "Find NCI-Supported Clinical Trials - Advanced Search - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - Advanced Search - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                                                  |
-			| description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                                                  |
-			| og:title       | Find NCI-Supported Clinical Trials - Advanced Search                                                                                                     |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced                                                                            |
-			| og:description | Use our advanced search to find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/advanced"
+			| og:title       | Find Cancer Clinical Trials - Advanced Search                                                                                                     |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/advanced                                                                            |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/advanced"
 
 	Scenario: User is able to start over his/her search on basic search form page
 		Given the user navigates to "//v?a=40&id=NCI-2014-01507&loc=0&rl=1"
@@ -208,18 +208,18 @@ Feature:  As a user, I want to be able to view trial description page with all i
 			| Age      | 40        |
 		And "Start Over" link has a href "/"
 		When user clicks on "Start Over" link
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And the url is "/"
-		And the title tag should be "Find NCI-Supported Clinical Trials - NCI"
+		And the title tag should be "Find Cancer Clinical Trials - NCI"
 		And the page contains meta tags with the following names
 			| name        | content                                                                                                                       |
-			| description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
+			| description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
 		And the page contains meta tags with the following properties
 			| property       | content                                                                                                                       |
-			| og:title       | Find NCI-Supported Clinical Trials                                                                                            |
-			| og:url         | https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/                                                         |
-			| og:description | Find an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one. |
-		And there is a canonical link with the href "https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/"
+			| og:title       | Find Cancer Clinical Trials                                                                                            |
+			| og:url         | https://www.cancer.gov/research/participate/clinical-trials-search/                                                         |
+			| og:description | Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.                                                |
+		And there is a canonical link with the href "https://www.cancer.gov/research/participate/clinical-trials-search/"
 
 	Scenario: User is able to to print trial info
 		Given screen breakpoint is set to "desktop"
@@ -234,7 +234,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 
 		Scenario: User clicks on modify search, and is presented search criteria
 		Given the user navigates to "/advanced"
-		Then the page title is "Find NCI-Supported Clinical Trials"
+		Then the page title is "Find Cancer Clinical Trials"
 		And "Drug/Treatment" form section is displayed
 		When user clicks on "Drug" field
 		And user types "ibup" in "Drug" field
@@ -254,7 +254,7 @@ Feature:  As a user, I want to be able to view trial description page with all i
 	#this should be enabled by https://github.com/NCIOCPL/clinical-trials-search-app/issues/297
 	# Scenario: User is able to to email trial info
 	# Given screen breakpoint is set to "desktop"
-	# Given the user navigates to "/about-cancer/treatment/clinical-trials/search/v?a=40&id=NCI-2014-01507&loc=0&rl=1"
+	# Given the user navigates to "/research/participate/clinical-trials-search/v?a=40&id=NCI-2014-01507&loc=0&rl=1"
 	# Then the page title is "Crizotinib in Treating Patients with Stage IB-IIIA Non-small Cell Lung Cancer That Has Been Removed by Surgery and ALK Fusion Mutations (An ALCHEMIST Treatment Trial)"
 	# And "This clinical trial matches:" appears below the title
 	# And the criteria table displays the following

--- a/cypress/e2e/common/beforeEach.js
+++ b/cypress/e2e/common/beforeEach.js
@@ -14,7 +14,7 @@ beforeEach(() => {
 			canonicalHost: 'https://www.cancer.gov',
 			ctsApiEndpointV1: '/v1',
 			ctsApiEndpointV2: '/cts/mock-api/v2',
-			ctsTitle: 'Find NCI-Supported Clinical Trials',
+			ctsTitle: 'Find Cancer Clinical Trials',
 			printApiBase: '/mock-api/cts-print',
 			language: 'en',
 			rootId: 'NCI-CTS-root',

--- a/public/index.html
+++ b/public/index.html
@@ -7,7 +7,7 @@
     <link rel="stylesheet" href="%PUBLIC_URL%/index.css" />
     <link rel="stylesheet" href="%PUBLIC_URL%/__nci-dev__common.css" />
     <title>
-      Find NCI-Supported Clinical Trials - NCI
+      Find Cancer Clinical Trials - NCI
     </title>
     <script type="text/javascript">
       // Only setup the handler if this is not running under cypress.
@@ -76,7 +76,18 @@
           services: {},
           siteName: 'NCI',
           useSessionStorage: true,
-          zipConversionEndpoint: '/cts_api/zip_code_lookup'
+          zipConversionEndpoint: '/cts_api/zip_code_lookup',
+          pageTitle: 'Find Cancer Clinical Trials',
+          browserTitle: 'Find Cancer Clinical Trials',
+          basicSearchPageTitle: 'Find Cancer Clinical Trials',
+          advancedSearchPageTitle: 'Find Cancer Clinical Trials - Advanced Search',
+          basicSearchMetaDescription: 'Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.',
+          advancedSearchMetaDescription: 'Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.',
+          basicSearchIntroText: 'Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, <a href="/steps">Steps to Find a Clinical Trial</a>, to learn about options for finding trials not included in NCI\'s collection.',
+          advancedSearchIntroText: 'Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, <a href="/steps">Steps to Find a Clinical Trial</a>, to learn about options for finding trials not included in NCI\'s collection.',
+          resultsPageTitle: 'Clinical Trials Search Results',
+          resultsPageMetaDescription: 'Find Cancer Clinical Trials - Search Results',
+          breadcrumbText: 'Find Cancer Clinical Trials'
         },
       ];
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,21 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+// Process config text to convert Unicode escape sequences and fix double-escaped HTML entities
+const processConfigText = (config) => {
+	const processed = { ...config };
+	// Process any string values that might contain Unicode escapes or double-escaped entities
+	Object.keys(processed).forEach((key) => {
+		if (typeof processed[key] === 'string') {
+			// Convert Unicode escape sequences back to actual characters
+			processed[key] = processed[key].replace(/\\u2014/g, '—');
+			// Fix double-escaped HTML entities (e.g., &amp;mdash; -> &mdash;)
+			processed[key] = processed[key].replace(/&amp;mdash;/g, '&mdash;');
+		}
+	});
+	return processed;
+};
+
 // Redux
 import { Provider } from 'react-redux';
 import { createStore, combineReducers, applyMiddleware } from 'redux';
@@ -44,7 +59,7 @@ const initialize = ({
 	basePath = '/',
 	canonicalHost = 'https://www.cancer.gov',
 	ctsApiEndpointV2,
-	ctsTitle = 'Find NCI-Supported Clinical Trials',
+	ctsTitle = 'Find Cancer Clinical Trials',
 	initErrorsList = [],
 	language = 'en',
 	printApiBase = 'https://www.cancer.gov/CTS.Print',
@@ -57,9 +72,16 @@ const initialize = ({
 	siteName = 'NCI',
 	useSessionStorage = true,
 	zipConversionEndpoint = '/cts_api/zip_code_lookup',
-	// These have been added in to support integration testing.
-	// This should default to being the hardcoded default.
-	// (Which should not be the proxy...)
+	pageTitle = 'Find Cancer Clinical Trials',
+	browserTitle = 'Find Cancer Clinical Trials',
+	basicSearchPageTitle = 'Find Cancer Clinical Trials',
+	advancedSearchPageTitle = 'Find Cancer Clinical Trials - Advanced Search',
+	basicSearchMetaDescription = 'Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.',
+	advancedSearchMetaDescription = 'Find cancer clinical trials—and learn how to locate other research studies—that may be right for you or a loved one.',
+	basicSearchIntroText = 'Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, <a href="/steps">Steps to Find a Clinical Trial</a>, to learn about options for finding trials not included in NCI\'s collection.',
+	advancedSearchIntroText = 'Search for NCI-funded clinical trials near you, across the United States, and internationally, in addition to trials at NCI-Designated Cancer Centers supported by other organizations. See our guide, <a href="/steps">Steps to Find a Clinical Trial</a>, to learn about options for finding trials not included in NCI\'s collection.',
+	resultsPageTitle = 'Clinical Trials Search Results',
+	resultsPageMetaDescription = 'Find Cancer Clinical Trials - Search Results',
 } = {}) => {
 	const appRootDOMNode = document.getElementById(rootId);
 	const isRehydrating = appRootDOMNode.getAttribute('data-isRehydrating');
@@ -97,6 +119,16 @@ const initialize = ({
 		siteName,
 		useSessionStorage,
 		zipConversionEndpoint,
+		pageTitle,
+		browserTitle,
+		basicSearchPageTitle,
+		advancedSearchPageTitle,
+		basicSearchMetaDescription,
+		advancedSearchMetaDescription,
+		basicSearchIntroText,
+		advancedSearchIntroText,
+		resultsPageTitle,
+		resultsPageMetaDescription,
 	};
 
 	if (process.env.NODE_ENV !== 'development' && useSessionStorage === true) {
@@ -181,7 +213,8 @@ export default initialize;
 window.CTSApp = initialize;
 
 // The following lets us run the app in dev not in situ as would normally be the case.
-const appParams = window.APP_PARAMS || {};
+const rawAppParams = window.APP_PARAMS || {};
+const appParams = processConfigText(rawAppParams);
 const integrationTestOverrides = window.INT_TEST_APP_PARAMS || {};
 if (process.env.NODE_ENV !== 'production') {
 	// This is LOCAL DEV

--- a/src/utilities/__tests__/formDataConverter.js
+++ b/src/utilities/__tests__/formDataConverter.js
@@ -225,7 +225,7 @@ const TEST_CASES = [
 		},
 	],
 
-	//https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?t=C3167&st=C8644%7CC9143%7CC9140&stg=C7883%7CC7784&fin=C3586&a=35&q=cancer&va=1&loc=0&hv=1&tt=treatment&tt=supportive_care&d=C1647&i=C65008&tp=I&tp=II&tid=nci&in=smith&lo=mayo&rl=2
+	//https://www.cancer.gov/research/participate/clinical-trials-search/r?t=C3167&st=C8644%7CC9143%7CC9140&stg=C7883%7CC7784&fin=C3586&a=35&q=cancer&va=1&loc=0&hv=1&tt=treatment&tt=supportive_care&d=C1647&i=C65008&tp=I&tp=II&tid=nci&in=smith&lo=mayo&rl=2
 	[
 		'adv - minimum all non-location fields used',
 		{
@@ -258,7 +258,7 @@ const TEST_CASES = [
 			tpTidInvLo: 'i,ii|single:nci|smith|mayo',
 		},
 	],
-	//https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?t=C4872&st=C40367&st=C162648&st=C66719&st=C161830&st=C53558&st=C8287&st=C5214&st=C4017&st=C2924&st=C2918&st=C53556&st=C9245&stg=C139556%7CC139535%7CC88375&stg=C7768%7CC139538%7CC139569&stg=C139582%7CC139541%7CC88376%7CC7769&stg=C139542%7CC139583%7CC7770&stg=C139584%7CC139543%7CC7782&stg=C139545%7CC139587%7CC3995&fin=C150629&fin=C150630&fin=C68749&fin=C68748&fin=C118311&fin=C162184&fin=C162183&a=&q=&loc=0&tt=treatment&tt=supportive_care&tt=diagnostic&tt=basic_science&tt=prevention&tt=health_services_research&tt=screening&d=C855&d=C2039&d=C308%7CC15262&d=C1687&d=C307&d=C143250&i=C15722&i=C15329&i=C94626&i=C15751&i=C15358&i=C15313&tp=I&tp=II&tp=III&tp=IV&tid=nci%2Cnct%2Ccct%2Cdcp%2Cswog%2Cctep&in=&lo=&rl=2
+	//https://www.cancer.gov/research/participate/clinical-trials-search/r?t=C4872&st=C40367&st=C162648&st=C66719&st=C161830&st=C53558&st=C8287&st=C5214&st=C4017&st=C2924&st=C2918&st=C53556&st=C9245&stg=C139556%7CC139535%7CC88375&stg=C7768%7CC139538%7CC139569&stg=C139582%7CC139541%7CC88376%7CC7769&stg=C139542%7CC139583%7CC7770&stg=C139584%7CC139543%7CC7782&stg=C139545%7CC139587%7CC3995&fin=C150629&fin=C150630&fin=C68749&fin=C68748&fin=C118311&fin=C162184&fin=C162183&a=&q=&loc=0&tt=treatment&tt=supportive_care&tt=diagnostic&tt=basic_science&tt=prevention&tt=health_services_research&tt=screening&d=C855&d=C2039&d=C308%7CC15262&d=C1687&d=C307&d=C143250&i=C15722&i=C15329&i=C94626&i=C15751&i=C15358&i=C15313&tp=I&tp=II&tp=III&tp=IV&tid=nci%2Cnct%2Ccct%2Cdcp%2Cswog%2Cctep&in=&lo=&rl=2
 	[
 		'adv - Overload a bunch of fields',
 		{

--- a/src/utilities/__tests__/queryStringToSearchCriteria.other.js
+++ b/src/utilities/__tests__/queryStringToSearchCriteria.other.js
@@ -23,7 +23,7 @@ describe('Basic - queryStringToSearchCriteria maps query to form', () => {
 
 	it('R=1 param works for details', async () => {
 		global.jsdom.reconfigure({
-			url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=NCI1234&r=1',
+			url: 'https://www.cancer.gov/research/participate/clinical-trials-search/v?id=NCI1234&r=1',
 		});
 
 		const expected = {
@@ -46,7 +46,7 @@ describe('Basic - queryStringToSearchCriteria maps query to form', () => {
 
 	it('R=1 param fails for results', async () => {
 		global.jsdom.reconfigure({
-			url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?r=1',
+			url: 'https://www.cancer.gov/research/participate/clinical-trials-search/r?r=1',
 		});
 
 		const expected = {
@@ -70,7 +70,7 @@ describe('Basic - queryStringToSearchCriteria maps query to form', () => {
 
 	it('No rl fails for results', async () => {
 		global.jsdom.reconfigure({
-			url: 'https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r',
+			url: 'https://www.cancer.gov/research/participate/clinical-trials-search/r',
 		});
 
 		const expected = {

--- a/src/views/ResultsPage/ResultsPage.jsx
+++ b/src/views/ResultsPage/ResultsPage.jsx
@@ -42,8 +42,11 @@ const ResultsPage = () => {
 			analyticsName,
 			canonicalHost,
 			siteName,
+			searchUrl,
 			whichTrialsUrl,
 			zipConversionEndpoint,
+			resultsPageTitle,
+			resultsPageMetaDescription,
 			apiClients: { clinicalTrialsSearchClientV2 },
 		},
 	] = useAppSettings();
@@ -227,8 +230,8 @@ const ResultsPage = () => {
 					window.location.pathname,
 				// Any additional properties fall into the "page.additionalDetails" bucket
 				// for the event.
-				metaTitle: `Clinical Trials Search Results - ${siteName}`,
-				title: `Clinical Trials Search Results`,
+				metaTitle: `${resultsPageTitle} - ${siteName}`,
+				title: resultsPageTitle,
 				status: 'success',
 				formType: searchCriteriaObject.formType,
 				numResults: trialResults.total,
@@ -610,24 +613,17 @@ const ResultsPage = () => {
 	return (
 		<>
 			<Helmet>
-				<title>Clinical Trials Search Results - {siteName}</title>
-				<meta property="og:title" content="Clinical Trials Search Results" />
-				<link
-					rel="canonical"
-					href={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?${qs}`}
-				/>
+				<title>
+					{resultsPageTitle} - {siteName}
+				</title>
+				<meta property="og:title" content={resultsPageTitle} />
+				<link rel="canonical" href={`${canonicalHost}${searchUrl}/r?${qs}`} />
 				<meta
 					property="og:url"
-					content={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/r?${qs}`}
+					content={`${canonicalHost}${searchUrl}/r?${qs}`}
 				/>
-				<meta
-					name="description"
-					content="Find an NCI-supported clinical trial - Search results"
-				/>
-				<meta
-					property="og:description"
-					content="Find an NCI-supported clinical trial - Search results"
-				/>
+				<meta name="description" content={resultsPageMetaDescription} />
+				<meta property="og:description" content={resultsPageMetaDescription} />
 			</Helmet>
 
 			{error.length && error.filter((err) => err.fieldName === 'zip') ? (
@@ -640,7 +636,7 @@ const ResultsPage = () => {
 						<div className="loader__pageheader"></div>
 					) : (
 						<>
-							<h1>Clinical Trials Search Results</h1>
+							<h1>{resultsPageTitle}</h1>
 
 							<ResultsPageHeader
 								resultsCount={trialResults.total}

--- a/src/views/SearchPage/SearchPage.jsx
+++ b/src/views/SearchPage/SearchPage.jsx
@@ -85,6 +85,15 @@ const SearchPage = ({ formInit = 'basic' }) => {
 			siteName,
 			whatAreTrialsUrl,
 			whichTrialsUrl,
+			searchUrl,
+			advancedSearchUrl,
+			pageTitle,
+			basicSearchPageTitle,
+			advancedSearchPageTitle,
+			basicSearchMetaDescription,
+			advancedSearchMetaDescription,
+			basicSearchIntroText,
+			advancedSearchIntroText,
 		},
 	] = useAppSettings();
 	//this is SCO passed in from search results page
@@ -172,12 +181,15 @@ const SearchPage = ({ formInit = 'basic' }) => {
 				name:
 					canonicalHost.replace(/https:\/\/|http:\/\//, '') +
 					window.location.pathname,
-				title: `Find NCI-Supported Clinical Trials${
-					pageType === 'advanced' ? ' - Advanced Search' : ''
-				}`,
-				metaTitle: `Find NCI-Supported Clinical Trials - ${
-					pageType === 'advanced' ? 'Advanced Search - ' : ''
-				}${siteName}`,
+				title:
+					pageType === 'advanced'
+						? advancedSearchPageTitle
+						: basicSearchPageTitle,
+				metaTitle: `${
+					pageType === 'advanced'
+						? advancedSearchPageTitle
+						: basicSearchPageTitle
+				} - ${siteName}`,
 				// Any additional properties fall into the "page.additionalDetails" bucket
 				// for the event.
 			});
@@ -313,6 +325,13 @@ const SearchPage = ({ formInit = 'basic' }) => {
 		dispatch(clearForm());
 	};
 
+	// Helper function to process intro text template
+	const processIntroText = (template) => {
+		return template
+			.replace('{canonicalHost}', canonicalHost)
+			.replace('{whichTrialsUrl}', whichTrialsUrl);
+	};
+
 	const renderSearchTip = () => (
 		<div className="cts-search-tip">
 			<div className="cts-search-tip__icon">
@@ -342,58 +361,60 @@ const SearchPage = ({ formInit = 'basic' }) => {
 	return (
 		<article className="search-page">
 			<Helmet>
-				<title>
-					{`Find NCI-Supported Clinical Trials - ${
-						pageType === 'advanced' ? 'Advanced Search - ' : ''
-					}${siteName}`}
-				</title>
+				<title>{`${
+					pageType === 'advanced'
+						? advancedSearchPageTitle
+						: basicSearchPageTitle
+				} - ${siteName}`}</title>
 				<link
 					rel="canonical"
-					href={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search${
-						pageType === 'basic'
-							? BasicSearchPagePath()
-							: AdvancedSearchPagePath()
+					href={`${canonicalHost}${
+						pageType === 'basic' ? searchUrl + '/' : advancedSearchUrl
 					}`}
 				/>
 				<meta
 					name="description"
-					content={`${
-						pageType === 'basic' ? 'F' : 'Use our advanced search to f'
-					}ind an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one.`}
+					content={
+						pageType === 'advanced'
+							? advancedSearchMetaDescription
+							: basicSearchMetaDescription
+					}
 				/>
 				<meta
 					property="og:title"
-					content={`Find NCI-Supported Clinical Trials${
-						pageType === 'advanced' ? ' - Advanced Search' : ''
-					}`}
+					content={
+						pageType === 'advanced'
+							? advancedSearchPageTitle
+							: basicSearchPageTitle
+					}
 				/>
 				<meta
 					property="og:url"
-					content={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search${
-						pageType === 'basic'
-							? BasicSearchPagePath()
-							: AdvancedSearchPagePath()
+					content={`${canonicalHost}${
+						pageType === 'basic' ? searchUrl + '/' : advancedSearchUrl
 					}`}
 				/>
 				<meta
 					property="og:description"
-					content={`${
-						pageType === 'basic' ? 'F' : 'Use our advanced search to f'
-					}ind an NCI-supported clinical trial—and learn how to locate other research studies—that may be right for you or a loved one.`}
+					content={
+						pageType === 'advanced'
+							? advancedSearchMetaDescription
+							: basicSearchMetaDescription
+					}
 				/>
 			</Helmet>
 			<div ref={sentinelRef} className="search-page__sentinel"></div>
-			<h1>Find NCI-Supported Clinical Trials</h1>
+			<h1>{pageTitle}</h1>
 			<div className="search-page__header">
-				<p>
-					NCI-supported clinical trials are those sponsored or otherwise
-					financially supported by NCI. See our guide,{' '}
-					<a href={canonicalHost + whichTrialsUrl}>
-						Steps to Find a Clinical Trial
-					</a>
-					, to learn about options for finding trials not included in NCI&apos;s
-					collection.
-				</p>
+				<p
+					dangerouslySetInnerHTML={{
+						__html: processIntroText(
+							pageType === 'advanced'
+								? advancedSearchIntroText
+								: basicSearchIntroText
+						),
+					}}
+				/>
 				{renderSearchTip()}
 			</div>
 

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -69,6 +69,7 @@ const TrialDescriptionPage = () => {
 			analyticsName,
 			canonicalHost,
 			siteName,
+			searchUrl,
 			whichTrialsUrl,
 			zipConversionEndpoint,
 			apiClients: { clinicalTrialsSearchClientV2 },
@@ -558,11 +559,11 @@ const TrialDescriptionPage = () => {
 							/>
 							<link
 								rel="canonical"
-								href={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=${currId}`}
+								href={`${canonicalHost}${searchUrl}/v?id=${currId}`}
 							/>
 							<meta
 								property="og:url"
-								content={`https://www.cancer.gov/about-cancer/treatment/clinical-trials/search/v?id=${currId}`}
+								content={`${canonicalHost}${searchUrl}/v?id=${currId}`}
 							/>
 							<meta name="description" content={trialDescription.brief_title} />
 							<meta
@@ -641,7 +642,6 @@ const TrialDescriptionPage = () => {
 												{renderEligibilityCriteria()}
 											</AccordionItem>
 											<AccordionItem titleCollapsed="Locations &amp; Contacts">
-												`{' '}
 												<>
 													<p>
 														Additional locations may be listed on
@@ -749,7 +749,7 @@ const TrialDescriptionPage = () => {
 															ClinicalTrials.gov ID
 														</strong>
 														<a
-															href={`http://clinicaltrials.gov/study/${trialDescription.nct_id}`}
+															href={`https://www.clinicaltrials.gov/study/${trialDescription.nct_id}`}
 															target="_blank"
 															rel="noopener noreferrer">
 															{trialDescription.nct_id}

--- a/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
+++ b/src/views/TrialDescriptionPage/TrialDescriptionPage.jsx
@@ -641,28 +641,42 @@ const TrialDescriptionPage = () => {
 												{renderEligibilityCriteria()}
 											</AccordionItem>
 											<AccordionItem titleCollapsed="Locations &amp; Contacts">
-												{activeRecruitmentSites &&
-												activeRecruitmentSites.length > 0 ? (
-													<SitesList
-														searchCriteria={searchCriteriaObject}
-														sites={activeRecruitmentSites}
-													/>
-												) : noLocInfo.includes(
-														trialDescription.current_trial_status.toLowerCase()
-												  ) ? (
-													<p>Location information is not yet available.</p>
-												) : (
+												`{' '}
+												<>
 													<p>
-														See trial information on{' '}
+														Additional locations may be listed on
+														ClinicalTrials.gov for{' '}
 														<a
 															href={`https://www.clinicaltrials.gov/study/${trialDescription.nct_id}`}
 															target="_blank"
 															rel="noopener noreferrer">
-															ClinicalTrials.gov
-														</a>{' '}
-														for a list of participating sites.
+															{trialDescription.nct_id}
+														</a>
+														.
 													</p>
-												)}
+													{activeRecruitmentSites &&
+													activeRecruitmentSites.length > 0 ? (
+														<SitesList
+															searchCriteria={searchCriteriaObject}
+															sites={activeRecruitmentSites}
+														/>
+													) : noLocInfo.includes(
+															trialDescription.current_trial_status.toLowerCase()
+													  ) ? (
+														<p>Location information is not yet available.</p>
+													) : (
+														<p>
+															See trial information on{' '}
+															<a
+																href={`https://www.clinicaltrials.gov/study/${trialDescription.nct_id}`}
+																target="_blank"
+																rel="noopener noreferrer">
+																ClinicalTrials.gov
+															</a>{' '}
+															for a list of participating sites.
+														</p>
+													)}
+												</>
 											</AccordionItem>
 											<AccordionItem titleCollapsed="Trial Objectives and Outline">
 												{trialDescription.detail_description && (


### PR DESCRIPTION
* Adds an additional link to ClinicalTrials.gov
* Un-hardcodes page title, browser title, meta description, intro text, canonical host, and adds config variables
* Updates tests

Closes #642 
Closes #643 
Closes #650