### PR TITLE
(#672) Prior Therapy API endpoints

### DIFF
--- a/cypress/e2e/AdvancedSearchPage/AdvancedSearchForm.feature
+++ b/cypress/e2e/AdvancedSearchPage/AdvancedSearchForm.feature
@@ -49,6 +49,35 @@ Feature: As a user, I want to be able to search for a clinical trial using advan
 		When user clicks on "advanced search" with href "/advanced"
 		Then user is redirected to "/advanced"
 
+	# TODO(#672): Flesh out these stub scenarios for the Prior Therapy field once
+	# UI copy and fixtures are finalized. See spec section 8.
+	Scenario: Prior Therapy field is displayed on the advanced form
+		Given the user navigates to "/advanced"
+		Then the page title is "Find Cancer Clinical Trials"
+		And "Prior Therapy" form section is displayed
+
+	Scenario: User can select multiple prior therapies, submit, and rehydrate from the URL
+		Given the user navigates to "/advanced"
+		Then the page title is "Find Cancer Clinical Trials"
+		# TODO(#672): type into Prior Therapy field, select 2 suggestions, submit form,
+		# assert URL contains pt=<code1>|<code2>, reload and assert chips restored,
+		# remove a chip and assert URL/state updated.
+
+	# Demonstrates that the Prior Therapy autocomplete combines categories from
+	# Drug (agent, agent category) and Treatment / Other Intervention (other) in a
+	# single dropdown. Backed by support/mock-data/interventions/platinum_10_count_desc.json
+	# which intentionally contains one of each category.
+	Scenario: Prior Therapy autocomplete surfaces mixed Agent + Agent Category + Other results
+		Given the user navigates to "/advanced"
+		Then the page title is "Find Cancer Clinical Trials"
+		And "Prior Therapy" form section is displayed
+		When user types "platinum" in "PriorTherapy" field
+		# TODO(#672): the dropdown should contain "Cisplatin" (agent),
+		# "Platinum Compound (DRUG FAMILY)" (agent category), and
+		# "Platinum-Based Radiotherapy" (other).
+		# Add concrete dropdown-item assertions once the fieldMap entry and
+		# dropdown step definitions are in place.
+
 		### meta data
 		Scenario: As a search engine I want to have access to the meta data on a page
 		Given the user navigates to "/advanced"

--- a/cypress/utils/ctsFields.js
+++ b/cypress/utils/ctsFields.js
@@ -20,5 +20,6 @@ export const fieldMap = {
     "TrialInvestigator": "inv",
     "LeadOrganization": "component-unique-id-20",
     "Keywords": "keywordPhrases",
-    "TrialPhase": "trialphase"
+    "TrialPhase": "trialphase",
+    "PriorTherapy": "pt"
 };

--- a/src/components/search-modules/PriorTherapy/PriorTherapy.jsx
+++ b/src/components/search-modules/PriorTherapy/PriorTherapy.jsx
@@ -1,5 +1,106 @@
+import React, { useState, useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import PropTypes from 'prop-types';
+import { Fieldset, Autocomplete } from '../../atomic';
+import { searchPriorTherapyAction } from '../../../store/actionsV2';
 import './PriorTherapy.scss';
+import { useAppSettings } from '../../../store/store.js';
 
-const PriorTherapy = () => {};
+const PriorTherapy = ({ handleUpdate }) => {
+	const placeholderText = 'Please enter 3 or more characters';
+	const dispatch = useDispatch();
+
+	const [{ helpUrl }] = useAppSettings();
+	const { priorTherapy } = useSelector((store) => store.form);
+	const { priorTherapyOptions } = useSelector((store) => store.cache);
+	const priorTherapyOptionsData = priorTherapyOptions?.data ? priorTherapyOptions.data : [];
+
+	const [priorTherapyVal, setPriorTherapyVal] = useState({ value: '' });
+
+	useEffect(() => {
+		if (priorTherapyVal.value.length > 2) {
+			dispatch(searchPriorTherapyAction({ searchText: priorTherapyVal.value }));
+		}
+	}, [priorTherapyVal, dispatch]);
+
+	const filterSelectedItems = (items = [], selections = []) => {
+		if (!items.length || !selections.length) {
+			return items;
+		}
+		return items.filter((item) => !selections.find((selection) => selection.name === item.name));
+	};
+
+	const applyOptionsFilterAndFormatting = (searchVal, item, isHighlighted) => {
+		const searchStr = new RegExp('(^' + searchVal.value + '|\\s+' + searchVal.value + ')', 'i');
+		const filteredSynonyms = Array.isArray(item.synonyms) ? item.synonyms.filter((synonym) => synonym.match(searchStr)) : [];
+		const filteredSynonymsCount = filteredSynonyms.length;
+
+		return (
+			<div className={`cts-autocomplete__menu-item ${isHighlighted ? 'highlighted' : ''}`} key={item.codes[0]}>
+				<div className="preferredName">
+					{item.name}
+					{item.category.indexOf('category') !== -1 ? ' (DRUG FAMILY)' : ''}
+				</div>
+				{filteredSynonymsCount > 0 && (
+					<span className="synonyms">
+						Other Names:{' '}
+						<ol>
+							{filteredSynonyms.map((synonym, i) => (
+								<li
+									key={i}
+									dangerouslySetInnerHTML={{
+										__html: synonym.match(searchStr) ? synonym.replace(searchStr, `<strong>$&</strong>`) : synonym,
+									}}></li>
+							))}
+						</ol>
+					</span>
+				)}
+			</div>
+		);
+	};
+
+	return (
+		<Fieldset
+			id="prior-therapy"
+			legend={
+				<>
+					Prior Therapy <span className="prior-therapy__beta">BETA</span>
+				</>
+			}
+			helpUrl={helpUrl + '#priortherapy'}>
+			<p>Search for treatments you have already received. Trials that exclude these therapies will be filtered out.</p>
+
+			<Autocomplete
+				id="pt"
+				label="Prior Therapy"
+				inputHelpText="More than one selection may be made."
+				value={priorTherapyVal.value}
+				inputProps={{
+					placeholder: 'Start typing to select prior therapies',
+				}}
+				items={filterSelectedItems(priorTherapyOptionsData, priorTherapy)}
+				getItemValue={(item) => item.name}
+				shouldItemRender={() => true}
+				onChange={(event, value) => setPriorTherapyVal({ value })}
+				onSelect={(value) => {
+					handleUpdate('priorTherapy', [...priorTherapy, priorTherapyOptionsData.find(({ name }) => name === value)]);
+					setPriorTherapyVal({ value: '' });
+				}}
+				multiselect={true}
+				chipList={priorTherapy}
+				onChipRemove={(e) => {
+					const newChips = priorTherapy.filter((item) => item.name !== e.label);
+					handleUpdate('priorTherapy', [...newChips]);
+				}}
+				renderMenu={(children) => <div className="cts-autocomplete__menu --drugs">{priorTherapyVal.value.length > 2 ? filterSelectedItems(priorTherapyOptionsData, priorTherapy).length ? children : <div className="cts-autocomplete__menu-item">No results found</div> : <div className="cts-autocomplete__menu-item">{placeholderText}</div>}</div>}
+				renderItem={(item, isHighlighted) => applyOptionsFilterAndFormatting(priorTherapyVal, item, isHighlighted)}
+			/>
+		</Fieldset>
+	);
+};
+
+PriorTherapy.propTypes = {
+	handleUpdate: PropTypes.func,
+};
 
 export default PriorTherapy;

--- a/src/components/search-modules/PriorTherapy/PriorTherapy.jsx
+++ b/src/components/search-modules/PriorTherapy/PriorTherapy.jsx
@@ -1,0 +1,5 @@
+import './PriorTherapy.scss';
+
+const PriorTherapy = () => {};
+
+export default PriorTherapy;

--- a/src/components/search-modules/PriorTherapy/PriorTherapy.scss
+++ b/src/components/search-modules/PriorTherapy/PriorTherapy.scss
@@ -1,0 +1,12 @@
+.prior-therapy__beta {
+	display: inline-block;
+	margin-left: 0.5rem;
+	padding: 0.1rem 0.4rem;
+	font-size: 0.7rem;
+	font-weight: bold;
+	line-height: 1;
+	color: #fff;
+	background-color: #2c7a32;
+	border-radius: 3px;
+	vertical-align: middle;
+}

--- a/src/components/search-modules/PriorTherapy/index.jsx
+++ b/src/components/search-modules/PriorTherapy/index.jsx
@@ -1,0 +1,1 @@
+export { default } from './PriorTherapy';

--- a/src/components/search-modules/index.js
+++ b/src/components/search-modules/index.js
@@ -5,6 +5,7 @@ export { default as DrugTreatment } from './DrugTreatment';
 export { default as KeywordsPhrases } from './KeywordsPhrases';
 export { default as LeadOrganization } from './LeadOrganization';
 export { default as Location } from './Location';
+export { default as PriorTherapy } from './PriorTherapy';
 export { default as TrialId } from './TrialId';
 export { default as TrialInvestigators } from './TrialInvestigators';
 export { default as TrialPhase } from './TrialPhase';

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -32,7 +32,7 @@ export const ACTIVE_RECRUITMENT_STATUSES = [
 ];
 
 // Specify which fields will be returned in the TrialsResults Object from clinicaltrialsapi
-export const SEARCH_RETURNS_FIELDS = ['nci_id', 'nct_id', 'brief_title', 'sites.org_name', 'sites.org_postal_code', 'eligibility.structured', 'current_trial_status', 'sites.org_va', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.org_coordinates', 'sites.recruitment_status', 'diseases'];
+export const SEARCH_RETURNS_FIELDS = ['nci_id', 'nct_id', 'brief_title', 'sites.org_name', 'sites.org_postal_code', 'eligibility.structured', 'current_trial_status', 'sites.org_va', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.org_coordinates', 'sites.recruitment_status', 'diseases', 'prior_therapy'];
 
 //These are the two catch all buckets that we must add to the bottom of the list.
 //ORDER will matter here.

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -86,6 +86,7 @@ export const defaultSCOState = {
 	vaOnly: false, // (va) VA facilities only
 	drugs: [], // (dt) Drug/Drug family
 	treatments: [], // (ti) Treatment/Interventions
+	priorTherapy: [], // (pt) Prior Therapy
 	trialId: '', // (tid) Trial ID,
 	investigator: { term: '', termKey: '' }, // (in) Trial investigators ('in' is legacy but is a keyword and does not work well as a key name; be ready to handle both in query string)
 	leadOrg: { term: '', termKey: '' }, // (lo) Lead Organization

--- a/src/hooks/ctsApiSupport/__tests__/useCtsApi.test.js
+++ b/src/hooks/ctsApiSupport/__tests__/useCtsApi.test.js
@@ -132,7 +132,7 @@ describe('tests for useCtsApi', () => {
 
 			const expected = {
 				current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 				'arms.interventions.intervention_code': ['C1234'],
 				from: 0,
 				size: 1,
@@ -174,7 +174,7 @@ describe('tests for useCtsApi', () => {
 
 			const expected = {
 				current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 				'arms.interventions.intervention_code': ['C1234'],
 				from: 0,
 				size: 1,
@@ -213,7 +213,7 @@ describe('tests for useCtsApi', () => {
 
 			const expected = {
 				current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 				'arms.interventions.intervention_code': ['C1234'],
 				from: 0,
 				size: 1,

--- a/src/middleware/CTSMiddlewareV2.js
+++ b/src/middleware/CTSMiddlewareV2.js
@@ -1,5 +1,5 @@
 import { receiveData } from '../store/actions';
-import { getCountries, getDiseasesForTypeAhead, getFindings, getHospitals, getLeadOrg, getMainType, getOtherInterventions, getStages, getSubtypes, searchDrug, searchTrialInvestigators } from '../services/api/clinical-trials-search-api';
+import { getCountries, getDiseasesForTypeAhead, getFindings, getHospitals, getLeadOrg, getMainType, getOtherInterventions, getStages, getSubtypes, searchDrug, searchPriorTherapy, searchTrialInvestigators } from '../services/api/clinical-trials-search-api';
 
 /**
  * This middleware serves two purposes (and could perhaps be broken into two pieces).
@@ -54,6 +54,9 @@ const createCTSMiddlewareV2 =
 					}
 					case 'searchDrug': {
 						return searchDrug(client, requestParams);
+					}
+					case 'searchPriorTherapy': {
+						return searchPriorTherapy(client, requestParams);
 					}
 					case 'searchTrialInvestigators': {
 						return searchTrialInvestigators(client, requestParams);

--- a/src/services/api/actions/__tests__/getClinicalTrialsAction.test.js
+++ b/src/services/api/actions/__tests__/getClinicalTrialsAction.test.js
@@ -10,7 +10,7 @@ describe('testing getClinicalTrials', () => {
 			type: 'getClinicalTrials',
 			payload: {
 				current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 				'arms.interventions.nci_thesaurus_concept_id': ['C1234'],
 				primary_purpose: 'treatment',
 				from: 0,
@@ -35,7 +35,7 @@ describe('testing getClinicalTrials', () => {
 			type: 'getClinicalTrials',
 			payload: {
 				current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+				include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 				from: 5,
 				size: 10,
 			},

--- a/src/services/api/actions/getClinicalTrialsAction.js
+++ b/src/services/api/actions/getClinicalTrialsAction.js
@@ -12,7 +12,7 @@ export const getClinicalTrialsAction = ({ from = 0, requestFilters = {}, size = 
 	// Include only active trial statuses, requestFilters, from, and size.
 	const requestQuery = {
 		current_trial_status: ['Active', 'Approved', 'Enrolling by Invitation', 'In Review', 'Temporarily Closed to Accrual', 'Temporarily Closed to Accrual and Intervention'],
-		include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status'],
+		include: ['brief_summary', 'brief_title', 'current_trial_status', 'eligibility', 'eligibility.structured.minAgeInt', 'eligibility.structured.maxAgeInt', 'nci_id', 'nct_id', 'sites.org_name', 'sites.org_country', 'sites.org_state_or_province', 'sites.org_city', 'sites.recruitment_status', 'prior_therapy'],
 		...requestFilters,
 		from,
 		size,

--- a/src/services/api/clinical-trials-search-api/__tests__/getClinicalTrialsWithPriorTherapy.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/getClinicalTrialsWithPriorTherapy.test.js
@@ -1,0 +1,102 @@
+import nock from 'nock';
+
+import { getClinicalTrialsAction } from '../../actions/getClinicalTrialsAction';
+import clinicalTrialsSearchClientFactory from '../clinicalTrialsSearchClientFactory';
+import { getClinicalTrials } from '../getClinicalTrials';
+
+const client = clinicalTrialsSearchClientFactory('http://example.org');
+
+describe('testing getClinicalTrials', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	it('makes a request to api and returns 7 trials, for Cytoreductive Surgery', async () => {
+		const requestFilters = {
+			'prior_therapy.nci_thesaurus_concept_id': ['C132068'],
+		};
+
+		const query = getClinicalTrialsAction({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org')
+			.post('/trials', query.payload)
+			.reply(200, { total: 7, data: [{}] });
+		const response = await getClinicalTrials(client, query.payload);
+		expect(response.total).toEqual(7);
+		scope.isDone();
+	});
+
+	it.each([
+		['empty object', {}],
+		['null total', { total: null }],
+		['count with null trials', { total: 32 }],
+		['count with empty trials', { total: 32, data: [] }],
+		['zero count with trials', { total: 0, data: [1] }],
+	])('Invalid trial responses - %s', async (testCase, resObj) => {
+		const requestFilters = {
+			'prior_therapy.nci_thesaurus_concept_id': ['C132068'],
+		};
+
+		const query = getClinicalTrialsAction({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org').post('/trials', query.payload).reply(200, resObj);
+
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow('Trial count mismatch from the API');
+		scope.isDone();
+	});
+
+	it('makes a request where the response is 201', async () => {
+		const requestFilters = {
+			'bad_request.interventions.intervention_code_request': ['BAD404'],
+		};
+
+		const query = getClinicalTrialsAction({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org').post('/trials', query.payload).reply(201);
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow('Unexpected status 201 for fetching clinical trials');
+		scope.isDone();
+	});
+
+	it('throws a 500 error status', async () => {
+		const requestFilters = {
+			'prior_therapy.nci_thesaurus_concept_id': ['C132068'],
+		};
+
+		const query = getClinicalTrialsAction({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org').post('/trials', query.payload).reply(500);
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow('Unexpected status 500 for fetching clinical trials');
+		scope.isDone();
+	});
+
+	it('handles an error thrown by http client', async () => {
+		const requestFilters = {
+			'prior_therapy.nci_thesaurus_concept_id': ['C132068'],
+		};
+
+		const query = getClinicalTrialsAction({
+			requestFilters,
+		});
+
+		const scope = nock('http://example.org').post('/trials', query.payload).replyWithError('connection refused');
+		await expect(getClinicalTrials(client, query.payload)).rejects.toThrow('connection refused');
+		scope.isDone();
+	});
+});

--- a/src/services/api/clinical-trials-search-api/__tests__/searchPriorTherapy.test.js
+++ b/src/services/api/clinical-trials-search-api/__tests__/searchPriorTherapy.test.js
@@ -1,0 +1,110 @@
+import querystring from 'querystring';
+import nock from 'nock';
+
+import clinicalTrialsSearchClientFactory from '../clinicalTrialsSearchClientFactory';
+import { ACTIVE_TRIAL_STATUSES } from '../../../../constants';
+import { searchPriorTherapy } from '../searchPriorTherapy';
+import { searchPriorTherapyAction } from '../../../../store/actionsV2';
+
+const client = clinicalTrialsSearchClientFactory('http://example.org');
+
+const baseRequestQuery = (searchText) => ({
+	current_trial_status: ACTIVE_TRIAL_STATUSES,
+	sort: 'count',
+	order: 'desc',
+	category: ['Agent', 'Agent Category', 'Other'],
+	name: searchText,
+	size: 10,
+});
+
+describe('searchPriorTherapy', () => {
+	beforeAll(() => {
+		nock.disableNetConnect();
+	});
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	afterAll(() => {
+		nock.cleanAll();
+		nock.enableNetConnect();
+	});
+
+	it('makes a request to the api and matches returned result for specified search text', async () => {
+		const searchText = 'cis';
+		const query = searchPriorTherapyAction({ searchText });
+		const requestQuery = baseRequestQuery(searchText);
+
+		const result = {
+			data: [
+				{
+					name: 'Cisplatin',
+					codes: ['C376'],
+					category: ['agent'],
+					type: ['drug'],
+					synonyms: ['Cisplatin', 'CDDP'],
+					count: 200,
+				},
+			],
+			total: 1,
+		};
+
+		const scope = nock('http://example.org')
+			.get(`/interventions?${querystring.stringify(requestQuery)}`)
+			.reply(200, result);
+
+		const response = await searchPriorTherapy(client, query.payload.requestParams);
+
+		expect(response).toEqual(result);
+		scope.isDone();
+	});
+
+	it('throws a 204 error status', async () => {
+		const searchText = 'cis';
+		const query = searchPriorTherapyAction({ searchText });
+		const requestQuery = baseRequestQuery(searchText);
+
+		const scope = nock('http://example.org')
+			.get(`/interventions?${querystring.stringify(requestQuery)}`)
+			.reply(204);
+		await expect(searchPriorTherapy(client, query.payload.requestParams)).rejects.toThrow('Unexpected status 204 for fetching prior therapies');
+		scope.isDone();
+	});
+
+	it('throws a 404 error', async () => {
+		const searchText = 'cis';
+		const query = searchPriorTherapyAction({ searchText });
+		const requestQuery = baseRequestQuery(searchText);
+
+		const scope = nock('http://example.org')
+			.get(`/interventions?${querystring.stringify(requestQuery)}`)
+			.reply(404);
+		await expect(searchPriorTherapy(client, query.payload.requestParams)).rejects.toThrow('Unexpected status 404 for fetching prior therapies');
+		scope.isDone();
+	});
+
+	it('throws a 500 error status', async () => {
+		const searchText = 'cis';
+		const query = searchPriorTherapyAction({ searchText });
+		const requestQuery = baseRequestQuery(searchText);
+
+		const scope = nock('http://example.org')
+			.get(`/interventions?${querystring.stringify(requestQuery)}`)
+			.reply(500);
+		await expect(searchPriorTherapy(client, query.payload.requestParams)).rejects.toThrow('Unexpected status 500 for fetching prior therapies');
+		scope.isDone();
+	});
+
+	it('handles an error thrown by http client', async () => {
+		const searchText = 'cis';
+		const query = searchPriorTherapyAction({ searchText });
+		const requestQuery = baseRequestQuery(searchText);
+
+		const scope = nock('http://example.org')
+			.get(`/interventions?${querystring.stringify(requestQuery)}`)
+			.replyWithError('connection refused');
+		await expect(searchPriorTherapy(client, query.payload.requestParams)).rejects.toThrow('connection refused');
+		scope.isDone();
+	});
+});

--- a/src/services/api/clinical-trials-search-api/index.js
+++ b/src/services/api/clinical-trials-search-api/index.js
@@ -14,3 +14,4 @@ export { getSubtypes } from './getSubtypes';
 export { getStages } from './getStages';
 export { searchDrug } from './searchDrug';
 export { searchTrialInvestigators } from './searchTrialInvestigators';
+export { searchPriorTherapy } from './searchPriorTherapy';

--- a/src/services/api/clinical-trials-search-api/searchPriorTherapy.js
+++ b/src/services/api/clinical-trials-search-api/searchPriorTherapy.js
@@ -1,0 +1,25 @@
+import * as querystring from 'query-string';
+
+/**
+ * Fetches Prior Therapies to populate the prior therapy field in the Location section
+ *
+ * @param {import("axios").AxiosInstance} client An axios instance with the correct baseURL
+ * @param {object} query the cts query
+ */
+export const searchPriorTherapy = async (client, query) => {
+	try {
+		const res = await client.get(`/interventions?${querystring.stringify(query)}`);
+		if (res.status === 200) {
+			return res.data;
+		} else {
+			// This condition will be hit for anything < 300.
+			throw new Error(`Unexpected status ${res.status} for fetching prior therapies`);
+		}
+	} catch (error) {
+		// This conditional will be hit for any status >= 300.
+		if (error.response) {
+			throw new Error(`Unexpected status ${error.response.status} for fetching prior therapies`);
+		}
+		throw error;
+	}
+};

--- a/src/store/actionsV2/__tests__/searchPriorTherapyAction.test.js
+++ b/src/store/actionsV2/__tests__/searchPriorTherapyAction.test.js
@@ -1,0 +1,41 @@
+import { ACTIVE_TRIAL_STATUSES } from '../../../constants';
+import { searchPriorTherapyAction } from '../searchPriorTherapyAction';
+
+describe('searchPriorTherapyAction', () => {
+	it('should match the returned object', () => {
+		const searchText = 'cisplatin';
+
+		const requestQuery = {
+			current_trial_status: ACTIVE_TRIAL_STATUSES,
+			sort: 'count',
+			order: 'desc',
+			category: ['Agent', 'Agent Category', 'Other'],
+			name: searchText,
+			size: 10,
+		};
+
+		const expectedAction = {
+			type: '@@api/CTSv2',
+			payload: {
+				service: 'ctsSearchV2',
+				cacheKey: 'priorTherapyOptions',
+				method: 'searchPriorTherapy',
+				requestParams: requestQuery,
+			},
+		};
+
+		expect(searchPriorTherapyAction({ searchText })).toEqual(expectedAction);
+	});
+
+	it('handles exception when called without a search text parameter', () => {
+		expect(() => {
+			searchPriorTherapyAction({ searchText: null });
+		}).toThrow('You must specify a prior therapy in order to fetch it.');
+	});
+
+	it('handles exception when called with empty string search text', () => {
+		expect(() => {
+			searchPriorTherapyAction({ searchText: '' });
+		}).toThrow('You must specify a prior therapy in order to fetch it.');
+	});
+});

--- a/src/store/actionsV2/index.js
+++ b/src/store/actionsV2/index.js
@@ -9,3 +9,4 @@ export { getSubtypesAction } from './getSubtypesAction';
 export { getStagesAction } from './getStagesAction';
 export { searchDrugAction } from './searchDrugAction';
 export { searchTrialInvestigatorsAction } from './searchTrialInvestigatorsAction';
+export { searchPriorTherapyAction } from './searchPriorTherapyAction';

--- a/src/store/actionsV2/searchPriorTherapyAction.js
+++ b/src/store/actionsV2/searchPriorTherapyAction.js
@@ -13,7 +13,7 @@ export const searchPriorTherapyAction = ({ searchText }) => {
 		current_trial_status: ACTIVE_TRIAL_STATUSES,
 		sort: 'count',
 		order: 'desc',
-		category: ['Agent', 'Agent Category'],
+		category: ['Agent', 'Agent Category', 'Other'],
 		name: searchText,
 		size: 10,
 	};

--- a/src/store/actionsV2/searchPriorTherapyAction.js
+++ b/src/store/actionsV2/searchPriorTherapyAction.js
@@ -1,0 +1,30 @@
+import { ACTIVE_TRIAL_STATUSES } from '../../constants';
+
+/**
+ * Gets a list of Prior Therapies from the CTS api
+ * @param {String} searchText - free text string matching Prior Therapy name
+ * @return {{payload: {cacheKey: string, method: string, service: string, requestParams: {current_trial_status: string[], name: searchText, sort: 'count', order: 'desc', category: }}, type: string}}
+ */
+export const searchPriorTherapyAction = ({ searchText }) => {
+	if (!searchText || searchText === '') {
+		throw new Error('You must specify a prior therapy in order to fetch it.');
+	}
+	const requestQuery = {
+		current_trial_status: ACTIVE_TRIAL_STATUSES,
+		sort: 'count',
+		order: 'desc',
+		category: ['Agent', 'Agent Category'],
+		name: searchText,
+		size: 10,
+	};
+
+	return {
+		type: '@@api/CTSv2',
+		payload: {
+			service: 'ctsSearchV2',
+			cacheKey: 'priorTherapyOptions',
+			method: 'searchPriorTherapy',
+			requestParams: requestQuery,
+		},
+	};
+};

--- a/src/store/reducers/form.js
+++ b/src/store/reducers/form.js
@@ -38,6 +38,7 @@ export const defaultState = {
 	vaOnly: false, // (va) VA facilities only
 	drugs: [], // (dt) Drug/Drug family
 	treatments: [], // (ti) Treatment/Interventions
+	priorTherapy: [], // (pt) Prior Therapy
 	trialId: '', // (tid) Trial ID,
 	investigator: { term: '', termKey: '' }, // (in) Trial investigators ('in' is legacy but is a keyword and does not work well as a key name; be ready to handle both in query string)
 	leadOrg: { term: '', termKey: '' }, // (lo) Lead Organization

--- a/src/utilities/__tests__/buildQueryString.js
+++ b/src/utilities/__tests__/buildQueryString.js
@@ -653,6 +653,34 @@ const mappingTestCases = [
 			pn: 3,
 		},
 	],
+	/***************
+	 * Prior Therapy
+	 ***************/
+	[
+		'prior therapy / one id',
+		{
+			priorTherapy: [{ name: 'Trastuzumab', codes: ['C1674'] }],
+			formType: 'advanced',
+		},
+		{
+			...NO_LOC_ADVANCED,
+			pt: ['C1674'],
+		},
+	],
+	[
+		'prior therapy / two ids',
+		{
+			priorTherapy: [
+				{ name: 'Immunotherapy', codes: ['C15262'] },
+				{ name: 'Prior Therapy 2', codes: ['C5678'] },
+			],
+			formType: 'advanced',
+		},
+		{
+			...NO_LOC_ADVANCED,
+			pt: ['C15262', 'C5678'],
+		},
+	],
 ];
 
 describe('buildQueryString maps form state to url query', () => {

--- a/src/utilities/__tests__/defaultStateCopy.js
+++ b/src/utilities/__tests__/defaultStateCopy.js
@@ -37,6 +37,7 @@ export const defaultState = {
 	vaOnly: false, // (va) VA facilities only
 	drugs: [], // (dt) Drug/Drug family
 	treatments: [], // (ti) Treatment/Interventions
+	priorTherapy: [], // (pt) Prior Therapy
 	trialId: '', // (tid) Trial ID,
 	investigator: { term: '', termKey: '' }, // (in) Trial investigators ('in' is legacy but is a keyword and does not work well as a key name; be ready to handle both in query string)
 	leadOrg: { term: '', termKey: '' }, // (lo) Lead Organization

--- a/src/utilities/__tests__/formatTrialSearchQuery.js
+++ b/src/utilities/__tests__/formatTrialSearchQuery.js
@@ -499,6 +499,8 @@ const mappingTestCases = [
 		},
 		{
 			'prior_therapy.nci_thesaurus_concept_id': ['C1234'],
+			'prior_therapy.eligibility_criterion': 'exclusion',
+			'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
 		},
 	],
 	[
@@ -511,6 +513,8 @@ const mappingTestCases = [
 		},
 		{
 			'prior_therapy.nci_thesaurus_concept_id': ['C1234', 'C5678'],
+			'prior_therapy.eligibility_criterion': 'exclusion',
+			'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
 		},
 	],
 ];

--- a/src/utilities/__tests__/formatTrialSearchQuery.js
+++ b/src/utilities/__tests__/formatTrialSearchQuery.js
@@ -489,6 +489,30 @@ const mappingTestCases = [
 			'arms.interventions.nci_thesaurus_concept_id': ['C308', 'C15262', 'C17173'],
 		},
 	],
+	/**************
+	 * Prior Therapy tests
+	 **************/
+	[
+		'one prior therapy',
+		{
+			priorTherapy: [{ name: 'Prior Therapy', codes: ['C1234'] }],
+		},
+		{
+			'prior_therapy.nci_thesaurus_concept_id': ['C1234'],
+		},
+	],
+	[
+		'two prior therapies',
+		{
+			priorTherapy: [
+				{ name: 'Prior Therapy 1', codes: ['C1234'] },
+				{ name: 'Prior Therapy 2', codes: ['C5678'] },
+			],
+		},
+		{
+			'prior_therapy.nci_thesaurus_concept_id': ['C1234', 'C5678'],
+		},
+	],
 ];
 
 describe('formatTrialSearchQuery maps form to query', () => {

--- a/src/utilities/buildQueryString.js
+++ b/src/utilities/buildQueryString.js
@@ -1,5 +1,5 @@
 export const buildQueryString = (formStore) => {
-	const { formType, age, keywordPhrases, zip, zipRadius, cancerType, subtypes, stages, findings, country, location, city, states, hospital, healthyVolunteers, vaOnly, trialPhases, trialTypes, drugs, treatments, trialId, investigator, leadOrg, resultsPage } = formStore;
+	const { formType, age, keywordPhrases, zip, zipRadius, cancerType, subtypes, stages, findings, country, location, city, states, hospital, healthyVolunteers, vaOnly, trialPhases, trialTypes, drugs, treatments, trialId, investigator, leadOrg, resultsPage, priorTherapy } = formStore;
 
 	let searchValues = {};
 
@@ -101,6 +101,9 @@ export const buildQueryString = (formStore) => {
 		}
 		if (leadOrg.term !== '') {
 			searchValues.lo = leadOrg.term;
+		}
+		if (priorTherapy.length > 0) {
+			searchValues.pt = [...new Set(priorTherapy.map((item) => item.codes.join('|')))];
 		}
 
 		return searchValues;

--- a/src/utilities/formatTrialSearchQuery.js
+++ b/src/utilities/formatTrialSearchQuery.js
@@ -29,6 +29,12 @@ export const formatTrialSearchQuery = (form) => {
 		filterCriteria['arms.interventions.nci_thesaurus_concept_id'] = [...new Set([...drugIds, ...otherIds])];
 	}
 
+	//Prior Therapies
+	if (form.priorTherapy.length > 0) {
+		const priorTherapyIds = collapseConcepts(form.priorTherapy);
+		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
+	}
+
 	//Add Age filter
 	if (form.age !== '') {
 		filterCriteria['eligibility.structured.max_age_in_years_gte'] = form.age;

--- a/src/utilities/formatTrialSearchQuery.js
+++ b/src/utilities/formatTrialSearchQuery.js
@@ -33,6 +33,8 @@ export const formatTrialSearchQuery = (form) => {
 	if (form.priorTherapy.length > 0) {
 		const priorTherapyIds = collapseConcepts(form.priorTherapy);
 		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
+		filterCriteria['prior_therapy.eligibility_criterion'] = 'exclusion';
+		filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
 	}
 
 	//Add Age filter

--- a/src/utilities/formatTrialSearchQueryV2.js
+++ b/src/utilities/formatTrialSearchQueryV2.js
@@ -33,6 +33,8 @@ export const formatTrialSearchQueryV2 = (form) => {
 	if (form.priorTherapy.length > 0) {
 		const priorTherapyIds = collapseConcepts(form.priorTherapy);
 		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
+		filterCriteria['prior_therapy.eligibility_criterion'] = 'exclusion';
+		filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
 	}
 
 	//Add Age filter

--- a/src/utilities/formatTrialSearchQueryV2.js
+++ b/src/utilities/formatTrialSearchQueryV2.js
@@ -29,6 +29,12 @@ export const formatTrialSearchQueryV2 = (form) => {
 		filterCriteria['arms.interventions.nci_thesaurus_concept_id'] = [...new Set([...drugIds, ...otherIds])];
 	}
 
+	//Prior Therapies
+	if (form.priorTherapy.length > 0) {
+		const priorTherapyIds = collapseConcepts(form.priorTherapy);
+		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
+	}
+
 	//Add Age filter
 	if (form.age !== '') {
 		filterCriteria['eligibility.structured.max_age_in_years_gte'] = form.age;

--- a/src/utilities/queryStringToSearchCriteria.js
+++ b/src/utilities/queryStringToSearchCriteria.js
@@ -21,6 +21,7 @@ const ALLOWED_ADVANCED_DISEASES = {
 const ALLOWED_ADVANCED_INTERVENTIONS = {
 	drugs: ['agent', 'agent category'],
 	treatments: ['other', 'none'],
+	priorTherapy: ['agent', 'agent category', 'other', 'none'],
 };
 
 // NOTE: Some state values are not passed into the url

--- a/src/utilities/queryStringToSearchCriteria.js
+++ b/src/utilities/queryStringToSearchCriteria.js
@@ -64,6 +64,7 @@ const defaultState = {
 	vaOnly: false, // (va) VA facilities only
 	drugs: [], // (dt) Drug/Drug family
 	treatments: [], // (ti) Treatment/Interventions
+	priorTherapy: [], // (pt) Prior Therapy
 	trialId: '', // (tid) Trial ID,
 	investigator: { term: '', termKey: '' }, // (in) Trial investigators ('in' is legacy but is a keyword and does not work well as a key name; be ready to handle both in query string)
 	leadOrg: { term: '', termKey: '' }, // (lo) Lead Organization
@@ -726,6 +727,10 @@ const processInterventionsPass1 = (query) => {
 	// Other treatment
 	if (query['i']) {
 		interventionsFieldHandler(query['i'], 'treatments');
+	}
+	// Prior Therapy
+	if (query['pt']) {
+		interventionsFieldHandler(query['pt'], 'priorTherapy');
 	}
 
 	return [queryInterventions, rtnErrorsList];

--- a/src/views/SearchPage/SearchPage.jsx
+++ b/src/views/SearchPage/SearchPage.jsx
@@ -7,7 +7,7 @@ import { useTracking } from 'react-tracking';
 import { Delighter, StickySubmitBlock } from '../../components/atomic';
 import { convertObjectToBase64 } from '../../utilities/objects';
 
-import { Age, CancerTypeCondition, CancerTypeKeyword, DrugTreatment, KeywordsPhrases, LeadOrganization, Location, TrialId, TrialInvestigators, TrialPhase, TrialType, ZipCode } from '../../components/search-modules';
+import { Age, CancerTypeCondition, CancerTypeKeyword, DrugTreatment, KeywordsPhrases, LeadOrganization, Location, PriorTherapy, TrialId, TrialInvestigators, TrialPhase, TrialType, ZipCode } from '../../components/search-modules';
 import { updateForm, updateFormField, clearForm } from '../../store/actions';
 import { getMainTypeAction } from '../../store/actionsV2';
 import { getFieldInFocus, getFormInFocus, getHasDispatchedFormInteractionEvent, getHasUserInteractedWithForm } from '../../store/modules/analytics/tracking/tracking.selectors';
@@ -22,7 +22,7 @@ const queryString = require('query-string');
 
 // Module groups in arrays will be placed side-by-side in the form
 const basicFormModules = [CancerTypeKeyword, [Age, ZipCode]];
-const advancedFormModules = [CancerTypeCondition, [Age, KeywordsPhrases], Location, TrialType, DrugTreatment, TrialPhase, TrialId, TrialInvestigators, LeadOrganization];
+const advancedFormModules = [CancerTypeCondition, [Age, KeywordsPhrases], Location, TrialType, DrugTreatment, PriorTherapy, TrialPhase, TrialId, TrialInvestigators, LeadOrganization];
 
 const SearchPage = ({ formInit = 'basic' }) => {
 	const dispatch = useDispatch();

--- a/support/mock-data/clinical-trials/20165-100miles-request.json
+++ b/support/mock-data/clinical-trials/20165-100miles-request.json
@@ -1,38 +1,39 @@
 {
-    "sites.org_coordinates_lat": "39.0472",
-    "sites.org_coordinates_lon": "-77.3866",
-    "sites.org_coordinates_dist": "100mi",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from": 0,
-		"size": 10
+  "sites.org_coordinates_lat": "39.0472",
+  "sites.org_coordinates_lon": "-77.3866",
+  "sites.org_coordinates_dist": "100mi",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/22180-request.json
+++ b/support/mock-data/clinical-trials/22180-request.json
@@ -1,38 +1,39 @@
 {
-    "sites.org_coordinates_lat": "38.8935",
-    "sites.org_coordinates_lon": "-77.2532",
-    "sites.org_coordinates_dist": "100mi",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from":0,
-		"size":10
+  "sites.org_coordinates_lat": "38.8935",
+  "sites.org_coordinates_lon": "-77.2532",
+  "sites.org_coordinates_dist": "100mi",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/39years-request.json
+++ b/support/mock-data/clinical-trials/39years-request.json
@@ -1,30 +1,31 @@
 {
-    "eligibility.structured.max_age_in_years_gte": "39",
-    "eligibility.structured.min_age_in_years_lte": "39",
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from":0,
-		"size":10
+  "eligibility.structured.max_age_in_years_gte": "39",
+  "eligibility.structured.min_age_in_years_lte": "39",
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/40yrs-request.json
+++ b/support/mock-data/clinical-trials/40yrs-request.json
@@ -23,8 +23,9 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"from":0,
-	"size":10
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/40yrs_text-psa_zip-20892-request.json
+++ b/support/mock-data/clinical-trials/40yrs_text-psa_zip-20892-request.json
@@ -1,5 +1,4 @@
 {
-
   "current_trial_status": [
     "Active",
     "Approved",
@@ -22,19 +21,20 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"eligibility.structured.max_age_in_years_gte": 40,
-	"eligibility.structured.min_age_in_years_lte": 40,
-	"keyword": "psa",
-	"sites.org_postal_code": "20892",
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"from":0,
-	"size":10
+  "eligibility.structured.max_age_in_years_gte": 40,
+  "eligibility.structured.min_age_in_years_lte": 40,
+  "keyword": "psa",
+  "sites.org_postal_code": "20892",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/40yrs_trialtype_trialphase-request.json
+++ b/support/mock-data/clinical-trials/40yrs_trialtype_trialphase-request.json
@@ -1,38 +1,38 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"eligibility.structured.max_age_in_years_gte": 40,
-	"eligibility.structured.min_age_in_years_lte": 40,
-	"primary_purpose": [
-		"treatment"
-	],
-	"phase": [
-		"i",
-		"i_ii"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 40,
+  "eligibility.structured.min_age_in_years_lte": 40,
+  "primary_purpose": [
+    "treatment"
+  ],
+  "phase": [
+    "i",
+    "i_ii"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_fin-c18673,c28327-request.json
+++ b/support/mock-data/clinical-trials/C4872_fin-c18673,c28327-request.json
@@ -1,35 +1,36 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"finding": [
-		"C18673",
-		"C28327"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "finding": [
+    "C18673",
+    "C28327"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_fin-c18673-request.json
+++ b/support/mock-data/clinical-trials/C4872_fin-c18673-request.json
@@ -1,34 +1,35 @@
 {
-    "maintype": [
-        "C4872"
-    ],
-    "finding": [
-        "C18673"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "maintype": [
+    "C4872"
+  ],
+  "finding": [
+    "C18673"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_st-c8287,c162648-request.json
+++ b/support/mock-data/clinical-trials/C4872_st-c8287,c162648-request.json
@@ -1,36 +1,36 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C8287",
-		"C162648"
-	],
-		"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C8287",
+    "C162648"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_st-c8287-request.json
+++ b/support/mock-data/clinical-trials/C4872_st-c8287-request.json
@@ -1,34 +1,35 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C8287"
-	],
-		"from":0,
-		"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C8287"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_st-c8287_stg-C94774-request.json
+++ b/support/mock-data/clinical-trials/C4872_st-c8287_stg-C94774-request.json
@@ -1,37 +1,38 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C8287"
-	],
-	"stage": [
-		"C94774"
-	],
-		"from":0,
-		"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C8287"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_st-c8287_stg-C94774_fin-request.json
+++ b/support/mock-data/clinical-trials/C4872_st-c8287_stg-C94774_fin-request.json
@@ -1,41 +1,41 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C8287"
-	],
-	"stage": [
-		"C94774"
-	],
-	"finding": [
-		"C18673"
-	],
-		"from":0,
-		"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C8287"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "finding": [
+    "C18673"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/C4872_stg-C94774,77771-request.json
+++ b/support/mock-data/clinical-trials/C4872_stg-C94774,77771-request.json
@@ -1,35 +1,36 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"stage": [
-		"C94774",
-		"C7771"
-	],
-		"from":0,
-		"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "stage": [
+    "C94774",
+    "C7771"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/adrenal-cortex-cancer-request.json
+++ b/support/mock-data/clinical-trials/adrenal-cortex-cancer-request.json
@@ -1,32 +1,32 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C9325"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C9325"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/age-display-request.json
+++ b/support/mock-data/clinical-trials/age-display-request.json
@@ -1,37 +1,38 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"trial_ids": [
-		"NCI-2019-02289",
-		"NCI-2019-06216",
-		"NCI-2019-08622",
-		"NCI-2019-00399",
-		"NCI-2021-06711",
-		"NCI-2014-00677",
-		"NCI-2016-01734"
-	],
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "trial_ids": [
+    "NCI-2019-02289",
+    "NCI-2019-06216",
+    "NCI-2019-08622",
+    "NCI-2019-00399",
+    "NCI-2021-06711",
+    "NCI-2014-00677",
+    "NCI-2016-01734"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/aids_30yrs_zip-22182-request.json
+++ b/support/mock-data/clinical-trials/aids_30yrs_zip-22182-request.json
@@ -1,42 +1,42 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from":0,
-	"eligibility.structured.max_age_in_years_gte": 30,
-	"eligibility.structured.min_age_in_years_lte": 30,
-	"keyword": "aids",
-	"sites.org_coordinates_lat": "38.928",
-	"sites.org_coordinates_lon": "-77.2649",
-	"sites.org_coordinates_dist": "100mi",
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "eligibility.structured.max_age_in_years_gte": 30,
+  "eligibility.structured.min_age_in_years_lte": 30,
+  "keyword": "aids",
+  "sites.org_coordinates_lat": "38.928",
+  "sites.org_coordinates_lon": "-77.2649",
+  "sites.org_coordinates_dist": "100mi",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/aids_40yrs_zip-22182-request.json
+++ b/support/mock-data/clinical-trials/aids_40yrs_zip-22182-request.json
@@ -1,42 +1,42 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"eligibility.structured.max_age_in_years_gte": "40",
-	"eligibility.structured.min_age_in_years_lte": "40",
-	"keyword": "aids",
-	"sites.org_coordinates_lat": "38.928",
-	"sites.org_coordinates_lon": "-77.2649",
-	"sites.org_coordinates_dist": "100mi",
-	"from":0,
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "eligibility.structured.max_age_in_years_gte": "40",
+  "eligibility.structured.min_age_in_years_lte": "40",
+  "keyword": "aids",
+  "sites.org_coordinates_lat": "38.928",
+  "sites.org_coordinates_lon": "-77.2649",
+  "sites.org_coordinates_dist": "100mi",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all-fields-atNIH-request.json
+++ b/support/mock-data/clinical-trials/all-fields-atNIH-request.json
@@ -1,64 +1,65 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C2924"
-	],
-	"stage": [
-		"C94774"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C798",
-		"C15313"
-	],
-	"eligibility.structured.max_age_in_years_gte": 50,
-	"eligibility.structured.min_age_in_years_lte": 50,
-	"keyword": "Breast",
-	"primary_purpose": [
-		"treatment"
-	],
-	"phase": [
-		"iii",
-		"ii_iii"
-	],
-	"principal_investigator._fulltext": "Benjamin David Smith",
-	"lead_org._fulltext": "M D Anderson Cancer Center",
-	"trial_ids": [
-		"NCI-2017-00476"
-	],
-	"sites.org_postal_code": "20892",
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C2924"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C798",
+    "C15313"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 50,
+  "eligibility.structured.min_age_in_years_lte": 50,
+  "keyword": "Breast",
+  "primary_purpose": [
+    "treatment"
+  ],
+  "phase": [
+    "iii",
+    "ii_iii"
+  ],
+  "principal_investigator._fulltext": "Benjamin David Smith",
+  "lead_org._fulltext": "M D Anderson Cancer Center",
+  "trial_ids": [
+    "NCI-2017-00476"
+  ],
+  "sites.org_postal_code": "20892",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all-fields-country-state-request.json
+++ b/support/mock-data/clinical-trials/all-fields-country-state-request.json
@@ -1,68 +1,69 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C2924"
-	],
-	"stage": [
-		"C94774"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C798",
-		"C15313"
-	],
-	"eligibility.structured.max_age_in_years_gte": 50,
-	"eligibility.structured.min_age_in_years_lte": 50,
-	"keyword": "Breast",
-	"primary_purpose": [
-		"treatment"
-	],
-	"phase": [
-		"iii",
-		"ii_iii"
-	],
-	"principal_investigator._fulltext": "Benjamin David Smith",
-	"lead_org._fulltext": "M D Anderson Cancer Center",
-	"trial_ids": [
-		"NCI-2017-00476"
-	],
-	"sites.org_country": "United States",
-	"sites.org_city": "Atlanta",
-	"sites.org_state_or_province": [
-		"GA"
-	],
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C2924"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C798",
+    "C15313"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 50,
+  "eligibility.structured.min_age_in_years_lte": 50,
+  "keyword": "Breast",
+  "primary_purpose": [
+    "treatment"
+  ],
+  "phase": [
+    "iii",
+    "ii_iii"
+  ],
+  "principal_investigator._fulltext": "Benjamin David Smith",
+  "lead_org._fulltext": "M D Anderson Cancer Center",
+  "trial_ids": [
+    "NCI-2017-00476"
+  ],
+  "sites.org_country": "United States",
+  "sites.org_city": "Atlanta",
+  "sites.org_state_or_province": [
+    "GA"
+  ],
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all-fields-hospitals-request.json
+++ b/support/mock-data/clinical-trials/all-fields-hospitals-request.json
@@ -1,64 +1,65 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C2924"
-	],
-	"stage": [
-		"C94774"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C798",
-		"C15313"
-	],
-	"eligibility.structured.max_age_in_years_gte": 50,
-	"eligibility.structured.min_age_in_years_lte": 50,
-	"keyword": "Breast",
-	"primary_purpose": [
-		"treatment"
-	],
-	"phase": [
-		"iii",
-		"ii_iii"
-	],
-	"principal_investigator._fulltext": "Benjamin David Smith",
-	"lead_org._fulltext": "M D Anderson Cancer Center",
-	"trial_ids": [
-		"NCI-2017-00476"
-	],
-	"sites.org_name._fulltext": "anderson",
-	"from":0,
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C2924"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C798",
+    "C15313"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 50,
+  "eligibility.structured.min_age_in_years_lte": 50,
+  "keyword": "Breast",
+  "primary_purpose": [
+    "treatment"
+  ],
+  "phase": [
+    "iii",
+    "ii_iii"
+  ],
+  "principal_investigator._fulltext": "Benjamin David Smith",
+  "lead_org._fulltext": "M D Anderson Cancer Center",
+  "trial_ids": [
+    "NCI-2017-00476"
+  ],
+  "sites.org_name._fulltext": "anderson",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all-fields-zip-request.json
+++ b/support/mock-data/clinical-trials/all-fields-zip-request.json
@@ -1,66 +1,67 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C2924"
-	],
-	"stage": [
-		"C94774"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C798",
-		"C15313"
-	],
-	"eligibility.structured.max_age_in_years_gte": 50,
-	"eligibility.structured.min_age_in_years_lte": 50,
-	"keyword": "Breast",
-	"primary_purpose": [
-		"treatment"
-	],
-	"phase": [
-		"iii",
-		"ii_iii"
-	],
-	"principal_investigator._fulltext": "Benjamin David Smith",
-	"lead_org._fulltext": "M D Anderson Cancer Center",
-	"trial_ids": [
-		"NCI-2017-00476"
-	],
-	"sites.org_coordinates_lat": "33.7984",
-	"sites.org_coordinates_lon": "-84.3883",
-	"sites.org_coordinates_dist": "100mi",
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C2924"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C798",
+    "C15313"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 50,
+  "eligibility.structured.min_age_in_years_lte": 50,
+  "keyword": "Breast",
+  "primary_purpose": [
+    "treatment"
+  ],
+  "phase": [
+    "iii",
+    "ii_iii"
+  ],
+  "principal_investigator._fulltext": "Benjamin David Smith",
+  "lead_org._fulltext": "M D Anderson Cancer Center",
+  "trial_ids": [
+    "NCI-2017-00476"
+  ],
+  "sites.org_coordinates_lat": "33.7984",
+  "sites.org_coordinates_lon": "-84.3883",
+  "sites.org_coordinates_dist": "100mi",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all-trial-types-request.json
+++ b/support/mock-data/clinical-trials/all-trial-types-request.json
@@ -1,39 +1,39 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"primary_purpose": [
-		"treatment",
-		"prevention",
-		"supportive_care",
-		"health_services_research",
-		"diagnostic",
-		"screening",
-		"basic_science",
-		"other"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "primary_purpose": [
+    "treatment",
+    "prevention",
+    "supportive_care",
+    "health_services_research",
+    "diagnostic",
+    "screening",
+    "basic_science",
+    "other"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/all_trials-pn10-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn10-request.json
@@ -1,6 +1,6 @@
 {
   "from": 90,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn11-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn11-request.json
@@ -1,6 +1,6 @@
 {
   "from": 100,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn2-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn2-request.json
@@ -1,6 +1,6 @@
 {
-	"from":10,
-	"size": 10,
+  "from": 10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn3-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn3-request.json
@@ -1,6 +1,6 @@
 {
   "from": 20,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn4-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn4-request.json
@@ -1,6 +1,6 @@
 {
   "from": 30,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn5-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn5-request.json
@@ -1,6 +1,6 @@
 {
   "from": 40,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn6-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn6-request.json
@@ -1,6 +1,6 @@
 {
   "from": 50,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn679-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn679-request.json
@@ -1,28 +1,29 @@
 {
-	"from":6780,
-	"size":10,
-	"current_trial_status":[
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include":[
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	]
+  "from": 6780,
+  "size": 10,
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn680-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn680-request.json
@@ -1,28 +1,29 @@
 {
-	"from":6790,
-	"size":10,
-	"current_trial_status":[
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include":[
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	]
+  "from": 6790,
+  "size": 10,
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn681-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn681-request.json
@@ -1,28 +1,29 @@
 {
-	"from":6800,
-	"size":10,
-	"current_trial_status":[
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include":[
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	]
+  "from": 6800,
+  "size": 10,
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn682-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn682-request.json
@@ -1,28 +1,29 @@
 {
-	"from":6810,
-	"size":10,
-	"current_trial_status":[
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include":[
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	]
+  "from": 6810,
+  "size": 10,
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn683-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn683-request.json
@@ -1,28 +1,29 @@
 {
-	"from":6820,
-	"size":10,
-	"current_trial_status":[
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include":[
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	]
+  "from": 6820,
+  "size": 10,
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn7-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn7-request.json
@@ -1,6 +1,6 @@
 {
   "from": 60,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn8-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn8-request.json
@@ -1,6 +1,6 @@
 {
   "from": 70,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-pn9-request.json
+++ b/support/mock-data/clinical-trials/all_trials-pn9-request.json
@@ -1,6 +1,6 @@
 {
   "from": 80,
-	"size":10,
+  "size": 10,
   "current_trial_status": [
     "Active",
     "Approved",
@@ -23,6 +23,7 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ]
 }

--- a/support/mock-data/clinical-trials/all_trials-request.json
+++ b/support/mock-data/clinical-trials/all_trials-request.json
@@ -21,8 +21,9 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"from":0,
-	"size":10
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/ant-drug-request.json
+++ b/support/mock-data/clinical-trials/ant-drug-request.json
@@ -1,31 +1,32 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C274"
-	],
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C274"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/at-nih-only-request.json
+++ b/support/mock-data/clinical-trials/at-nih-only-request.json
@@ -1,36 +1,37 @@
 {
-    "sites.org_postal_code": "20892",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_postal_code": "20892",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/basic_bogus_phrase-request.json
+++ b/support/mock-data/clinical-trials/basic_bogus_phrase-request.json
@@ -1,29 +1,30 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"keyword": "asdf",
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "keyword": "asdf",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/bre-request.json
+++ b/support/mock-data/clinical-trials/bre-request.json
@@ -1,30 +1,30 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"keyword": "bre",
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "keyword": "bre",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/breast-cancer-70-request.json
+++ b/support/mock-data/clinical-trials/breast-cancer-70-request.json
@@ -1,33 +1,34 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"eligibility.structured.max_age_in_years_gte": "70",
-	"eligibility.structured.min_age_in_years_lte": "70",
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "eligibility.structured.max_age_in_years_gte": "70",
+  "eligibility.structured.min_age_in_years_lte": "70",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/breast-cancer-request.json
+++ b/support/mock-data/clinical-trials/breast-cancer-request.json
@@ -1,31 +1,32 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/breast-cancer_dcis-request.json
+++ b/support/mock-data/clinical-trials/breast-cancer_dcis-request.json
@@ -1,35 +1,35 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4872"
-	],
-	"subtype": [
-		"C2924"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4872"
+  ],
+  "subtype": [
+    "C2924"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/breastCancer_40yrs-request.json
+++ b/support/mock-data/clinical-trials/breastCancer_40yrs-request.json
@@ -1,5 +1,4 @@
 {
-
   "current_trial_status": [
     "Active",
     "Approved",
@@ -22,11 +21,14 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"maintype": ["C4872"],
-	"eligibility.structured.max_age_in_years_gte": 40,
-	"eligibility.structured.min_age_in_years_lte": 40,
-	"from":0,
-	"size":10
+  "maintype": [
+    "C4872"
+  ],
+  "eligibility.structured.max_age_in_years_gte": 40,
+  "eligibility.structured.min_age_in_years_lte": 40,
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/c8287-request.json
+++ b/support/mock-data/clinical-trials/c8287-request.json
@@ -1,31 +1,32 @@
 {
-    "maintype": [
-        "C8287"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from":0,
-		"size":10
+  "maintype": [
+    "C8287"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/c9293-request.json
+++ b/support/mock-data/clinical-trials/c9293-request.json
@@ -1,32 +1,32 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C9293"
-	],
-			"from":0,
-			"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C9293"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/chimeric-drug-request.json
+++ b/support/mock-data/clinical-trials/chimeric-drug-request.json
@@ -1,33 +1,33 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C137999",
-		"C126102"
-	],
-		"from":0,
-		"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C137999",
+    "C126102"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/country_state_vaOnly-request.json
+++ b/support/mock-data/clinical-trials/country_state_vaOnly-request.json
@@ -1,38 +1,41 @@
 {
-    "sites.org_va": true,
-    "sites.org_country": "United States",
-    "sites.org_state_or_province": ["WA"],
-    "sites.recruitment_status": [
-      "active",
-      "approved",
-      "enrolling_by_invitation",
-      "in_review",
-      "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-      "Active",
-      "Approved",
-      "Enrolling by Invitation",
-      "In Review",
-      "Temporarily Closed to Accrual",
-      "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-      "nci_id",
-      "nct_id",
-      "brief_title",
-      "sites.org_name",
-      "sites.org_postal_code",
-      "eligibility.structured",
-      "current_trial_status",
-      "sites.org_va",
-      "sites.org_country",
-      "sites.org_state_or_province",
-      "sites.org_city",
-      "sites.org_coordinates",
-      "sites.recruitment_status",
-      "diseases"
-    ],
-		"from":0,
-		"size":10
-  }
+  "sites.org_va": true,
+  "sites.org_country": "United States",
+  "sites.org_state_or_province": [
+    "WA"
+  ],
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
+}

--- a/support/mock-data/clinical-trials/dcis-request.json
+++ b/support/mock-data/clinical-trials/dcis-request.json
@@ -1,31 +1,32 @@
 {
-    "maintype": [
-        "C2924"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from":0,
-		"size":10
+  "maintype": [
+    "C2924"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/drug-bevacizumab_preferred_name-avastatin-request.json
+++ b/support/mock-data/clinical-trials/drug-bevacizumab_preferred_name-avastatin-request.json
@@ -1,32 +1,32 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C2039"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C2039"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/drug-ibuprofen-bevacizumab_treatment-polymorphism-analysis-orchiectomy-request.json
+++ b/support/mock-data/clinical-trials/drug-ibuprofen-bevacizumab_treatment-polymorphism-analysis-orchiectomy-request.json
@@ -1,35 +1,35 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C561",
-		"C2039",
-		"C18309",
-		"C15288"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C561",
+    "C2039",
+    "C18309",
+    "C15288"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/drug-ibuprofen_treatment-polymorphism-analysis-request.json
+++ b/support/mock-data/clinical-trials/drug-ibuprofen_treatment-polymorphism-analysis-request.json
@@ -1,32 +1,33 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C561",
-		"C18309"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C561",
+    "C18309"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/drug-isoflavone_treatment-polymorphism-analysis_multi-phase-request.json
+++ b/support/mock-data/clinical-trials/drug-isoflavone_treatment-polymorphism-analysis_multi-phase-request.json
@@ -1,5 +1,4 @@
 {
-
   "current_trial_status": [
     "Active",
     "Approved",
@@ -22,10 +21,21 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"arms.interventions.nci_thesaurus_concept_id": ["C599", "C18309"],
-	"phase": ["i", "ii", "iii", "iv", "i_ii", "ii_iii"],
-	"from":0,
-	"size":10
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C599",
+    "C18309"
+  ],
+  "phase": [
+    "i",
+    "ii",
+    "iii",
+    "iv",
+    "i_ii",
+    "ii_iii"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/early-stage-breast-cancer-request.json
+++ b/support/mock-data/clinical-trials/early-stage-breast-cancer-request.json
@@ -1,5 +1,4 @@
 {
-
   "current_trial_status": [
     "Active",
     "Approved",
@@ -22,10 +21,15 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"maintype": ["C4872"],
-	"stage": ["C94774"],
-	"from":0,
-	"size":10
+  "maintype": [
+    "C4872"
+  ],
+  "stage": [
+    "C94774"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/empty-zip-request.json
+++ b/support/mock-data/clinical-trials/empty-zip-request.json
@@ -1,35 +1,36 @@
 {
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-		"from":0,
-		"size":10
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/england-london-request.json
+++ b/support/mock-data/clinical-trials/england-london-request.json
@@ -1,36 +1,37 @@
 {
-    "sites.org_country": "United Kingdom",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "United Kingdom",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/erlanger-hospital-request.json
+++ b/support/mock-data/clinical-trials/erlanger-hospital-request.json
@@ -1,36 +1,37 @@
 {
-	"current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"sites.org_name._fulltext": "Erlanger Medical Center",
-	"from":0,
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "sites.org_name._fulltext": "Erlanger Medical Center",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/gender-both-request.json
+++ b/support/mock-data/clinical-trials/gender-both-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2021-08397"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2021-08397"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/gender-female-request.json
+++ b/support/mock-data/clinical-trials/gender-female-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2023-04529"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2023-04529"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/gender-male-request.json
+++ b/support/mock-data/clinical-trials/gender-male-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2020-04705"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2020-04705"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/healthy_many-trial-types-request.json
+++ b/support/mock-data/clinical-trials/healthy_many-trial-types-request.json
@@ -1,5 +1,4 @@
 {
-
   "current_trial_status": [
     "Active",
     "Approved",
@@ -22,18 +21,20 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"primary_purpose": [
-		"treatment",
-		"prevention",
-		"supportive_care",
-		"health_services_research",
-		"diagnostic",
-		"screening",
-		"basic_science",
-		"other"
-	],
-	"eligibility.structured.accepts_healthy_volunteers": true,	"from":0,
-	"size":10
+  "primary_purpose": [
+    "treatment",
+    "prevention",
+    "supportive_care",
+    "health_services_research",
+    "diagnostic",
+    "screening",
+    "basic_science",
+    "other"
+  ],
+  "eligibility.structured.accepts_healthy_volunteers": true,
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/hospital-request.json
+++ b/support/mock-data/clinical-trials/hospital-request.json
@@ -1,36 +1,37 @@
 {
-    "current_trial_status": [
-      "Active",
-      "Approved",
-      "Enrolling by Invitation",
-      "In Review",
-      "Temporarily Closed to Accrual",
-      "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-      "nci_id",
-      "nct_id",
-      "brief_title",
-      "sites.org_name",
-      "sites.org_postal_code",
-      "eligibility.structured",
-      "current_trial_status",
-      "sites.org_va",
-      "sites.org_country",
-      "sites.org_state_or_province",
-      "sites.org_city",
-      "sites.org_coordinates",
-      "sites.recruitment_status",
-      "diseases"
-    ],
-	"sites.org_name._fulltext": "UM Baltimore Washington Medical Center/Tate Cancer Center",
-	"from":0,
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size":10
-  }
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "sites.org_name._fulltext": "UM Baltimore Washington Medical Center/Tate Cancer Center",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
+}

--- a/support/mock-data/clinical-trials/hv-all-types-request.json
+++ b/support/mock-data/clinical-trials/hv-all-types-request.json
@@ -1,28 +1,30 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"eligibility.structured.accepts_healthy_volunteers": true,	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "eligibility.structured.accepts_healthy_volunteers": true,
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/hv-treatment-request.json
+++ b/support/mock-data/clinical-trials/hv-treatment-request.json
@@ -1,32 +1,33 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"primary_purpose": [
-		"treatment"
-	],
-	"eligibility.structured.accepts_healthy_volunteers": true,	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "primary_purpose": [
+    "treatment"
+  ],
+  "eligibility.structured.accepts_healthy_volunteers": true,
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/keyword-chronic-kidney-request.json
+++ b/support/mock-data/clinical-trials/keyword-chronic-kidney-request.json
@@ -1,30 +1,30 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"keyword": "chronic kidney disease due to hypertension",
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "keyword": "chronic kidney disease due to hypertension",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/keyword-no-results-request.json
+++ b/support/mock-data/clinical-trials/keyword-no-results-request.json
@@ -1,30 +1,30 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"keyword": "penguin",
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "keyword": "penguin",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/keyword-psa-request.json
+++ b/support/mock-data/clinical-trials/keyword-psa-request.json
@@ -1,30 +1,30 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"keyword": "psa",
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "keyword": "psa",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/lo_barretos-request.json
+++ b/support/mock-data/clinical-trials/lo_barretos-request.json
@@ -1,30 +1,30 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"lead_org._fulltext": "Barretos Cancer Hospital",
-
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "lead_org._fulltext": "Barretos Cancer Hospital",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/lo_brown-request.json
+++ b/support/mock-data/clinical-trials/lo_brown-request.json
@@ -1,30 +1,30 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"lead_org._fulltext": "Brown University",
-
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "lead_org._fulltext": "Brown University",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/mayo-lead-org-request.json
+++ b/support/mock-data/clinical-trials/mayo-lead-org-request.json
@@ -1,29 +1,30 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"lead_org._fulltext": "mayo",
-	"from": 0,
-	"size": 10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "lead_org._fulltext": "mayo",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/mayo-location-hospital-request.json
+++ b/support/mock-data/clinical-trials/mayo-location-hospital-request.json
@@ -1,36 +1,37 @@
 {
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"sites.org_name._fulltext": "mayo",
-	"from":0,
-	"size":10
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "sites.org_name._fulltext": "mayo",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/phase-i-phase-ii-request.json
+++ b/support/mock-data/clinical-trials/phase-i-phase-ii-request.json
@@ -1,35 +1,35 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"phase": [
-		"i",
-		"ii",
-		"i_ii",
-		"ii_iii"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "phase": [
+    "i",
+    "ii",
+    "i_ii",
+    "ii_iii"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/russia-request.json
+++ b/support/mock-data/clinical-trials/russia-request.json
@@ -1,36 +1,37 @@
 {
-    "sites.org_country": "Russia",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "Russia",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/sex-all-request.json
+++ b/support/mock-data/clinical-trials/sex-all-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2014-02674"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2014-02674"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/sex-female-request.json
+++ b/support/mock-data/clinical-trials/sex-female-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2017-02047"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2017-02047"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/sex-male-request.json
+++ b/support/mock-data/clinical-trials/sex-male-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2024-04336"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2024-04336"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/stage-iii-bladder-advanced-request.json
+++ b/support/mock-data/clinical-trials/stage-iii-bladder-advanced-request.json
@@ -1,36 +1,36 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"maintype": [
-		"C4912"
-	],
-	"stage": [
-		"C140421",
-		"C7898"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "maintype": [
+    "C4912"
+  ],
+  "stage": [
+    "C140421",
+    "C7898"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/stage-iii-bladder-request.json
+++ b/support/mock-data/clinical-trials/stage-iii-bladder-request.json
@@ -1,32 +1,33 @@
 {
-    "maintype": [
-        "C140421",
-        "C7898"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "maintype": [
+    "C140421",
+    "C7898"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/treatment-diagnostic-request.json
+++ b/support/mock-data/clinical-trials/treatment-diagnostic-request.json
@@ -1,32 +1,33 @@
 {
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"primary_purpose": [
-		"treatment",
-		"diagnostic"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "primary_purpose": [
+    "treatment",
+    "diagnostic"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/treatment-polymorphism-analysis-request.json
+++ b/support/mock-data/clinical-trials/treatment-polymorphism-analysis-request.json
@@ -1,32 +1,32 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"arms.interventions.nci_thesaurus_concept_id": [
-		"C18309"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "arms.interventions.nci_thesaurus_concept_id": [
+    "C18309"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial-status-approved-request.json
+++ b/support/mock-data/clinical-trials/trial-status-approved-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2024-09778"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2024-09778"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial-status-closed-accrual-intervention-request.json
+++ b/support/mock-data/clinical-trials/trial-status-closed-accrual-intervention-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2015-00695"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-        "In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2015-00695"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial-status-enrolling-by-invite-request.json
+++ b/support/mock-data/clinical-trials/trial-status-enrolling-by-invite-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2020-01400"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2020-01400"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial-status-temp-closed-to-accrual-request.json
+++ b/support/mock-data/clinical-trials/trial-status-temp-closed-to-accrual-request.json
@@ -1,29 +1,32 @@
 {
-	"trial_ids": ["NCI-2022-10532"],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-        "In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from": 0,
-	"size": 10
+  "trial_ids": [
+    "NCI-2022-10532"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial_investigator_grace_autosuggest_searching-request.json
+++ b/support/mock-data/clinical-trials/trial_investigator_grace_autosuggest_searching-request.json
@@ -1,30 +1,30 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"principal_investigator._fulltext": "Grace Smith",
-
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "principal_investigator._fulltext": "Grace Smith",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trial_investigator_henry_autosuggest_searching-request.json
+++ b/support/mock-data/clinical-trials/trial_investigator_henry_autosuggest_searching-request.json
@@ -1,30 +1,30 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"principal_investigator._fulltext": "henry",
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "principal_investigator._fulltext": "henry",
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-ecog-partial-trialid-search-request.json
+++ b/support/mock-data/clinical-trials/trialid-ecog-partial-trialid-search-request.json
@@ -1,32 +1,32 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"trial_ids": [
-		"ecog"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "trial_ids": [
+    "ecog"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-ecog-swog-partial-trialid-search-request.json
+++ b/support/mock-data/clinical-trials/trialid-ecog-swog-partial-trialid-search-request.json
@@ -1,33 +1,33 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"trial_ids": [
-		"ecog",
-		"swog"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "trial_ids": [
+    "ecog",
+    "swog"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-nci-2018-02825-nci-2015-00054-nci-2014-01507-trialid-search-request.json
+++ b/support/mock-data/clinical-trials/trialid-nci-2018-02825-nci-2015-00054-nci-2014-01507-trialid-search-request.json
@@ -1,34 +1,34 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"trial_ids": [
-		"NCI-2018-02825",
-		"NCI-2015-00054",
-		"NCI-2014-01507"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "trial_ids": [
+    "NCI-2018-02825",
+    "NCI-2015-00054",
+    "NCI-2014-01507"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-nci-2018-02825-trialid-search-request.json
+++ b/support/mock-data/clinical-trials/trialid-nci-2018-02825-trialid-search-request.json
@@ -1,32 +1,32 @@
 {
-
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"trial_ids": [
-		"NCI-2018-02825"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "trial_ids": [
+    "NCI-2018-02825"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-nci-2018-02825_investigator_leadorg-request.json
+++ b/support/mock-data/clinical-trials/trialid-nci-2018-02825_investigator_leadorg-request.json
@@ -21,11 +21,14 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"principal_investigator._fulltext": "Jarushka Naidoo",
-	"lead_org._fulltext": "ECOG-ACRIN Cancer Research Group",
-	"trial_ids": ["NCI-2018-02825"],
-	"from":0,
-	"size":10
+  "principal_investigator._fulltext": "Jarushka Naidoo",
+  "lead_org._fulltext": "ECOG-ACRIN Cancer Research Group",
+  "trial_ids": [
+    "NCI-2018-02825"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialid-nci-2018-1234-non-existing-trialid-search-request.json
+++ b/support/mock-data/clinical-trials/trialid-nci-2018-1234-non-existing-trialid-search-request.json
@@ -1,31 +1,32 @@
 {
-	"trial_ids": [
-		"NCI-2018-1234"
-	],
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-	"from":0,
-	"size":10
+  "trial_ids": [
+    "NCI-2018-1234"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/trialphaseI-checkbox-checked-request.json
+++ b/support/mock-data/clinical-trials/trialphaseI-checkbox-checked-request.json
@@ -1,33 +1,33 @@
 {
-
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"phase": [
-		"i",
-		"i_ii"
-	],
-	"from":0,
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "phase": [
+    "i",
+    "i_ii"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/uk-london-request.json
+++ b/support/mock-data/clinical-trials/uk-london-request.json
@@ -1,37 +1,38 @@
 {
-    "sites.org_country": "United Kingdom",
-    "sites.org_city": "London",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "United Kingdom",
+  "sites.org_city": "London",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/us-miami-request.json
+++ b/support/mock-data/clinical-trials/us-miami-request.json
@@ -1,37 +1,38 @@
 {
-    "sites.org_country": "United States",
-    "sites.org_city": "Miami",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "United States",
+  "sites.org_city": "Miami",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/us-va-ca-request.json
+++ b/support/mock-data/clinical-trials/us-va-ca-request.json
@@ -1,40 +1,41 @@
 {
-    "sites.org_country": "United States",
-    "sites.org_state_or_province": [
-        "VA",
-        "CA"
-    ],
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "United States",
+  "sites.org_state_or_province": [
+    "VA",
+    "CA"
+  ],
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/us-va-richmond-request.json
+++ b/support/mock-data/clinical-trials/us-va-richmond-request.json
@@ -1,40 +1,41 @@
 {
-    "sites.org_country": "United States",
-    "sites.org_city": "Richmond",
-    "sites.org_state_or_province": [
-        "VA"
-    ],
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_country": "United States",
+  "sites.org_city": "Richmond",
+  "sites.org_state_or_province": [
+    "VA"
+  ],
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/va-20165-request.json
+++ b/support/mock-data/clinical-trials/va-20165-request.json
@@ -1,39 +1,40 @@
 {
-    "sites.org_va": true,
-    "sites.org_coordinates_lat": "39.0472",
-    "sites.org_coordinates_lon": "-77.3866",
-    "sites.org_coordinates_dist": "200mi",
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_va": true,
+  "sites.org_coordinates_lat": "39.0472",
+  "sites.org_coordinates_lon": "-77.3866",
+  "sites.org_coordinates_dist": "200mi",
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/va-22182-request.json
+++ b/support/mock-data/clinical-trials/va-22182-request.json
@@ -1,39 +1,40 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
-	"include": [
-		"nci_id",
-		"nct_id",
-		"brief_title",
-		"sites.org_name",
-		"sites.org_postal_code",
-		"eligibility.structured",
-		"current_trial_status",
-		"sites.org_va",
-		"sites.org_country",
-		"sites.org_state_or_province",
-		"sites.org_city",
-		"sites.org_coordinates",
-		"sites.recruitment_status",
-		"diseases"
-	],
-    "sites.org_va": true,
-    "sites.org_coordinates_lat": "38.928",
-    "sites.org_coordinates_lon": "-77.2649",
-    "sites.org_coordinates_dist": "500mi",
-	"from":0,
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-	"size":10
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "sites.org_va": true,
+  "sites.org_coordinates_lat": "38.928",
+  "sites.org_coordinates_lon": "-77.2649",
+  "sites.org_coordinates_dist": "500mi",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/va-only-request.json
+++ b/support/mock-data/clinical-trials/va-only-request.json
@@ -1,36 +1,37 @@
 {
-    "sites.org_va": true,
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_va": true,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/va-us-va-richmond-request.json
+++ b/support/mock-data/clinical-trials/va-us-va-richmond-request.json
@@ -1,41 +1,42 @@
 {
-    "sites.org_va": true,
-    "sites.org_country": "United States",
-    "sites.org_city": "Richmond",
-    "sites.org_state_or_province": [
-        "VA"
-    ],
-    "sites.recruitment_status": [
-        "active",
-        "approved",
-        "enrolling_by_invitation",
-        "in_review",
-        "temporarily_closed_to_accrual"
-    ],
-    "current_trial_status": [
-        "Active",
-        "Approved",
-        "Enrolling by Invitation",
-        "In Review",
-        "Temporarily Closed to Accrual",
-        "Temporarily Closed to Accrual and Intervention"
-    ],
-    "include": [
-        "nci_id",
-        "nct_id",
-        "brief_title",
-        "sites.org_name",
-        "sites.org_postal_code",
-        "eligibility.structured",
-        "current_trial_status",
-        "sites.org_va",
-        "sites.org_country",
-        "sites.org_state_or_province",
-        "sites.org_city",
-        "sites.org_coordinates",
-        "sites.recruitment_status",
-        "diseases"
-    ],
-	"from":0,
-	"size":10
+  "sites.org_va": true,
+  "sites.org_country": "United States",
+  "sites.org_city": "Richmond",
+  "sites.org_state_or_province": [
+    "VA"
+  ],
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
+  "include": [
+    "nci_id",
+    "nct_id",
+    "brief_title",
+    "sites.org_name",
+    "sites.org_postal_code",
+    "eligibility.structured",
+    "current_trial_status",
+    "sites.org_va",
+    "sites.org_country",
+    "sites.org_state_or_province",
+    "sites.org_city",
+    "sites.org_coordinates",
+    "sites.recruitment_status",
+    "diseases",
+    "prior_therapy"
+  ],
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/zip-22182-radius-50-request.json
+++ b/support/mock-data/clinical-trials/zip-22182-radius-50-request.json
@@ -31,8 +31,9 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"from":0,
-	"size":10
+  "from": 0,
+  "size": 10
 }

--- a/support/mock-data/clinical-trials/zip-22182-request.json
+++ b/support/mock-data/clinical-trials/zip-22182-request.json
@@ -1,12 +1,12 @@
 {
-	"current_trial_status": [
-		"Active",
-		"Approved",
-		"Enrolling by Invitation",
-		"In Review",
-		"Temporarily Closed to Accrual",
-		"Temporarily Closed to Accrual and Intervention"
-	],
+  "current_trial_status": [
+    "Active",
+    "Approved",
+    "Enrolling by Invitation",
+    "In Review",
+    "Temporarily Closed to Accrual",
+    "Temporarily Closed to Accrual and Intervention"
+  ],
   "include": [
     "nci_id",
     "nct_id",
@@ -21,18 +21,19 @@
     "sites.org_city",
     "sites.org_coordinates",
     "sites.recruitment_status",
-    "diseases"
+    "diseases",
+    "prior_therapy"
   ],
-	"sites.org_coordinates_lat": "38.928",
-	"sites.org_coordinates_lon": "-77.2649",
-	"sites.org_coordinates_dist": "100mi",
-	"from":0,
-	"sites.recruitment_status": [
-		"active",
-		"approved",
-		"enrolling_by_invitation",
-		"in_review",
-		"temporarily_closed_to_accrual"
-	],
-	"size": 10
+  "sites.org_coordinates_lat": "38.928",
+  "sites.org_coordinates_lon": "-77.2649",
+  "sites.org_coordinates_dist": "100mi",
+  "from": 0,
+  "sites.recruitment_status": [
+    "active",
+    "approved",
+    "enrolling_by_invitation",
+    "in_review",
+    "temporarily_closed_to_accrual"
+  ],
+  "size": 10
 }

--- a/support/mock-data/interventions/platinum_10_count_desc.json
+++ b/support/mock-data/interventions/platinum_10_count_desc.json
@@ -1,0 +1,58 @@
+{
+	"data": [
+		{
+			"name": "Cisplatin",
+			"codes": [
+				"C376"
+			],
+			"category": [
+				"agent"
+			],
+			"type": [
+				"drug"
+			],
+			"synonyms": [
+				"Cisplatin",
+				"CDDP",
+				"cis-Platinum"
+			],
+			"count": 200
+		},
+		{
+			"name": "Platinum Compound",
+			"codes": [
+				"C1909"
+			],
+			"category": [
+				"agent category"
+			],
+			"type": [
+				"drug"
+			],
+			"synonyms": [
+				"Platinum Compound",
+				"Platinum Agent",
+				"Platinum-Based Therapy"
+			],
+			"count": 120
+		},
+		{
+			"name": "Platinum-Based Radiotherapy",
+			"codes": [
+				"C99999"
+			],
+			"category": [
+				"other"
+			],
+			"type": [
+				"radiation"
+			],
+			"synonyms": [
+				"Platinum-Based Radiotherapy",
+				"Platinum Radiation"
+			],
+			"count": 5
+		}
+	],
+	"total": 3
+}


### PR DESCRIPTION
* Adds PriorTherapy.jsx, index.jsx, and PriorTherapy.scss
* Adds searchPriorTherapy.js
* Adds searchPriorTherapyAction.js
* Adds getClinicalTrialsWithPriorTherapy.test.js
* Adds prior_therapy to SEARCH_RETURNS_FIELDS in constants/index.js
* Updates clinical-trials-search-api/index.js to include searchPriorTherapy
* Updates actionsV2/index.js to include searchPriorTherapyAction
* Updates buildQueryString to include priorTherapy
* Updates formatTrialSearchQuery to include priorTherapy
* Updates queryStringToSearchCriteria.js to include priorTherapy
* Updates defaultStateCopy.js to include priorTherapy