### PR TITLE
(#685) Update empty prior therapy field workaround

### DIFF
--- a/src/utilities/__tests__/formatTrialSearchQuery.js
+++ b/src/utilities/__tests__/formatTrialSearchQuery.js
@@ -500,8 +500,7 @@ const mappingTestCases = [
 		{
 			'prior_therapy.nci_thesaurus_concept_id': ['C1234'],
 			'prior_therapy.eligibility_criterion': 'exclusion',
-			// inclusion_indicator (TRIAL/TREE/DESCENDANT) is intentionally disabled in the query builder
-			// 'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
+			'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
 		},
 	],
 	[
@@ -515,8 +514,7 @@ const mappingTestCases = [
 		{
 			'prior_therapy.nci_thesaurus_concept_id': ['C1234', 'C5678'],
 			'prior_therapy.eligibility_criterion': 'exclusion',
-			// inclusion_indicator (TRIAL/TREE/DESCENDANT) is intentionally disabled in the query builder
-			// 'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
+			'prior_therapy.inclusion_indicator': ['TRIAL', 'TREE', 'DESCENDANT'],
 		},
 	],
 ];

--- a/src/utilities/formatTrialSearchQuery.js
+++ b/src/utilities/formatTrialSearchQuery.js
@@ -34,9 +34,7 @@ export const formatTrialSearchQuery = (form) => {
 		const priorTherapyIds = collapseConcepts(form.priorTherapy);
 		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
 		filterCriteria['prior_therapy.eligibility_criterion'] = 'exclusion';
-		// Disabled: do not constrain prior therapy matches to the trial/tree/descendant
-		// inclusion levels. Leaving this commented out widens the prior therapy match.
-		// filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
+		filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
 	}
 
 	//Add Age filter

--- a/src/utilities/formatTrialSearchQueryV2.js
+++ b/src/utilities/formatTrialSearchQueryV2.js
@@ -34,9 +34,7 @@ export const formatTrialSearchQueryV2 = (form) => {
 		const priorTherapyIds = collapseConcepts(form.priorTherapy);
 		filterCriteria['prior_therapy.nci_thesaurus_concept_id'] = [...new Set([...priorTherapyIds])];
 		filterCriteria['prior_therapy.eligibility_criterion'] = 'exclusion';
-		// Disabled: do not constrain prior therapy matches to the trial/tree/descendant
-		// inclusion levels. Leaving this commented out widens the prior therapy match.
-		// filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
+		filterCriteria['prior_therapy.inclusion_indicator'] = ['TRIAL', 'TREE', 'DESCENDANT'];
 	}
 
 	//Add Age filter

--- a/support/mock-data/clinical-trials/drug-bevacizumab_treatment-sbrt_prior-therapy_multi-phase-request.json
+++ b/support/mock-data/clinical-trials/drug-bevacizumab_treatment-sbrt_prior-therapy_multi-phase-request.json
@@ -34,6 +34,11 @@
     "C15262"
   ],
   "prior_therapy.eligibility_criterion": "exclusion",
+  "prior_therapy.inclusion_indicator": [
+    "TRIAL",
+    "TREE",
+    "DESCENDANT"
+  ],
   "phase": [
     "i",
     "ii",

--- a/support/mock-data/clinical-trials/prior-therapy-cisplatin-platinum-compound-request.json
+++ b/support/mock-data/clinical-trials/prior-therapy-cisplatin-platinum-compound-request.json
@@ -29,6 +29,11 @@
     "C1909"
   ],
   "prior_therapy.eligibility_criterion": "exclusion",
+  "prior_therapy.inclusion_indicator": [
+    "TRIAL",
+    "TREE",
+    "DESCENDANT"
+  ],
   "from": 0,
   "size": 10
 }

--- a/support/mock-data/clinical-trials/prior-therapy-platinum-compound-request.json
+++ b/support/mock-data/clinical-trials/prior-therapy-platinum-compound-request.json
@@ -28,6 +28,11 @@
     "C1909"
   ],
   "prior_therapy.eligibility_criterion": "exclusion",
+  "prior_therapy.inclusion_indicator": [
+    "TRIAL",
+    "TREE",
+    "DESCENDANT"
+  ],
   "from": 0,
   "size": 10
 }


### PR DESCRIPTION
* Adds inclusion_indicator back into the trialSearchQuery for prior therapy
* Updates formatTrialSearchQuery.js test

Closes #685